### PR TITLE
Specify GameViewResolution by enum

### DIFF
--- a/Runtime/Attributes/GameViewResolution.cs
+++ b/Runtime/Attributes/GameViewResolution.cs
@@ -32,16 +32,23 @@ namespace TestHelper.Attributes
         /// <returns>width, height, and name</returns>
         public static (uint, uint, string) GetParameter(this GameViewResolution resolution)
         {
-            return resolution switch
+            switch (resolution)
             {
-                GameViewResolution.VGA => (640, 480, "VGA"),
-                GameViewResolution.XGA => (1024, 768, "XGA"),
-                GameViewResolution.WXGA => (1366, 768, "WXGA"),
-                GameViewResolution.FullHD => (1920, 1080, "Full HD"),
-                GameViewResolution.QHD => (2560, 1440, "QHD"),
-                GameViewResolution.FourK_UHD => (3840, 2160, "4K UHD"),
-                _ => (0, 0, "undefined")
-            };
+                case GameViewResolution.VGA:
+                    return (640, 480, "VGA");
+                case GameViewResolution.XGA:
+                    return (1024, 768, "XGA");
+                case GameViewResolution.WXGA:
+                    return (1366, 768, "WXGA");
+                case GameViewResolution.FullHD:
+                    return (1920, 1080, "Full HD");
+                case GameViewResolution.QHD:
+                    return (2560, 1440, "QHD");
+                case GameViewResolution.FourK_UHD:
+                    return (3840, 2160, "4K UHD");
+                default:
+                    return (0, 0, "undefined");
+            }
         }
     }
 }

--- a/Runtime/Attributes/GameViewResolution.cs
+++ b/Runtime/Attributes/GameViewResolution.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace TestHelper.Attributes
+{
+    /// <summary>
+    /// Enum for <c>GameView</c> resolution.
+    /// </summary>
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [SuppressMessage("ReSharper", "MissingXmlDoc")]
+    public enum GameViewResolution
+    {
+        VGA,
+        XGA,
+        WXGA,
+        FullHD,
+        QHD,
+        FourK_UHD
+    }
+
+    /// <summary>
+    /// Extension methods for <c>GameViewResolution</c>.
+    /// </summary>
+    public static class GameViewResolutionExtensions
+    {
+        /// <summary>
+        /// Get resolution parameter.
+        /// </summary>
+        /// <param name="resolution"></param>
+        /// <returns>width, height, and name</returns>
+        public static (uint, uint, string) GetParameter(this GameViewResolution resolution)
+        {
+            return resolution switch
+            {
+                GameViewResolution.VGA => (640, 480, "VGA"),
+                GameViewResolution.XGA => (1024, 768, "XGA"),
+                GameViewResolution.WXGA => (1366, 768, "WXGA"),
+                GameViewResolution.FullHD => (1920, 1080, "Full HD"),
+                GameViewResolution.QHD => (2560, 1440, "QHD"),
+                GameViewResolution.FourK_UHD => (3840, 2160, "4K UHD"),
+                _ => (0, 0, "undefined")
+            };
+        }
+    }
+}

--- a/Runtime/Attributes/GameViewResolution.cs.meta
+++ b/Runtime/Attributes/GameViewResolution.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3950c57ae8414bec821666e0692f6495
+timeCreated: 1697378305

--- a/Runtime/Attributes/GameViewResolutionAttribute.cs
+++ b/Runtime/Attributes/GameViewResolutionAttribute.cs
@@ -36,6 +36,15 @@ namespace TestHelper.Attributes
             _name = name;
         }
 
+        /// <summary>
+        /// Set <c>GameView</c> resolution before SetUp test.
+        /// </summary>
+        /// <param name="resolution">GameView resolutions enum</param>
+        public GameViewResolutionAttribute(GameViewResolution resolution)
+        {
+            (_width, _height, _name) = resolution.GetParameter();
+        }
+
         public void ApplyToContext(ITestExecutionContext context)
         {
 #if UNITY_2022_2_OR_NEWER

--- a/Tests/Runtime/Attributes/GameViewResolutionAttributeTest.cs
+++ b/Tests/Runtime/Attributes/GameViewResolutionAttributeTest.cs
@@ -23,7 +23,7 @@ namespace TestHelper.Attributes
         }
 
         [Test]
-        [GameViewResolution(640, 480, "VGA")]
+        [GameViewResolution(GameViewResolution.VGA)]
         public async Task Attach_SetScreenSizeToVGA()
         {
             await Task.Yield(); // Wait to apply change GameView resolution


### PR DESCRIPTION
Added a new constructor to the GameViewResolutionAttribute class that takes a GameViewResolution enum as a parameter instead of width, height and a name. This simplifies the application of this attribute in the GameViewResolutionAttributeTest as you can directly pass the predefined enum value. This change aims to improve code readability and ease of use.