### PR TITLE
Update Unity version in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,10 +34,10 @@ jobs:
       matrix:
         unityVersion: # Available versions see: https://game.ci/docs/docker/versions
           - 2019.4.40f1
-          - 2022.3.4f1
-          - 2023.1.2f1
+          - 2022.3.11f1
+          - 2023.1.16f1
         include:
-          - unityVersion: 2022.3.4f1
+          - unityVersion: 2022.3.11f1
             octocov: true
 
     steps:


### PR DESCRIPTION
The Unity versions used in the .github workflow for testing were updated. Earlier, the versions were 2022.3.4f1 and 2023.1.2f1. They have been changed to 2022.3.11f1 and 2023.1.16f1, respectively. This change is necessary to ensure that the tests are run using the recent Unity versions, thus keeping our package up-to-date and relevant.
