### PR TITLE
Fix CreateSceneAttribute tests

### DIFF
--- a/Runtime/Attributes/CreateSceneAttribute.cs
+++ b/Runtime/Attributes/CreateSceneAttribute.cs
@@ -44,26 +44,17 @@ namespace TestHelper.Attributes
         {
             _newSceneName = $"Scene of {TestContext.CurrentContext.Test.FullName}";
 
-            if (Application.isEditor)
+            if (Application.isEditor && !Application.isPlaying)
             {
 #if UNITY_EDITOR
-                if (Application.isPlaying)
-                {
-                    // Play Mode tests running in Editor
-                    var scene = SceneManager.CreateScene(_newSceneName);
-                    SceneManager.SetActiveScene(scene);
-                }
-                else
-                {
-                    // Edit Mode tests
-                    var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene);
-                    scene.name = _newSceneName;
-                }
+                // Edit Mode tests
+                var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene);
+                scene.name = _newSceneName;
 #endif
             }
             else
             {
-                // Play Mode tests running on Player
+                // Play Mode tests
                 var scene = SceneManager.CreateScene(_newSceneName);
                 SceneManager.SetActiveScene(scene);
             }

--- a/Tests/Runtime/Attributes/CreateSceneAttributeTest.cs
+++ b/Tests/Runtime/Attributes/CreateSceneAttributeTest.cs
@@ -4,7 +4,6 @@
 using System.Collections;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 
@@ -21,11 +20,8 @@ namespace TestHelper.Attributes
             Assert.That(scene.name, Is.EqualTo(
                 "Scene of TestHelper.Attributes.CreateSceneAttributeTest.Attach_CreateNewSceneWithoutCameraAndLight"));
 
-            var camera = GameObject.Find("Main Camera");
-            Assert.That(camera, Is.Null);
-
-            var light = GameObject.Find("Directional Light");
-            Assert.That(light, Is.Null);
+            var rootGameObjects = scene.GetRootGameObjects(); // Note: GameObject.Find finds objects in inactive scenes
+            Assert.That(rootGameObjects, Is.Empty);
         }
 
         [Test]
@@ -36,8 +32,9 @@ namespace TestHelper.Attributes
             Assert.That(scene.name, Is.EqualTo(
                 "Scene of TestHelper.Attributes.CreateSceneAttributeTest.Attach_WithCamera_CreateNewSceneWithCamera"));
 
-            var camera = GameObject.Find("Main Camera");
-            Assert.That(camera, Is.Not.Null);
+            var rootGameObjects = scene.GetRootGameObjects(); // Note: GameObject.Find finds objects in inactive scenes
+            Assert.That(rootGameObjects, Has.Length.EqualTo(1));
+            Assert.That(rootGameObjects[0].name, Is.EqualTo("Main Camera"));
         }
 
         [Test]
@@ -48,8 +45,9 @@ namespace TestHelper.Attributes
             Assert.That(scene.name, Is.EqualTo(
                 "Scene of TestHelper.Attributes.CreateSceneAttributeTest.Attach_WithLight_CreateNewSceneWithLight"));
 
-            var light = GameObject.Find("Directional Light");
-            Assert.That(light, Is.Not.Null);
+            var rootGameObjects = scene.GetRootGameObjects(); // Note: GameObject.Find finds objects in inactive scenes
+            Assert.That(rootGameObjects, Has.Length.EqualTo(1));
+            Assert.That(rootGameObjects[0].name, Is.EqualTo("Directional Light"));
         }
 
         [Test]


### PR DESCRIPTION
I stopped using GameObject.Find.
Because of GameObject.Find finds objects in inactive scenes.

And refactor CreateSceneAttribute.