### PR TITLE
Add GameObjectNameComparer

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,10 @@ using UnityEngine;
 public class MyTestClass
 {
     [Test]
-    [LoadScene("Assets/MyTests/Scenes/Scene.unity")]
+    [LoadScene("Assets/MyTests/Scenes/TestScene.unity")]
     public void MyTestMethod()
     {
-        var cube = GameObject.Find("Cube");
+        var cube = GameObject.Find("Cube in TestScene");
         Assert.That(cube, Is.Not.Null);
     }
 }
@@ -226,7 +226,7 @@ public class GameObjectNameComparerTest
     [Test]
     public void UsingGameObjectNameComparer_CompareGameObjectsByName()
     {
-        var actual = Object.FindObjectsOfType<GameObject>();
+        var actual = GameObject.FindObjectsOfType<GameObject>();
         Assert.That(actual, Does.Contain(new GameObject("test")).Using(new GameObjectNameComparer()));
     }
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Test](https://github.com/nowsprinting/test-helper/actions/workflows/test.yml/badge.svg)](https://github.com/nowsprinting/test-helper/actions/workflows/test.yml)
 [![openupm](https://img.shields.io/npm/v/com.nowsprinting.test-helper?label=openupm&registry_uri=https://package.openupm.com)](https://openupm.com/packages/com.nowsprinting.test-helper/)
 
-Provides attributes and constraints useful for testing.
+Provides custom attributes, comparers, and constraints useful for testing with Unity Test Framework.
 
 Required Unity 2019 LTS or later.
 
@@ -205,6 +205,32 @@ public class MyTestClass
 > **Note**  
 > - Load scene run after `OneTimeSetUp` and before `SetUp`
 > - Scene file path is starts with `Assets/` or `Packages/`. And package name using `name` instead of `displayName`, when scenes in the package. (e.g., `Packages/com.nowsprinting.test-helper/Tests/Scenes/Scene.unity`)
+
+
+### Comparers
+
+#### GameObjectNameComparer
+
+`GameObjectNameComparer` is an NUnit test comparer class to compare GameObjects by name.
+
+Usage:
+
+```csharp
+using NUnit.Framework;
+using TestHelper.Comparers;
+using UnityEngine;
+
+[TestFixture]
+public class GameObjectNameComparerTest
+{
+    [Test]
+    public void UsingGameObjectNameComparer_CompareGameObjectsByName()
+    {
+        var actual = Object.FindObjectsOfType<GameObject>();
+        Assert.That(actual, Does.Contain(new GameObject("test")).Using(new GameObjectNameComparer()));
+    }
+}
+```
 
 
 ### Constraints

--- a/Runtime/Comparers.meta
+++ b/Runtime/Comparers.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6223d3d8d80f46589a8d448ae4c09ad5
+timeCreated: 1698475775

--- a/Runtime/Comparers/GameObjectNameComparer.cs
+++ b/Runtime/Comparers/GameObjectNameComparer.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using UnityEngine;
+
+namespace TestHelper.Comparers
+{
+    /// <summary>
+    /// Compare GameObjects by name.
+    /// </summary>
+    public class GameObjectNameComparer : IComparer<GameObject>
+    {
+        /// <inheritdoc/>
+        [SuppressMessage("ReSharper", "PossibleNullReferenceException")]
+        public int Compare(GameObject x, GameObject y)
+        {
+            return string.Compare(x.name, y.name, StringComparison.Ordinal);
+        }
+    }
+}

--- a/Runtime/Comparers/GameObjectNameComparer.cs.meta
+++ b/Runtime/Comparers/GameObjectNameComparer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: bc3e145844c14fad97707b5d27114aad
+timeCreated: 1698475796

--- a/Tests/Runtime/Comparers.meta
+++ b/Tests/Runtime/Comparers.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f0050f9f619f4960ac56b3a351868d1d
+timeCreated: 1698475781

--- a/Tests/Runtime/Comparers/GameObjectNameComparerTest.cs
+++ b/Tests/Runtime/Comparers/GameObjectNameComparerTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2023 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using System;
 using NUnit.Framework;
 using UnityEngine;
 
@@ -12,26 +13,41 @@ namespace TestHelper.Comparers
         [Test]
         public void UsingWithEqualTo_CompareGameObjectsByName()
         {
-            var actual = new GameObject("test");
+            var actual = new GameObject("test object");
 
-            Assert.That(actual, Is.EqualTo(new GameObject("test")).Using(new GameObjectNameComparer()));
-            // Message if failure:
-            //   Expected: <test1 (UnityEngine.GameObject)>
-            //   But was:  <test (UnityEngine.GameObject)>
+            Assert.That(actual, Is.EqualTo(new GameObject("test object")).Using(new GameObjectNameComparer()));
+        }
+
+        [Test]
+        public void UsingWithEqualTo_NotEqualName_Failure()
+        {
+            var actual = new GameObject("actual object");
+
+            Assert.That(() =>
+            {
+                Assert.That(actual, Is.EqualTo(new GameObject("expected object")).Using(new GameObjectNameComparer()));
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: <expected object (UnityEngine.GameObject)>{Environment.NewLine}  But was:  <actual object (UnityEngine.GameObject)>{Environment.NewLine}"));
         }
 
         [Test]
         public void UsingWithCollection_CompareGameObjectsByName()
         {
-            var actual = new []
-            {
-                new GameObject("test1"), new GameObject("test2"), new GameObject("test3"),
-            };
+            var actual = new[] { new GameObject("test1"), new GameObject("test2"), new GameObject("test3"), };
 
             Assert.That(actual, Does.Contain(new GameObject("test3")).Using(new GameObjectNameComparer()));
-            // Message if failure:
-            //   Expected: collection containing <test4 (UnityEngine.GameObject)>
-            //   But was:  < <test1 (UnityEngine.GameObject)>, <test2 (UnityEngine.GameObject)>, <test3 (UnityEngine.GameObject)> >
+        }
+
+        [Test]
+        public void UsingWithCollection_NotContain_Failure()
+        {
+            var actual = new[] { new GameObject("test1"), new GameObject("test2"), new GameObject("test3"), };
+
+            Assert.That(() =>
+            {
+                Assert.That(actual, Does.Contain(new GameObject("test4")).Using(new GameObjectNameComparer()));
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: collection containing <test4 (UnityEngine.GameObject)>{Environment.NewLine}  But was:  < <test1 (UnityEngine.GameObject)>, <test2 (UnityEngine.GameObject)>, <test3 (UnityEngine.GameObject)> >{Environment.NewLine}"));
         }
     }
 }

--- a/Tests/Runtime/Comparers/GameObjectNameComparerTest.cs
+++ b/Tests/Runtime/Comparers/GameObjectNameComparerTest.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using NUnit.Framework;
+using UnityEngine;
+
+namespace TestHelper.Comparers
+{
+    [TestFixture]
+    public class GameObjectNameComparerTest
+    {
+        [Test]
+        public void UsingWithEqualTo_CompareGameObjectsByName()
+        {
+            var actual = new GameObject("test");
+
+            Assert.That(actual, Is.EqualTo(new GameObject("test")).Using(new GameObjectNameComparer()));
+            // Message if failure:
+            //   Expected: <test1 (UnityEngine.GameObject)>
+            //   But was:  <test (UnityEngine.GameObject)>
+        }
+
+        [Test]
+        public void UsingWithCollection_CompareGameObjectsByName()
+        {
+            var actual = new []
+            {
+                new GameObject("test1"), new GameObject("test2"), new GameObject("test3"),
+            };
+
+            Assert.That(actual, Does.Contain(new GameObject("test3")).Using(new GameObjectNameComparer()));
+            // Message if failure:
+            //   Expected: collection containing <test4 (UnityEngine.GameObject)>
+            //   But was:  < <test1 (UnityEngine.GameObject)>, <test2 (UnityEngine.GameObject)>, <test3 (UnityEngine.GameObject)> >
+        }
+    }
+}

--- a/Tests/Runtime/Comparers/GameObjectNameComparerTest.cs.meta
+++ b/Tests/Runtime/Comparers/GameObjectNameComparerTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1c09323d51c14e19b58c5cb38c5cf18f
+timeCreated: 1698476008


### PR DESCRIPTION
`GameObjectNameComparer` is an NUnit test comparer class to compare GameObjects by name.

Usage:

```csharp
using NUnit.Framework;
using TestHelper.Comparers;
using UnityEngine;

[TestFixture]
public class GameObjectNameComparerTest
{
    [Test]
    public void UsingGameObjectNameComparer_CompareGameObjectsByName()
    {
        var actual = Object.FindObjectsOfType<GameObject>();
        Assert.That(actual, Does.Contain(new GameObject("test")).Using(new GameObjectNameComparer()));
    }
}
```