### PR TITLE
Add TakeScreenshot attribute

### DIFF
--- a/Editor/OpenPersistentDataPathMenu.cs
+++ b/Editor/OpenPersistentDataPathMenu.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using UnityEditor;
+using UnityEngine;
+
+namespace TestHelper.Editor
+{
+    /// <summary>
+    /// Open persistent data directory in the Finder.
+    /// <see href="https://docs.unity3d.com/ScriptReference/Application-persistentDataPath.html">Application.persistentDataPath</see>
+    /// </summary>
+    public static class OpenPersistentDataPathMenu
+    {
+        [MenuItem("Window/Open Persistent Data Directory")]
+        private static void OpenPersistentDataPathMenuItem()
+        {
+            EditorUtility.RevealInFinder(Application.persistentDataPath);
+        }
+    }
+}

--- a/Editor/OpenPersistentDataPathMenu.cs.meta
+++ b/Editor/OpenPersistentDataPathMenu.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7957072f339c435eb32235a3b9531b50
+timeCreated: 1698241534

--- a/README.md
+++ b/README.md
@@ -264,6 +264,31 @@ public class MyTestClass
 > When used with operators, use it in method style. e.g., `Is.Not.Destroyed()`
 
 
+### Utilities
+
+#### ScreenshotHelper
+
+`ScreenshotHelper` is a utility class to take a screenshot.
+
+Usage:
+
+```csharp
+[TestFixture]
+public class MyTestClass
+{
+    [UnityTest]
+    public IEnumerator MyTestMethod()
+    {
+        yield return ScreenshotHelper.TakeScreenshot();
+    }
+}
+```
+
+> **Note**
+> Default save path is $"{Application.persistentDataPath}/TestHelper/Screenshots/{TestName}.png".
+> You can specify save directory and/or filename by arguments.
+
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -330,6 +330,13 @@ public class MyTestClass
 > - Files with the same name will be overwritten. Please specify filename argument when calling over twice in one method.
 
 
+## Editor Extensions
+
+### Open Persistent Data Directory
+
+Select **Window** > **Open Persistent Data Directory**, which opens the directory pointed to by [persistent data path](https://docs.unity3d.com/ScriptReference/Application-persistentDataPath.html) in the Finder/ File Explorer.
+
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,42 @@ public class MyTestClass
 > - Load scene run after `OneTimeSetUp` and before `SetUp`
 > - Scene file path is starts with `Assets/` or `Packages/`. And package name using `name` instead of `displayName`, when scenes in the package. (e.g., `Packages/com.nowsprinting.test-helper/Tests/Scenes/Scene.unity`)
 
+#### TakeScreenshot
+
+`TakeScreenshotAttribute` is an NUnit test attribute class to take a screenshot and save it to a file after running test.
+
+Default save path is "`Application.persistentDataPath`/TestHelper/Screenshots/`CurrentTest.Name`.png".
+You can specify the save directory and/or filename by arguments.
+
+This attribute can attached to test method only.
+Can be used with sync Test, async Test, and UnityTest.
+
+Usage:
+    
+```csharp
+using NUnit.Framework;
+using TestHelper.Attributes;
+using UnityEngine;
+
+[TestFixture]
+public class MyTestClass
+{
+    [Test]
+    [TakeScreenshot]
+    public void MyTestMethod()
+    {
+        // take screenshot after running the test.
+    }
+}
+```
+
+> **Warning**
+> - Do not attach to Edit Mode tests.
+> - `GameView` must be visible. Use [FocusGameViewAttribute](#FocusGameView) or [GameViewResolutionAttribute](#GameViewResolution) if running on batch mode.
+
+> **Note**  
+> If you want to take screenshots at any time, use the [ScreenshotHelper](#ScreenshotHelper) class.
+
 
 ### Comparers
 
@@ -268,7 +304,10 @@ public class MyTestClass
 
 #### ScreenshotHelper
 
-`ScreenshotHelper` is a utility class to take a screenshot.
+`ScreenshotHelper` is a utility class to take a screenshot and save it to a file.
+
+Default save path is "`Application.persistentDataPath`/TestHelper/Screenshots/`CurrentTest.Name`.png".
+You can specify the save directory and/or filename by arguments.
 
 Usage:
 
@@ -284,9 +323,11 @@ public class MyTestClass
 }
 ```
 
-> **Note**
-> Default save path is $"{Application.persistentDataPath}/TestHelper/Screenshots/{TestName}.png".
-> You can specify save directory and/or filename by arguments.
+> **Warning**  
+> - Do not call from Edit Mode tests.
+> - Must be called from main thread.
+> - `GameView` must be visible. Use [FocusGameViewAttribute](#FocusGameView) or [GameViewResolutionAttribute](#GameViewResolution) if running on batch mode.
+> - Files with the same name will be overwritten. Please specify filename argument when calling over twice in one method.
 
 
 

--- a/Runtime/Attributes/TakeScreenshotAttribute.cs
+++ b/Runtime/Attributes/TakeScreenshotAttribute.cs
@@ -1,0 +1,66 @@
+// Copyright (c) 2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.Collections;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using TestHelper.Utils;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace TestHelper.Attributes
+{
+    /// <summary>
+    /// Take a screenshot and save it to file after running the test.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class TakeScreenshotAttribute : NUnitAttribute, IOuterUnityTestAction
+    {
+        private readonly string _directory;
+        private readonly string _filename;
+        private readonly int _superSize;
+        private readonly ScreenCapture.StereoScreenCaptureMode _stereoCaptureMode;
+
+        /// <summary>
+        /// Take a screenshot and save it to file after running the test.
+        /// Default save path is $"{Application.persistentDataPath}/TestHelper/Screenshots/{CurrentTest.Name}.png".
+        /// If you want to take screenshots at any time, use the <c>ScreenshotHelper</c> class.
+        /// </summary>
+        /// <remarks>
+        /// Limitations:
+        ///  - Do not attach to Edit Mode tests.
+        ///  - <c>GameView</c> must be visible. Use <c>FocusGameViewAttribute</c> or <c>GameViewResolutionAttribute</c> if running on batch mode.
+        /// <br/>
+        /// Using <c>ScreenCapture.CaptureScreenshotAsTexture</c> internally.
+        /// </remarks>
+        /// <param name="directory">Directory to save screenshots relative to project path. Only effective in Editor.</param>
+        /// <param name="filename">Filename to store screenshot.</param>
+        /// <param name="superSize">The factor to increase resolution with.</param>
+        /// <param name="stereoCaptureMode">The eye texture to capture when stereo rendering is enabled.</param>
+        public TakeScreenshotAttribute(
+            string directory = null,
+            string filename = null,
+            int superSize = 1,
+            ScreenCapture.StereoScreenCaptureMode stereoCaptureMode = ScreenCapture.StereoScreenCaptureMode.LeftEye
+        )
+        {
+            _directory = directory;
+            _filename = filename;
+            _superSize = superSize;
+            _stereoCaptureMode = stereoCaptureMode;
+        }
+
+        /// <inheritdoc />
+        public IEnumerator BeforeTest(ITest test)
+        {
+            yield return null;
+        }
+
+        /// <inheritdoc />
+        public IEnumerator AfterTest(ITest test)
+        {
+            yield return ScreenshotHelper.TakeScreenshot(_directory, _filename, _superSize, _stereoCaptureMode);
+        }
+    }
+}

--- a/Runtime/Attributes/TakeScreenshotAttribute.cs.meta
+++ b/Runtime/Attributes/TakeScreenshotAttribute.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7307f056757c49478248024e766f0b29
+timeCreated: 1698486905

--- a/Runtime/Utils.meta
+++ b/Runtime/Utils.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 139090ceb06e48b09e19b90b9c997940
+timeCreated: 1697970069

--- a/Runtime/Utils/ScreenshotHelper.cs
+++ b/Runtime/Utils/ScreenshotHelper.cs
@@ -30,12 +30,12 @@ namespace TestHelper.Utils
 
         /// <summary>
         /// Take a screenshot and save it to file.
-        /// Default save path is $"{Application.persistentDataPath}/TestHelper/Screenshots/{TestName}.png".
+        /// Default save path is $"{Application.persistentDataPath}/TestHelper/Screenshots/{CurrentTest.Name}.png".
         /// </summary>
         /// <remarks>
         /// Limitations:
         ///  - Do not call from Edit Mode tests.
-        ///  - Do not call from not main thread.
+        ///  - Must be called from main thread.
         ///  - <c>GameView</c> must be visible. Use <c>FocusGameViewAttribute</c> or <c>GameViewResolutionAttribute</c> if running on batch mode.
         ///  - Files with the same name will be overwritten. Please specify filename argument when calling over twice in one method.
         /// <br/>

--- a/Runtime/Utils/ScreenshotHelper.cs
+++ b/Runtime/Utils/ScreenshotHelper.cs
@@ -75,7 +75,10 @@ namespace TestHelper.Utils
             }
 
             Directory.CreateDirectory(directory);
-            filename ??= DefaultFilename();
+            if (filename == null)
+            {
+                filename = DefaultFilename();
+            }
 
             yield return new WaitForEndOfFrame(); // Required to take screenshots
 

--- a/Runtime/Utils/ScreenshotHelper.cs
+++ b/Runtime/Utils/ScreenshotHelper.cs
@@ -75,6 +75,7 @@ namespace TestHelper.Utils
             }
 
             Directory.CreateDirectory(directory);
+
             if (filename == null)
             {
                 filename = DefaultFilename();

--- a/Runtime/Utils/ScreenshotHelper.cs
+++ b/Runtime/Utils/ScreenshotHelper.cs
@@ -1,0 +1,92 @@
+// Copyright (c) 2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Collections;
+using System.IO;
+using System.Threading;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace TestHelper.Utils
+{
+    /// <summary>
+    /// Helper class for taking a screenshots.
+    /// </summary>
+    public static class ScreenshotHelper
+    {
+        private static string DefaultDirectoryPath()
+        {
+            return Path.Combine(Application.persistentDataPath, "TestHelper", "Screenshots");
+        }
+
+        private static string DefaultFilename()
+        {
+            return $"{TestContext.CurrentTestExecutionContext.CurrentTest.Name}.png"
+                .Replace('(', '_')
+                .Replace(')', '_')
+                .Replace(',', '-');
+            // Note: Same as the file name created under ActualImages of the Graphics Tests Framework package.
+        }
+
+        /// <summary>
+        /// Take a screenshot and save it to file.
+        /// Default save path is $"{Application.persistentDataPath}/TestHelper/Screenshots/{TestName}.png".
+        /// </summary>
+        /// <remarks>
+        /// Limitations:
+        ///  - Do not call from Edit Mode tests.
+        ///  - Do not call from not main thread.
+        ///  - <c>GameView</c> must be visible. Use <c>FocusGameViewAttribute</c> or <c>GameViewResolutionAttribute</c> if running on batch mode.
+        ///  - Files with the same name will be overwritten. Please specify filename argument when calling over twice in one method.
+        /// <br/>
+        /// Using <c>ScreenCapture.CaptureScreenshotAsTexture</c> internally.
+        /// </remarks>
+        /// <param name="directory">Directory to save screenshots relative to project path. Only effective in Editor.</param>
+        /// <param name="filename">Filename to store screenshot.</param>
+        /// <param name="superSize">The factor to increase resolution with.</param>
+        /// <param name="stereoCaptureMode">The eye texture to capture when stereo rendering is enabled.</param>
+        public static IEnumerator TakeScreenshot(
+            string directory = null,
+            string filename = null,
+            int superSize = 1,
+            ScreenCapture.StereoScreenCaptureMode stereoCaptureMode = ScreenCapture.StereoScreenCaptureMode.LeftEye
+        )
+        {
+            if (superSize != 1 && stereoCaptureMode != ScreenCapture.StereoScreenCaptureMode.LeftEye)
+            {
+                Debug.LogError("superSize and stereoCaptureMode cannot be specified at the same time.");
+                yield break;
+            }
+
+            if (Thread.CurrentThread.ManagedThreadId != 1)
+            {
+                Debug.LogError("Must be called from the main thread.");
+                yield break;
+                // Note: This is not the case since it is a coroutine.
+            }
+
+            if (Application.isEditor && directory != null)
+            {
+                directory = Path.GetFullPath(directory);
+            }
+            else
+            {
+                directory = DefaultDirectoryPath(); // Not apply specific directory when running on player
+            }
+
+            Directory.CreateDirectory(directory);
+            filename ??= DefaultFilename();
+
+            yield return new WaitForEndOfFrame(); // Required to take screenshots
+
+            var texture = superSize != 1
+                ? ScreenCapture.CaptureScreenshotAsTexture(superSize)
+                : ScreenCapture.CaptureScreenshotAsTexture(stereoCaptureMode);
+
+            var path = Path.Combine(directory, filename);
+            var bytes = texture.EncodeToPNG();
+            File.WriteAllBytes(path, bytes);
+            Debug.Log($"Save screenshot to {path}");
+        }
+    }
+}

--- a/Runtime/Utils/ScreenshotHelper.cs.meta
+++ b/Runtime/Utils/ScreenshotHelper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 23af3c20652b4e3a9d0d5791b397bc94
+timeCreated: 1697970075

--- a/Tests/Runtime/Attributes/TakeScreenshotAttributeTest.cs
+++ b/Tests/Runtime/Attributes/TakeScreenshotAttributeTest.cs
@@ -1,0 +1,65 @@
+// Copyright (c) 2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.IO;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TestHelper.Attributes
+{
+    [TestFixture]
+    public class TakeScreenshotAttributeTest
+    {
+        private readonly string _defaultOutputDirectory =
+            Path.Combine(Application.persistentDataPath, "TestHelper", "Screenshots");
+
+        private Text _text;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var textObject = GameObject.Find("Text");
+            Assume.That(textObject, Is.Not.Null);
+
+            _text = textObject.GetComponent<Text>();
+            _text.text = TestContext.CurrentTestExecutionContext.CurrentTest.Name;
+        }
+
+        [Test, Order(0)]
+        [GameViewResolution(GameViewResolution.VGA)]
+        [LoadScene("Packages/com.nowsprinting.test-helper/Tests/Scenes/ScreenshotTest.unity")]
+        [TakeScreenshot]
+        public void Attach_TakeScreenshotAndSaveToDefaultPath()
+        {
+            // take screenshot after running the test.
+        }
+
+        [Test, Order(1)]
+        public void Attach_TakeScreenshotAndSaveToDefaultPath_AfterRunningTest_ExistFile()
+        {
+            var path = Path.Combine(
+                _defaultOutputDirectory,
+                $"{nameof(Attach_TakeScreenshotAndSaveToDefaultPath)}.png");
+            Assert.That(path, Does.Exist);
+        }
+
+        [Test, Order(0)]
+        [GameViewResolution(GameViewResolution.VGA)]
+        [LoadScene("Packages/com.nowsprinting.test-helper/Tests/Scenes/ScreenshotTest.unity")]
+        [TakeScreenshot(filename: nameof(AttachWithFilename_TakeScreenshotAndSaveToSpecifyPath) + ".png")]
+        public void AttachWithFilename_TakeScreenshotAndSaveToSpecifyPath()
+        {
+            // take screenshot after running the test.
+        }
+
+        [Test, Order(1)]
+        public void AttachWithFilename_TakeScreenshotAndSaveToSpecifyPath_AfterRunningTest_ExistFile()
+        {
+            var path = Path.Combine(
+                _defaultOutputDirectory,
+                $"{nameof(AttachWithFilename_TakeScreenshotAndSaveToSpecifyPath)}.png");
+            Assert.That(path, Does.Exist);
+        }
+    }
+}

--- a/Tests/Runtime/Attributes/TakeScreenshotAttributeTest.cs.meta
+++ b/Tests/Runtime/Attributes/TakeScreenshotAttributeTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 840e7946732b449bb468ea3a66dbb6cb
+timeCreated: 1698486913

--- a/Tests/Runtime/Utils.meta
+++ b/Tests/Runtime/Utils.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a7c2208cd8384da2abd0184aa374f2be
+timeCreated: 1698152230

--- a/Tests/Runtime/Utils/ScreenshotHelperTest.cs
+++ b/Tests/Runtime/Utils/ScreenshotHelperTest.cs
@@ -71,22 +71,6 @@ namespace TestHelper.Utils
         }
 
         [UnityTest]
-        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.LinuxEditor)]
-        public IEnumerator TakeScreenshot_SpecifyAbsolutePath_NotWork()
-        {
-            yield return ScreenshotHelper.TakeScreenshot(directory: "/tmp/com.nowsprinting.test-helper/test");
-            LogAssert.Expect(LogType.Error, "directory must be relative path.");
-        }
-
-        [UnityTest]
-        [UnityPlatform(RuntimePlatform.WindowsEditor)]
-        public IEnumerator TakeScreenshot_SpecifyAbsolutePathWindows_NotWork()
-        {
-            yield return ScreenshotHelper.TakeScreenshot(directory: @"C:\tmp\com.nowsprinting.test-helper\test");
-            LogAssert.Expect(LogType.Error, "directory must be relative path.");
-        }
-
-        [UnityTest]
         [LoadScene("Packages/com.nowsprinting.test-helper/Tests/Scenes/ScreenshotTest.unity")]
         public IEnumerator TakeScreenshot_SpecifyFilename_SaveToSpecifyPath()
         {

--- a/Tests/Runtime/Utils/ScreenshotHelperTest.cs
+++ b/Tests/Runtime/Utils/ScreenshotHelperTest.cs
@@ -1,0 +1,154 @@
+// Copyright (c) 2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Collections;
+using System.IO;
+using NUnit.Framework;
+using TestHelper.Attributes;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+
+namespace TestHelper.Utils
+{
+    [TestFixture]
+    [GameViewResolution(GameViewResolution.VGA)]
+    public class ScreenshotHelperTest
+    {
+        private const int FileSizeThreshold = 5441; // VGA size solid color file size
+
+        private readonly string _defaultOutputDirectory =
+            Path.Combine(Application.persistentDataPath, "TestHelper", "Screenshots");
+
+        private Text _text;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var textObject = GameObject.Find("Text");
+            Assume.That(textObject, Is.Not.Null);
+
+            _text = textObject.GetComponent<Text>();
+            _text.text = TestContext.CurrentTestExecutionContext.CurrentTest.Name;
+        }
+
+        [UnityTest]
+        [LoadScene("Packages/com.nowsprinting.test-helper/Tests/Scenes/ScreenshotTest.unity")]
+        public IEnumerator TakeScreenshot_SaveToDefaultPath()
+        {
+            yield return ScreenshotHelper.TakeScreenshot();
+
+            var path = Path.Combine(_defaultOutputDirectory, $"{nameof(TakeScreenshot_SaveToDefaultPath)}.png");
+            Assert.That(path, Does.Exist);
+            Assert.That(File.ReadAllBytes(path), Has.Length.GreaterThan(FileSizeThreshold));
+        }
+
+        [UnityTest]
+        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
+        [LoadScene("Packages/com.nowsprinting.test-helper/Tests/Scenes/ScreenshotTest.unity")]
+        public IEnumerator TakeScreenshot_SpecifyDirectoryInEditor_SaveToSpecifyPath()
+        {
+            const string RelativePath = "Logs/Screenshots";
+            yield return ScreenshotHelper.TakeScreenshot(directory: RelativePath);
+
+            var path = Path.Combine(Path.GetFullPath(RelativePath),
+                $"{nameof(TakeScreenshot_SpecifyDirectoryInEditor_SaveToSpecifyPath)}.png");
+            Assert.That(path, Does.Exist);
+        }
+
+        [UnityTest]
+        [UnityPlatform(exclude =
+            new[] { RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor })]
+        [LoadScene("Packages/com.nowsprinting.test-helper/Tests/Scenes/ScreenshotTest.unity")]
+        public IEnumerator TakeScreenshot_SpecifyDirectoryOnPlayer_SaveToDefaultPath()
+        {
+            const string RelativePath = "Logs/Screenshots";
+            yield return ScreenshotHelper.TakeScreenshot(directory: RelativePath);
+
+            var path = Path.Combine(_defaultOutputDirectory,
+                $"{nameof(TakeScreenshot_SpecifyDirectoryOnPlayer_SaveToDefaultPath)}.png");
+            Assert.That(path, Does.Exist);
+        }
+
+        [UnityTest]
+        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.LinuxEditor)]
+        public IEnumerator TakeScreenshot_SpecifyAbsolutePath_NotWork()
+        {
+            yield return ScreenshotHelper.TakeScreenshot(directory: "/tmp/com.nowsprinting.test-helper/test");
+            LogAssert.Expect(LogType.Error, "directory must be relative path.");
+        }
+
+        [UnityTest]
+        [UnityPlatform(RuntimePlatform.WindowsEditor)]
+        public IEnumerator TakeScreenshot_SpecifyAbsolutePathWindows_NotWork()
+        {
+            yield return ScreenshotHelper.TakeScreenshot(directory: @"C:\tmp\com.nowsprinting.test-helper\test");
+            LogAssert.Expect(LogType.Error, "directory must be relative path.");
+        }
+
+        [UnityTest]
+        [LoadScene("Packages/com.nowsprinting.test-helper/Tests/Scenes/ScreenshotTest.unity")]
+        public IEnumerator TakeScreenshot_SpecifyFilename_SaveToSpecifyPath()
+        {
+            const string Filename1 = "SpecifyFilename1.png";
+            const string Filename2 = "SpecifyFilename2.png";
+
+            _text.text = Filename1;
+            yield return ScreenshotHelper.TakeScreenshot(filename: Filename1);
+
+            _text.text = Filename2;
+            yield return ScreenshotHelper.TakeScreenshot(filename: Filename2);
+
+            Assert.That(Path.Combine(_defaultOutputDirectory, Filename1), Does.Exist);
+            Assert.That(Path.Combine(_defaultOutputDirectory, Filename2), Does.Exist);
+        }
+
+        [UnityTest]
+        [LoadScene("Packages/com.nowsprinting.test-helper/Tests/Scenes/ScreenshotTest.unity")]
+        public IEnumerator TakeScreenshot_SpecifySuperSize_SaveSuperSizeFile()
+        {
+            yield return ScreenshotHelper.TakeScreenshot(superSize: 2);
+
+            var path = Path.Combine(_defaultOutputDirectory,
+                $"{nameof(TakeScreenshot_SpecifySuperSize_SaveSuperSizeFile)}.png");
+            Assert.That(path, Does.Exist);
+            // Please visually check the file.
+        }
+
+        [UnityTest]
+        [LoadScene("Packages/com.nowsprinting.test-helper/Tests/Scenes/ScreenshotTest.unity")]
+        public IEnumerator TakeScreenshot_SpecifyStereoCaptureMode_SaveStereoFile()
+        {
+            yield return ScreenshotHelper.TakeScreenshot(
+                stereoCaptureMode: ScreenCapture.StereoScreenCaptureMode.BothEyes);
+
+            var path = Path.Combine(_defaultOutputDirectory,
+                $"{nameof(TakeScreenshot_SpecifyStereoCaptureMode_SaveStereoFile)}.png");
+            Assert.That(path, Does.Exist);
+            // Require stereo rendering settings.
+            // See: https://docs.unity3d.com/Manual/SinglePassStereoRendering.html
+        }
+
+        [UnityTest]
+        public IEnumerator TakeScreenshot_SpecifySuperSizeAndStereoCaptureMode_NotWork()
+        {
+            yield return ScreenshotHelper.TakeScreenshot(
+                superSize: 2,
+                stereoCaptureMode: ScreenCapture.StereoScreenCaptureMode.BothEyes);
+            LogAssert.Expect(LogType.Error, "superSize and stereoCaptureMode cannot be specified at the same time.");
+        }
+
+        [UnityTest]
+        [LoadScene("Packages/com.nowsprinting.test-helper/Tests/Scenes/ScreenshotTest.unity")]
+        public IEnumerator TakeScreenshot_Parameterized_SaveAllFiles(
+            [Values(0, 1)] int i,
+            [Values(2, 3)] int j)
+        {
+            yield return ScreenshotHelper.TakeScreenshot();
+
+            var path = Path.Combine(_defaultOutputDirectory,
+                $"{nameof(TakeScreenshot_Parameterized_SaveAllFiles)}_{i}-{j}_.png");
+            Assert.That(path, Does.Exist);
+        }
+    }
+}

--- a/Tests/Runtime/Utils/ScreenshotHelperTest.cs.meta
+++ b/Tests/Runtime/Utils/ScreenshotHelperTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9c559438a0f648d49f0c29fe4fc48a9a
+timeCreated: 1698152241

--- a/Tests/Scenes/ScreenshotTest.unity
+++ b/Tests/Scenes/ScreenshotTest.unity
@@ -1,0 +1,568 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.44657838, g: 0.49641228, b: 0.57481676, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &67664795
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 67664797}
+  - component: {fileID: 67664796}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &67664796
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 67664795}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &67664797
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 67664795}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &126562836
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 126562839}
+  - component: {fileID: 126562838}
+  - component: {fileID: 126562837}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &126562837
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 126562836}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &126562838
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 126562836}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &126562839
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 126562836}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1034913016
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1034913020}
+  - component: {fileID: 1034913019}
+  - component: {fileID: 1034913018}
+  - component: {fileID: 1034913017}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1034913017
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1034913016}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1034913018
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1034913016}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &1034913019
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1034913016}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1034913020
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1034913016}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1822830420}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1 &1515053724
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1515053727}
+  - component: {fileID: 1515053726}
+  - component: {fileID: 1515053725}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1515053725
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1515053724}
+  m_Enabled: 1
+--- !u!20 &1515053726
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1515053724}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1515053727
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1515053724}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1822830419
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1822830420}
+  - component: {fileID: 1822830422}
+  - component: {fileID: 1822830421}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1822830420
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1822830419}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1034913020}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 640, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1822830421
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1822830419}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: New Text
+--- !u!222 &1822830422
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1822830419}
+  m_CullTransparentMesh: 1
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1515053727}
+  - {fileID: 67664797}
+  - {fileID: 1034913020}
+  - {fileID: 126562839}

--- a/Tests/Scenes/ScreenshotTest.unity.meta
+++ b/Tests/Scenes/ScreenshotTest.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 76007ca585f2f45e09c17a4c46d30e6f
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
`TakeScreenshotAttribute` is an NUnit test attribute class to take a screenshot and save it to a file after running test.

Default save path is "`Application.persistentDataPath`/TestHelper/Screenshots/`CurrentTest.Name`.png".
You can specify the save directory and/or filename by arguments.

This attribute can attached to test method only.
Can be used with sync Test, async Test, and UnityTest.

Usage:
    
```csharp
using NUnit.Framework;
using TestHelper.Attributes;
using UnityEngine;

[TestFixture]
public class MyTestClass
{
    [Test]
    [TakeScreenshot]
    public void MyTestMethod()
    {
        // take screenshot after running the test.
    }
}
```

> **Warning**
> - Do not attach to Edit Mode tests.
> - `GameView` must be visible. Use [FocusGameViewAttribute](#FocusGameView) or [GameViewResolutionAttribute](#GameViewResolution) if running on batch mode.

> **Note**  
> If you want to take screenshots at any time, use the [ScreenshotHelper](#ScreenshotHelper) class.