### PR TITLE
Add TimeScaleAttribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,31 @@ public class MyTestClass
 > **Note**  
 > If you want to take screenshots at any time, use the [ScreenshotHelper](#ScreenshotHelper) class.
 
+#### TimeScale
+
+`TimeScaleAttribute` is an NUnit test attribute class to change the [Time.TimeScale](https://docs.unity3d.com/ScriptReference/Time-timeScale.html) during the test running.
+
+This attribute can attached to test method only.
+Can be used with sync Test, async Test, and UnityTest.
+
+Usage:
+
+```csharp
+using NUnit.Framework;
+using TestHelper.Attributes;
+
+[TestFixture]
+public class MyTestClass
+{
+    [Test]
+    [TimeScale(2.0f)]
+    public void MyTestMethod()
+    {
+        // Running at 2x speed.
+    }
+}
+```
+
 
 ### Comparers
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ public class MyTestClass
 
 #### TimeScale
 
-`TimeScaleAttribute` is an NUnit test attribute class to change the [Time.TimeScale](https://docs.unity3d.com/ScriptReference/Time-timeScale.html) during the test running.
+`TimeScaleAttribute` is an NUnit test attribute class to change the [Time.timeScale](https://docs.unity3d.com/ScriptReference/Time-timeScale.html) during the test running.
 
 This attribute can attached to test method only.
 Can be used with sync Test, async Test, and UnityTest.

--- a/Runtime/Attributes/TimeScaleAttribute.cs
+++ b/Runtime/Attributes/TimeScaleAttribute.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.Collections;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace TestHelper.Attributes
+{
+    /// <summary>
+    /// Change the <c>Time.TimeScale</c> during the test running.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class TimeScaleAttribute : NUnitAttribute, IOuterUnityTestAction
+    {
+        private readonly float _beforeTimeScale;
+        private readonly float _timeScale;
+
+        /// <summary>
+        /// Change the <c>Time.TimeScale</c> during the test running.
+        /// </summary>
+        /// <param name="timeScale">The scale at which time passes.</param>
+        public TimeScaleAttribute(float timeScale)
+        {
+            _beforeTimeScale = Time.timeScale;
+            _timeScale = timeScale;
+        }
+
+        /// <inheritdoc />
+        public IEnumerator BeforeTest(ITest test)
+        {
+            Time.timeScale = _timeScale;
+            yield return null;
+        }
+
+        /// <inheritdoc />
+        public IEnumerator AfterTest(ITest test)
+        {
+            Time.timeScale = _beforeTimeScale;
+            yield return null;
+        }
+    }
+}

--- a/Runtime/Attributes/TimeScaleAttribute.cs
+++ b/Runtime/Attributes/TimeScaleAttribute.cs
@@ -11,7 +11,7 @@ using UnityEngine.TestTools;
 namespace TestHelper.Attributes
 {
     /// <summary>
-    /// Change the <c>Time.TimeScale</c> during the test running.
+    /// Change the <c>Time.timeScale</c> during the test running.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public class TimeScaleAttribute : NUnitAttribute, IOuterUnityTestAction
@@ -20,7 +20,7 @@ namespace TestHelper.Attributes
         private readonly float _timeScale;
 
         /// <summary>
-        /// Change the <c>Time.TimeScale</c> during the test running.
+        /// Change the <c>Time.timeScale</c> during the test running.
         /// </summary>
         /// <param name="timeScale">The scale at which time passes.</param>
         public TimeScaleAttribute(float timeScale)

--- a/Runtime/Attributes/TimeScaleAttribute.cs.meta
+++ b/Runtime/Attributes/TimeScaleAttribute.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 19608e13f9d447fd807ee19205efbc54
+timeCreated: 1698418095

--- a/Tests/Runtime/Attributes/TimeScaleAttributeTest.cs
+++ b/Tests/Runtime/Attributes/TimeScaleAttributeTest.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Collections;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace TestHelper.Attributes
+{
+    [TestFixture]
+    public class TimeScaleAttributeTest
+    {
+        [Test, Order(0)]
+        [TimeScale(2.0f)]
+        public void Attach_ApplyTimeScale()
+        {
+            Assert.That(Time.timeScale, Is.EqualTo(2.0f));
+        }
+
+        [Test, Order(0)]
+        [TimeScale(3.0f)]
+        public async Task AttachToAsyncTest_ApplyTimeScale()
+        {
+            Assert.That(Time.timeScale, Is.EqualTo(3.0f));
+            await Task.Yield();
+        }
+
+        [UnityTest, Order(0)]
+        [TimeScale(4.0f)]
+        public IEnumerator AttachToUnityTest_ApplyTimeScale()
+        {
+            Assert.That(Time.timeScale, Is.EqualTo(4.0f));
+            yield return null;
+        }
+
+        [Test, Order(1)]
+        public void AfterRunningTest_RevertTimeScale()
+        {
+            Assert.That(Time.timeScale, Is.EqualTo(1.0f));
+        }
+    }
+}

--- a/Tests/Runtime/Attributes/TimeScaleAttributeTest.cs.meta
+++ b/Tests/Runtime/Attributes/TimeScaleAttributeTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1cddd34bc63f494682b12454f87d6f4d
+timeCreated: 1698418104


### PR DESCRIPTION
`TimeScaleAttribute` is an NUnit test attribute class to change the [Time.timeScale](https://docs.unity3d.com/ScriptReference/Time-timeScale.html) during the test running.

This attribute can attached to test method only.
Can be used with sync Test, async Test, and UnityTest.

Usage:

```csharp
using NUnit.Framework;
using TestHelper.Attributes;

[TestFixture]
public class MyTestClass
{
    [Test]
    [TimeScale(2.0f)]
    public void MyTestMethod()
    {
        // Running at 2x speed.
    }
}
```