### PR TITLE
Add GizmosShowOnGameViewAttribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ public class MyTestClass
 }
 ```
 
+> **Note**  
+> In batchmode, open `GameView` window.
+
 
 #### IgnoreBatchMode
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,32 @@ public class MyTestClass
 > In batchmode, open `GameView` window.
 
 
+#### GizmosShowOnGameView
+
+`GizmosShowOnGameViewAttribute` is an NUnit test attribute class to show/hide Gizmos on `GameView` during the test running.
+
+This attribute can attached to test method only.
+Can be used with sync Test, async Test, and UnityTest.
+
+Usage:
+
+```csharp
+using NUnit.Framework;
+using TestHelper.Attributes;
+
+[TestFixture]
+public class MyTestClass
+{
+    [Test]
+    [GizmosShowOnGameView(true)]
+    public void MyTestMethod()
+    {
+        // Show Gizmos on GameView.
+    }
+}
+```
+
+
 #### IgnoreBatchMode
 
 `IgnoreBatchModeAttribute` is an NUnit test attribute class to skip test execution when run tests with `-batchmode` from the commandline.

--- a/Runtime/Attributes/GizmosShowOnGameViewAttribute.cs
+++ b/Runtime/Attributes/GizmosShowOnGameViewAttribute.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.Collections;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using TestHelper.RuntimeInternals;
+using UnityEngine.TestTools;
+
+namespace TestHelper.Attributes
+{
+    /// <summary>
+    /// Show/ hide Gizmos on <c>GameView</c> during the test running.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class GizmosShowOnGameViewAttribute : NUnitAttribute, IOuterUnityTestAction
+    {
+        private readonly bool _show;
+        private readonly bool _beforeShow;
+
+        /// <summary>
+        /// Show/ hide Gizmos on <c>GameView</c> during the test running.
+        /// </summary>
+        /// <param name="show">True: show Gizmos, False: hide Gizmos.</param>
+        public GizmosShowOnGameViewAttribute(bool show = true)
+        {
+            _show = show;
+            _beforeShow = GameViewControlHelper.GetGizmos();
+        }
+
+        /// <inheritdoc />
+        public IEnumerator BeforeTest(ITest test)
+        {
+            GameViewControlHelper.SetGizmos(_show);
+            yield return null;
+        }
+
+        /// <inheritdoc />
+        public IEnumerator AfterTest(ITest test)
+        {
+            GameViewControlHelper.SetGizmos(_beforeShow);
+            yield return null;
+        }
+    }
+}

--- a/Runtime/Attributes/GizmosShowOnGameViewAttribute.cs.meta
+++ b/Runtime/Attributes/GizmosShowOnGameViewAttribute.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3a637ba305864a10abff5c260c115410
+timeCreated: 1698672259

--- a/Runtime/Attributes/TakeScreenshotAttribute.cs
+++ b/Runtime/Attributes/TakeScreenshotAttribute.cs
@@ -5,9 +5,10 @@ using System;
 using System.Collections;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
-using TestHelper.Utils;
+using TestHelper.RuntimeInternals;
 using UnityEngine;
 using UnityEngine.TestTools;
+using ScreenshotHelper = TestHelper.Utils.ScreenshotHelper;
 
 namespace TestHelper.Attributes
 {
@@ -21,6 +22,7 @@ namespace TestHelper.Attributes
         private readonly string _filename;
         private readonly int _superSize;
         private readonly ScreenCapture.StereoScreenCaptureMode _stereoCaptureMode;
+        private readonly bool _gizmos;
 
         /// <summary>
         /// Take a screenshot and save it to file after running the test.
@@ -38,17 +40,19 @@ namespace TestHelper.Attributes
         /// <param name="filename">Filename to store screenshot.</param>
         /// <param name="superSize">The factor to increase resolution with.</param>
         /// <param name="stereoCaptureMode">The eye texture to capture when stereo rendering is enabled.</param>
+        /// <param name="gizmos">True: show Gizmos on GameView</param>
         public TakeScreenshotAttribute(
             string directory = null,
             string filename = null,
             int superSize = 1,
-            ScreenCapture.StereoScreenCaptureMode stereoCaptureMode = ScreenCapture.StereoScreenCaptureMode.LeftEye
-        )
+            ScreenCapture.StereoScreenCaptureMode stereoCaptureMode = ScreenCapture.StereoScreenCaptureMode.LeftEye,
+            bool gizmos = false)
         {
             _directory = directory;
             _filename = filename;
             _superSize = superSize;
             _stereoCaptureMode = stereoCaptureMode;
+            _gizmos = gizmos;
         }
 
         /// <inheritdoc />
@@ -60,7 +64,19 @@ namespace TestHelper.Attributes
         /// <inheritdoc />
         public IEnumerator AfterTest(ITest test)
         {
+            var beforeGizmos = false;
+            if (_gizmos)
+            {
+                beforeGizmos = GameViewControlHelper.GetGizmos();
+                GameViewControlHelper.SetGizmos(true);
+            }
+
             yield return ScreenshotHelper.TakeScreenshot(_directory, _filename, _superSize, _stereoCaptureMode);
+
+            if (_gizmos)
+            {
+                GameViewControlHelper.SetGizmos(beforeGizmos);
+            }
         }
     }
 }

--- a/RuntimeInternals/GameViewControlHelper.cs
+++ b/RuntimeInternals/GameViewControlHelper.cs
@@ -1,8 +1,6 @@
 // Copyright (c) 2023 Koji Hasegawa.
 // This software is released under the MIT License.
 
-using System;
-using System.Reflection;
 using TestHelper.RuntimeInternals.Wrappers.UnityEditor;
 using UnityEditor;
 using UnityEngine;
@@ -15,24 +13,13 @@ namespace TestHelper.RuntimeInternals
     /// </summary>
     public static class GameViewControlHelper
     {
-        private static Type s_gameView;
-
         /// <summary>
         /// Focus <c>GameView</c> or <c>SimulatorWindow</c>.
         /// </summary>
         public static void Focus()
         {
 #if UNITY_EDITOR
-            if (s_gameView == null)
-            {
-                var assembly = Assembly.Load("UnityEditor.dll");
-                var viewClass = Application.isBatchMode ? "UnityEditor.GameView" : "UnityEditor.PlayModeView";
-                // Note: Freezes when getting SimulatorWindow in batchmode
-
-                s_gameView = assembly.GetType(viewClass);
-            }
-
-            EditorWindow.GetWindow(s_gameView, false, null, true);
+            GameViewWrapper.GetWindow();
 #endif
         }
 

--- a/RuntimeInternals/GameViewControlHelper.cs
+++ b/RuntimeInternals/GameViewControlHelper.cs
@@ -24,6 +24,38 @@ namespace TestHelper.RuntimeInternals
         }
 
         /// <summary>
+        /// Get Gizmos show/ hide status on <c>GameView</c>.
+        /// </summary>
+        /// <returns>True: show Gizmos, False: hide Gizmos.</returns>
+        public static bool GetGizmos()
+        {
+            var gizmos = false;
+#if UNITY_EDITOR
+            var gameViewWrapper = GameViewWrapper.GetWindow(false);
+            if (gameViewWrapper != null)
+            {
+                gizmos = gameViewWrapper.GetGizmos();
+            }
+#endif
+            return gizmos;
+        }
+
+        /// <summary>
+        /// Show/ hide Gizmos on <c>GameView</c>.
+        /// </summary>
+        /// <param name="show">True: show Gizmos, False: hide Gizmos.</param>
+        public static void SetGizmos(bool show)
+        {
+#if UNITY_EDITOR
+            var gameViewWrapper = GameViewWrapper.GetWindow(false);
+            if (gameViewWrapper != null)
+            {
+                gameViewWrapper.SetGizmos(show);
+            }
+#endif
+        }
+
+        /// <summary>
         /// Set <c>GameView</c> resolution.
         /// </summary>
         /// <param name="width">GameView width [px]</param>

--- a/RuntimeInternals/Wrappers/UnityEditor/GameViewWrapper.cs
+++ b/RuntimeInternals/Wrappers/UnityEditor/GameViewWrapper.cs
@@ -21,6 +21,9 @@ namespace TestHelper.RuntimeInternals.Wrappers.UnityEditor
         private static readonly PropertyInfo s_selectedSizeIndex = s_gameView
             .GetProperty("selectedSizeIndex", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
+        private static readonly FieldInfo s_gizmos = s_gameView
+            .GetField("m_Gizmos", BindingFlags.Instance | BindingFlags.NonPublic);
+
         private readonly EditorWindow _instance;
 
         private GameViewWrapper(EditorWindow instance)
@@ -28,7 +31,7 @@ namespace TestHelper.RuntimeInternals.Wrappers.UnityEditor
             _instance = instance;
         }
 
-        public static GameViewWrapper GetWindow()
+        public static GameViewWrapper GetWindow(bool focus = true)
         {
             if (s_gameView == null)
             {
@@ -43,7 +46,13 @@ namespace TestHelper.RuntimeInternals.Wrappers.UnityEditor
                 return null;
             }
 
-            var gameView = EditorWindow.GetWindow(s_gameView, false, null, true);
+            if (s_gizmos == null)
+            {
+                Debug.LogError("GameView.m_Gizmos field not found.");
+                return null;
+            }
+
+            var gameView = EditorWindow.GetWindow(s_gameView, false, null, focus);
             if (gameView == null)
             {
                 Debug.LogError("EditorWindow.GetWindow(GameView) failed.");
@@ -61,6 +70,16 @@ namespace TestHelper.RuntimeInternals.Wrappers.UnityEditor
         public void SelectedSizeIndex(int index)
         {
             s_selectedSizeIndex.SetValue(_instance, index);
+        }
+
+        public bool GetGizmos()
+        {
+            return (bool)s_gizmos.GetValue(_instance);
+        }
+
+        public void SetGizmos(bool show)
+        {
+            s_gizmos.SetValue(_instance, show);
         }
     }
 }

--- a/Tests/Runtime/Attributes/GizmosShowOnGameViewAttributeTest.cs
+++ b/Tests/Runtime/Attributes/GizmosShowOnGameViewAttributeTest.cs
@@ -1,0 +1,71 @@
+// Copyright (c) 2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Collections;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using TestHelper.Utils;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace TestHelper.Attributes
+{
+    [TestFixture]
+    public class GizmosShowOnGameViewAttributeTest
+    {
+        private class GizmoDemo : MonoBehaviour
+        {
+            private void OnDrawGizmos()
+            {
+                Gizmos.color = Color.red;
+                Gizmos.DrawSphere(transform.position, 0.2f);
+            }
+        }
+
+        [UnitySetUp]
+        public IEnumerator UnitySetUp()
+        {
+            var gameObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            gameObject.AddComponent<GizmoDemo>();
+            yield return null;
+        }
+
+        [UnityTearDown]
+        public IEnumerator UnityTearDown()
+        {
+            yield return ScreenshotHelper.TakeScreenshot(); // Take screenshot before hide Gizmos.
+        }
+
+        [Test]
+        [CreateScene(camera: true, light: true)]
+        [GizmosShowOnGameView]
+        public void Attach_True_ShowGizmos()
+        {
+            // verify screenshot.
+        }
+
+        [Test]
+        [CreateScene(camera: true, light: true)]
+        [GizmosShowOnGameView(false)]
+        public void Attach_False_HideGizmos()
+        {
+            // verify screenshot.
+        }
+
+        [Test]
+        [CreateScene(camera: true, light: true)]
+        [GizmosShowOnGameView()]
+        public async Task AttachToAsyncTest_ShowGizmos()
+        {
+            await Task.Yield();
+        }
+
+        [UnityTest]
+        [CreateScene(camera: true, light: true)]
+        [GizmosShowOnGameView()]
+        public IEnumerator AttachToUnityTest_ShowGizmos()
+        {
+            yield return null;
+        }
+    }
+}

--- a/Tests/Runtime/Attributes/GizmosShowOnGameViewAttributeTest.cs.meta
+++ b/Tests/Runtime/Attributes/GizmosShowOnGameViewAttributeTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 73971ef78bfc46199676e6a57b297512
+timeCreated: 1698673251

--- a/Tests/Runtime/Attributes/TakeScreenshotAttributeTest.cs
+++ b/Tests/Runtime/Attributes/TakeScreenshotAttributeTest.cs
@@ -141,5 +141,25 @@ namespace TestHelper.Attributes
                 $"{nameof(AttachWithFilename_TakeScreenshotAndSaveToSpecifyPath)}.png");
             Assert.That(path, Does.Exist);
         }
+
+        private class GizmoDemo : MonoBehaviour
+        {
+            private void OnDrawGizmos()
+            {
+                Gizmos.color = Color.red;
+                Gizmos.DrawSphere(transform.position, 0.2f);
+            }
+        }
+
+        [Test]
+        [LoadScene(TestScene)]
+        [TakeScreenshot(gizmos: true)]
+        public void AttachWithGizmos_TakeScreenshotWithGizmos()
+        {
+            var gameObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            gameObject.AddComponent<GizmoDemo>();
+
+            // Take screenshot after running the test.
+        }
     }
 }


### PR DESCRIPTION
`GizmosShowOnGameViewAttribute` is an NUnit test attribute class to show/hide Gizmos on `GameView` during the test running.

This attribute can attached to test method only.
Can be used with sync Test, async Test, and UnityTest.

Usage:

```csharp
using NUnit.Framework;
using TestHelper.Attributes;

[TestFixture]
public class MyTestClass
{
    [Test]
    [GizmosShowOnGameView(true)]
    public void MyTestMethod()
    {
        // Show Gizmos on GameView.
    }
}
```

> **Note**  
> In batchmode, open `GameView` window.