### PR TITLE
Add tests using ScreenshotHelper.TakeScreenshot method from async test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,7 @@ jobs:
           npm install -g openupm-cli
           openupm add -f com.unity.test-framework
           openupm add -f com.unity.testtools.codecoverage
+          openupm add -f com.cysharp.unitask
           openupm add -ft "${{ env.package_name }}"@file:../../
         working-directory: ${{ env.CREATED_PROJECT_PATH }}
 

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ create_project:
 	touch UnityProject~/Assets/.gitkeep
 	openupm -c $(PROJECT_HOME) add -f com.unity.test-framework
 	openupm -c $(PROJECT_HOME) add -f com.unity.testtools.codecoverage
+	openupm -c $(PROJECT_HOME) add -f com.cysharp.unitask
 	openupm -c $(PROJECT_HOME) add -ft $(PACKAGE_NAME)@file:../../
 
 .PHONY: remove_project

--- a/README.md
+++ b/README.md
@@ -390,6 +390,15 @@ public class MyTestClass
     {
         yield return ScreenshotHelper.TakeScreenshot();
     }
+
+    [Test]
+    public async Task MyTestMethodAsync()
+    {
+        var coroutineRunner = new GameObject().AddComponent<CoroutineRunner>();
+        await ScreenshotHelper.TakeScreenshot().ToUniTask(coroutineRunner);
+    }
+
+    private class CoroutineRunner : MonoBehaviour { }
 }
 ```
 
@@ -398,6 +407,7 @@ public class MyTestClass
 > - Must be called from main thread.
 > - `GameView` must be visible. Use [FocusGameViewAttribute](#FocusGameView) or [GameViewResolutionAttribute](#GameViewResolution) if running on batch mode.
 > - Files with the same name will be overwritten. Please specify filename argument when calling over twice in one method.
+> - UniTask is required to be used from the async test. And also needs coroutineRunner (any MonoBehaviour) because TakeScreenshot method uses WaitForEndOfFrame inside. See more information: https://github.com/Cysharp/UniTask#ienumeratortounitask-limitation
 
 
 ### Editor Extensions

--- a/README.md
+++ b/README.md
@@ -479,6 +479,10 @@ make create_project
 UNITY_VERSION=2019.4.40f1 make -k test
 ```
 
+> **Warning**  
+> Required install packages for running tests (when adding to the `testables` in package.json), as follows:
+> - [UniTask](https://github.com/Cysharp/UniTask) package v2.3.3 or later
+
 
 
 ## Release workflow

--- a/Tests/Runtime/TestHelper.Tests.asmdef
+++ b/Tests/Runtime/TestHelper.Tests.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
-        "TestHelper"
+        "TestHelper",
+        "UniTask"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Tests/Runtime/Utils/ScreenshotHelperTest.cs
+++ b/Tests/Runtime/Utils/ScreenshotHelperTest.cs
@@ -3,6 +3,8 @@
 
 using System.Collections;
 using System.IO;
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.Attributes;
 using UnityEngine;
@@ -186,6 +188,31 @@ namespace TestHelper.Utils
 
             yield return ScreenshotHelper.TakeScreenshot();
             Assert.That(path, Does.Exist);
+        }
+
+        [Test]
+        [LoadScene(TestScene)]
+        public async Task TakeScreenshot_FromAsyncTest()
+        {
+            var path = Path.Combine(_defaultOutputDirectory, $"{nameof(TakeScreenshot_FromAsyncTest)}.png");
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+
+            Assume.That(path, Does.Not.Exist);
+
+            var coroutineRunner = new GameObject().AddComponent<CoroutineRunner>();
+            await ScreenshotHelper.TakeScreenshot().ToUniTask(coroutineRunner);
+            // Note: UniTask is required to be used from the async test.
+            //   And also needs coroutineRunner (any MonoBehaviour) because TakeScreenshot method uses WaitForEndOfFrame inside.
+            //   See more information: https://github.com/Cysharp/UniTask#ienumeratortounitask-limitation
+
+            Assert.That(path, Does.Exist);
+        }
+
+        private class CoroutineRunner : MonoBehaviour
+        {
         }
     }
 }

--- a/Tests/RuntimeInternals/ScreenshotHelperTest.cs
+++ b/Tests/RuntimeInternals/ScreenshotHelperTest.cs
@@ -6,15 +6,18 @@ using System.IO;
 using System.Threading.Tasks;
 using Cysharp.Threading.Tasks;
 using NUnit.Framework;
-using TestHelper.Attributes;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 using UnityEngine.UI;
+#if UNITY_EDITOR
+using UnityEditor.SceneManagement;
+#endif
 
 namespace TestHelper.RuntimeInternals
 {
     [TestFixture]
-    [GameViewResolution(GameViewResolution.VGA)]
+    [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
     public class ScreenshotHelperTest
     {
         private const string TestScene = "Packages/com.nowsprinting.test-helper/Tests/Scenes/ScreenshotTest.unity";
@@ -25,9 +28,14 @@ namespace TestHelper.RuntimeInternals
 
         private Text _text;
 
-        [SetUp]
-        public void SetUp()
+        [UnitySetUp]
+        public IEnumerator SetUp()
         {
+#if UNITY_EDITOR
+            yield return EditorSceneManager.LoadSceneAsyncInPlayMode(
+                TestScene,
+                new LoadSceneParameters(LoadSceneMode.Single));
+#endif
             var textObject = GameObject.Find("Text");
             Assume.That(textObject, Is.Not.Null);
 
@@ -36,7 +44,6 @@ namespace TestHelper.RuntimeInternals
         }
 
         [UnityTest]
-        [LoadScene(TestScene)]
         public IEnumerator TakeScreenshot_SaveToDefaultPath()
         {
             var path = Path.Combine(_defaultOutputDirectory, $"{nameof(TakeScreenshot_SaveToDefaultPath)}.png");
@@ -54,7 +61,6 @@ namespace TestHelper.RuntimeInternals
         }
 
         [Test]
-        [LoadScene(TestScene)]
         public async Task TakeScreenshot_FromAsyncTest()
         {
             var path = Path.Combine(_defaultOutputDirectory, $"{nameof(TakeScreenshot_FromAsyncTest)}.png");

--- a/Tests/RuntimeInternals/ScreenshotHelperTest.cs
+++ b/Tests/RuntimeInternals/ScreenshotHelperTest.cs
@@ -3,6 +3,8 @@
 
 using System.Collections;
 using System.IO;
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.Attributes;
 using UnityEngine;
@@ -49,6 +51,31 @@ namespace TestHelper.RuntimeInternals
 
             Assert.That(path, Does.Exist);
             Assert.That(File.ReadAllBytes(path), Has.Length.GreaterThan(FileSizeThreshold));
+        }
+
+        [Test]
+        [LoadScene(TestScene)]
+        public async Task TakeScreenshot_FromAsyncTest()
+        {
+            var path = Path.Combine(_defaultOutputDirectory, $"{nameof(TakeScreenshot_FromAsyncTest)}.png");
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+
+            Assume.That(path, Does.Not.Exist);
+
+            var coroutineRunner = new GameObject().AddComponent<CoroutineRunner>();
+            await ScreenshotHelper.TakeScreenshot().ToUniTask(coroutineRunner);
+            // Note: UniTask is required to be used from the async test.
+            //   And also needs coroutineRunner (any MonoBehaviour) because TakeScreenshot method uses WaitForEndOfFrame inside.
+            //   See more information: https://github.com/Cysharp/UniTask#ienumeratortounitask-limitation
+
+            Assert.That(path, Does.Exist);
+        }
+
+        private class CoroutineRunner : MonoBehaviour
+        {
         }
     }
 }

--- a/Tests/RuntimeInternals/TestHelper.RuntimeInternals.Tests.asmdef
+++ b/Tests/RuntimeInternals/TestHelper.RuntimeInternals.Tests.asmdef
@@ -5,7 +5,8 @@
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
         "TestHelper",
-        "TestHelper.RuntimeInternals"
+        "TestHelper.RuntimeInternals",
+        "UniTask"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Tests/RuntimeInternals/TestHelper.RuntimeInternals.Tests.asmdef
+++ b/Tests/RuntimeInternals/TestHelper.RuntimeInternals.Tests.asmdef
@@ -4,7 +4,6 @@
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
-        "TestHelper",
         "TestHelper.RuntimeInternals",
         "UniTask"
     ],


### PR DESCRIPTION
- Add tests using ScreenshotHelper.TakeScreenshot method from async test
- Remove dependency to TestHelper from RuntimeInternals
