### PR TITLE
Mod LogType `Warning` instead of `Error` when invalid argument

### DIFF
--- a/RuntimeInternals/ScreenshotHelper.cs
+++ b/RuntimeInternals/ScreenshotHelper.cs
@@ -66,13 +66,13 @@ namespace TestHelper.RuntimeInternals
         {
             if (superSize != 1 && stereoCaptureMode != ScreenCapture.StereoScreenCaptureMode.LeftEye)
             {
-                Debug.LogError("superSize and stereoCaptureMode cannot be specified at the same time.");
+                Debug.LogWarning("superSize and stereoCaptureMode cannot be specified at the same time.");
                 yield break;
             }
 
             if (Thread.CurrentThread.ManagedThreadId != 1)
             {
-                Debug.LogError("Must be called from the main thread.");
+                Debug.LogWarning("Must be called from the main thread.");
                 yield break;
                 // Note: This is not the case since it is a coroutine.
             }

--- a/Tests/Runtime/Attributes/TakeScreenshotAttributeTest.cs
+++ b/Tests/Runtime/Attributes/TakeScreenshotAttributeTest.cs
@@ -229,6 +229,7 @@ namespace TestHelper.Attributes
         }
 
         [Test, Order(1)]
+        [Description("This test fails with stereo rendering settings.")]
         public void AttachWithSuperSize_SaveSuperSizeScreenshot_ExistFile()
         {
             var path = Path.Combine(
@@ -236,6 +237,8 @@ namespace TestHelper.Attributes
                 $"{nameof(AttachWithSuperSize_SaveSuperSizeScreenshot)}.png");
             Assert.That(path, Does.Exist);
             Assert.That(File.ReadAllBytes(path), Has.Length.GreaterThan(FileSizeThreshold2X));
+            // Note: This test fails with stereo rendering settings.
+            //  See: https://docs.unity3d.com/Manual/SinglePassStereoRendering.html
         }
 
         [Test, Order(0)]
@@ -265,7 +268,7 @@ namespace TestHelper.Attributes
             Assert.That(path, Does.Exist);
             // Is it a stereo screenshot? See for yourself! Be a witness!!
             // Note: Require stereo rendering settings.
-            // See: https://docs.unity3d.com/Manual/SinglePassStereoRendering.html
+            //  See: https://docs.unity3d.com/Manual/SinglePassStereoRendering.html
         }
 
         private class GizmoDemo : MonoBehaviour

--- a/Tests/RuntimeInternals/ScreenshotHelperTest.cs
+++ b/Tests/RuntimeInternals/ScreenshotHelperTest.cs
@@ -110,7 +110,7 @@ namespace TestHelper.RuntimeInternals
             var coroutineRunner = new GameObject().AddComponent<CoroutineRunner>();
             await ScreenshotHelper.TakeScreenshot().ToUniTask(coroutineRunner);
             // Note: UniTask is required to be used from the async test.
-            //   And also needs coroutineRunner (any MonoBehaviour) because TakeScreenshot method uses WaitForEndOfFrame inside.
+            //   And also needs CoroutineRunner (any MonoBehaviour) because TakeScreenshot method uses WaitForEndOfFrame inside.
             //   See more information: https://github.com/Cysharp/UniTask#ienumeratortounitask-limitation
 
             Assert.That(path, Does.Exist);

--- a/Tests/RuntimeInternals/ScreenshotHelperTest.cs
+++ b/Tests/RuntimeInternals/ScreenshotHelperTest.cs
@@ -93,7 +93,7 @@ namespace TestHelper.RuntimeInternals
             yield return ScreenshotHelper.TakeScreenshot(
                 superSize: 2,
                 stereoCaptureMode: ScreenCapture.StereoScreenCaptureMode.BothEyes);
-            LogAssert.Expect(LogType.Error, "superSize and stereoCaptureMode cannot be specified at the same time.");
+            LogAssert.Expect(LogType.Warning, "superSize and stereoCaptureMode cannot be specified at the same time.");
         }
 
         [Test]


### PR DESCRIPTION
- Mod LogType `Warning` instead of `Error` when invalid argument
- Add comments and description to tests about stereo rendering settings