### PR TITLE
Add command line argument to specify screenshot save directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}  # Default is `auto`
           checkName: test result (${{ matrix.unityVersion }})
           projectPath: ${{ env.CREATED_PROJECT_PATH }}
-          customParameters: -testCategory "!IgnoreCI"
+          customParameters: -testCategory "!IgnoreCI" -testHelperScreenshotDirectory Screenshots
           coverageOptions: generateAdditionalMetrics;generateTestReferences;generateHtmlReport;generateAdditionalReports;dontClear;assemblyFilters:${{ env.assembly_filters }}
           # see: https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/manual/CoverageBatchmode.html
         env:
@@ -113,6 +113,7 @@ jobs:
           path: |
             ${{ steps.test.outputs.artifactsPath }}
             ${{ steps.test.outputs.coveragePath }}
+            Screenshots
         if: always()
 
   notify:

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,8 @@ $(TEST_CATEGORY) \
 $(TEST_FILTER) \
 $(ASSEMBLY_NAMES) \
 -testPlatform $(TEST_PLATFORM) \
--testResults $(LOG_DIR)/test_$(TEST_PLATFORM)_results.xml
+-testResults $(LOG_DIR)/test_$(TEST_PLATFORM)_results.xml \
+-testHelperScreenshotDirectory $(LOG_DIR)/Screenshots
 endef
 
 define test

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ public class MyTestClass
 
 Default save path is "`Application.persistentDataPath`/TestHelper/Screenshots/`CurrentTest.Name`.png".
 You can specify the save directory and/or filename by arguments.
+Directory can also be specified by command line arguments `-testHelperScreenshotDirectory`.
 
 This attribute can attached to test method only.
 Can be used with sync Test, async Test, and UnityTest.
@@ -376,6 +377,7 @@ public class MyTestClass
 Default save path is "`Application.persistentDataPath`/TestHelper/Screenshots/`CurrentTest.Name`.png".
 (Replace `CurrentTest.Name` to caller method name when run in runtime context.)
 You can specify the save directory and/or filename by arguments.
+Directory can also be specified by command line arguments `-testHelperScreenshotDirectory`.
 
 Usage:
 

--- a/Runtime/Attributes/TakeScreenshotAttribute.cs
+++ b/Runtime/Attributes/TakeScreenshotAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Koji Hasegawa.
+// Copyright (c) 2023-2024 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
@@ -26,7 +26,7 @@ namespace TestHelper.Attributes
         /// <summary>
         /// Take a screenshot and save it to file after running the test.
         /// Default save path is $"{Application.persistentDataPath}/TestHelper/Screenshots/{CurrentTest.Name}.png".
-        /// If you want to take screenshots at any time, use the <c>ScreenshotHelper</c> class.
+        /// If you want to take screenshots at any time, use the <c>TestHelper.RuntimeInternals.ScreenshotHelper</c> class.
         /// </summary>
         /// <remarks>
         /// Limitations:
@@ -35,8 +35,12 @@ namespace TestHelper.Attributes
         /// <br/>
         /// Using <c>ScreenCapture.CaptureScreenshotAsTexture</c> internally.
         /// </remarks>
-        /// <param name="directory">Directory to save screenshots.</param>
-        /// <param name="filename">Filename to store screenshot.</param>
+        /// <param name="directory">Directory to save screenshots.
+        /// If omitted, the directory specified by command line argument "-testHelperScreenshotDirectory" is used.
+        /// If the command line argument is also omitted, <c>Application.persistentDataPath</c> + "/TestHelper/Screenshots/" is used.</param>
+        /// <param name="filename">Filename to store screenshot.
+        /// Default filename is <c>CurrentTest.Name</c> + ".png" when run in test-framework context.
+        /// Using caller method name when run in runtime context.</param>
         /// <param name="superSize">The factor to increase resolution with.</param>
         /// <param name="stereoCaptureMode">The eye texture to capture when stereo rendering is enabled.</param>
         /// <param name="gizmos">True: show Gizmos on GameView</param>

--- a/RuntimeInternals/CommandLineArgs.cs
+++ b/RuntimeInternals/CommandLineArgs.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2023-2024 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.IO;
+using System.Linq;
+using UnityEngine;
+
+namespace TestHelper.RuntimeInternals
+{
+    /// <summary>
+    /// Manage command line arguments for test-helper.
+    /// </summary>
+    public static class CommandLineArgs
+    {
+        internal static string[] CachedCommandLineArgs = Environment.GetCommandLineArgs();
+
+        /// <summary>
+        /// Screenshot save directory.
+        /// Returns <c>Application.persistentDataPath</c> + "/TestHelper/Screenshots/" if not specified.
+        /// </summary>
+        /// <returns></returns>
+        public static string GetScreenshotDirectory()
+        {
+            const string ScreenshotDirectoryKey = "-testHelperScreenshotDirectory=";
+
+            var arg = CachedCommandLineArgs.FirstOrDefault(x => x.StartsWith(ScreenshotDirectoryKey));
+            if (arg != null)
+            {
+                return arg[ScreenshotDirectoryKey.Length..];
+            }
+            else
+            {
+                return Path.Combine(Application.persistentDataPath, "TestHelper", "Screenshots");
+            }
+        }
+    }
+}

--- a/RuntimeInternals/CommandLineArgs.cs
+++ b/RuntimeInternals/CommandLineArgs.cs
@@ -2,8 +2,8 @@
 // This software is released under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using UnityEngine;
 
 namespace TestHelper.RuntimeInternals
@@ -13,23 +13,43 @@ namespace TestHelper.RuntimeInternals
     /// </summary>
     public static class CommandLineArgs
     {
-        internal static string[] CachedCommandLineArgs = Environment.GetCommandLineArgs();
+        internal static Dictionary<string, string> DictionaryFromCommandLineArgs(string[] args)
+        {
+            var result = new Dictionary<string, string>();
+            for (var i = 0; i < args.Length; i++)
+            {
+                if (args[i].StartsWith("-"))
+                {
+                    var key = args[i];
+                    var value = string.Empty;
+                    if (i + 1 < args.Length && !args[i + 1].StartsWith("-"))
+                    {
+                        value = args[i + 1];
+                        i++;
+                    }
+
+                    result[key] = value;
+                }
+            }
+
+            return result;
+        }
 
         /// <summary>
         /// Screenshot save directory.
         /// Returns <c>Application.persistentDataPath</c> + "/TestHelper/Screenshots/" if not specified.
         /// </summary>
         /// <returns></returns>
-        public static string GetScreenshotDirectory()
+        public static string GetScreenshotDirectory(string[] args = null)
         {
-            const string ScreenshotDirectoryKey = "-testHelperScreenshotDirectory=";
+            const string ScreenshotDirectoryKey = "-testHelperScreenshotDirectory";
 
-            var arg = CachedCommandLineArgs.FirstOrDefault(x => x.StartsWith(ScreenshotDirectoryKey));
-            if (arg != null)
+            try
             {
-                return arg.Substring(ScreenshotDirectoryKey.Length);
+                args = args ?? Environment.GetCommandLineArgs();
+                return DictionaryFromCommandLineArgs(args)[ScreenshotDirectoryKey];
             }
-            else
+            catch (KeyNotFoundException)
             {
                 return Path.Combine(Application.persistentDataPath, "TestHelper", "Screenshots");
             }

--- a/RuntimeInternals/CommandLineArgs.cs
+++ b/RuntimeInternals/CommandLineArgs.cs
@@ -27,7 +27,7 @@ namespace TestHelper.RuntimeInternals
             var arg = CachedCommandLineArgs.FirstOrDefault(x => x.StartsWith(ScreenshotDirectoryKey));
             if (arg != null)
             {
-                return arg[ScreenshotDirectoryKey.Length..];
+                return arg.Substring(ScreenshotDirectoryKey.Length);
             }
             else
             {

--- a/RuntimeInternals/CommandLineArgs.cs.meta
+++ b/RuntimeInternals/CommandLineArgs.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 75d1e341a0f34380b43ef39e7e2acde6
+timeCreated: 1711029589

--- a/RuntimeInternals/ScreenshotHelper.cs
+++ b/RuntimeInternals/ScreenshotHelper.cs
@@ -1,10 +1,9 @@
-// Copyright (c) 2023 Koji Hasegawa.
+// Copyright (c) 2023-2024 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Collections;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using UnityEngine;
 #if UNITY_INCLUDE_TESTS
 using NUnit.Framework;
@@ -18,10 +17,7 @@ namespace TestHelper.RuntimeInternals
     /// </summary>
     public static class ScreenshotHelper
     {
-        private static string DefaultDirectoryPath()
-        {
-            return Path.Combine(Application.persistentDataPath, "TestHelper", "Screenshots");
-        }
+        private static string DefaultDirectoryPath => CommandLineArgs.GetScreenshotDirectory();
 
         private static string DefaultFilename(string callerMemberName)
         {
@@ -50,7 +46,9 @@ namespace TestHelper.RuntimeInternals
         /// <br/>
         /// Using <c>ScreenCapture.CaptureScreenshotAsTexture</c> internally.
         /// </remarks>
-        /// <param name="directory">Directory to save screenshots. Default save path is <c>Application.persistentDataPath</c> + "/TestHelper/Screenshots/".</param>
+        /// <param name="directory">Directory to save screenshots.
+        /// If omitted, the directory specified by command line argument "-testHelperScreenshotDirectory" is used.
+        /// If the command line argument is also omitted, <c>Application.persistentDataPath</c> + "/TestHelper/Screenshots/" is used.</param>
         /// <param name="filename">Filename to store screenshot.
         /// Default filename is <c>CurrentTest.Name</c> + ".png" when run in test-framework context.
         /// Using caller method name when run in runtime context.</param>
@@ -76,7 +74,7 @@ namespace TestHelper.RuntimeInternals
             }
             else
             {
-                directory = DefaultDirectoryPath(); // Not apply specific directory when running on player
+                directory = DefaultDirectoryPath; // Not apply specific directory when running on player
             }
 
             Directory.CreateDirectory(directory);

--- a/Tests/Runtime/Attributes/TakeScreenshotAttributeTest.cs
+++ b/Tests/Runtime/Attributes/TakeScreenshotAttributeTest.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using TestHelper.RuntimeInternals;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.UI;
@@ -18,9 +19,7 @@ namespace TestHelper.Attributes
         private const string TestScene = "Packages/com.nowsprinting.test-helper/Tests/Scenes/ScreenshotTest.unity";
         private const int FileSizeThreshold = 5441; // VGA size solid color file size
         private const int FileSizeThreshold2X = 100 * 1024; // Normal size is 80 to 90KB
-
-        private readonly string _defaultOutputDirectory =
-            Path.Combine(Application.persistentDataPath, "TestHelper", "Screenshots");
+        private readonly string _defaultOutputDirectory = CommandLineArgs.GetScreenshotDirectory();
 
         private Text _text;
 

--- a/Tests/RuntimeInternals/CommandLineArgsTest.cs
+++ b/Tests/RuntimeInternals/CommandLineArgsTest.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2023-2024 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.IO;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace TestHelper.RuntimeInternals
+{
+    [TestFixture]
+    public class CommandLineArgsTest
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            CommandLineArgs.CachedCommandLineArgs = Environment.GetCommandLineArgs();
+        }
+
+        [Test]
+        public void GetScreenshotDirectory_WithArgument_GotSpecifiedDirectory()
+        {
+            CommandLineArgs.CachedCommandLineArgs = new[] { "-testHelperScreenshotDirectory=Test" };
+            var actual = CommandLineArgs.GetScreenshotDirectory();
+            Assert.That(actual, Is.EqualTo("Test"));
+        }
+
+        [Test]
+        public void GetScreenshotDirectory_WithoutArgument_GotDefaultDirectory()
+        {
+            CommandLineArgs.CachedCommandLineArgs = Array.Empty<string>();
+            var actual = CommandLineArgs.GetScreenshotDirectory();
+            Assert.That(actual, Is.EqualTo(Path.Combine(Application.persistentDataPath, "TestHelper", "Screenshots")));
+        }
+    }
+}

--- a/Tests/RuntimeInternals/CommandLineArgsTest.cs
+++ b/Tests/RuntimeInternals/CommandLineArgsTest.cs
@@ -11,25 +11,32 @@ namespace TestHelper.RuntimeInternals
     [TestFixture]
     public class CommandLineArgsTest
     {
-        [TearDown]
-        public void TearDown()
+        [Test]
+        public void DictionaryFromCommandLineArgs()
         {
-            CommandLineArgs.CachedCommandLineArgs = Environment.GetCommandLineArgs();
+            var args = new[] { "-flag1", "-key1", "value1", "-flag2" };
+            var expected = new System.Collections.Generic.Dictionary<string, string>
+            {
+                { "-flag1", string.Empty }, //
+                { "-key1", "value1" }, //
+                { "-flag2", string.Empty },
+            };
+            var actual = CommandLineArgs.DictionaryFromCommandLineArgs(args);
+
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
         public void GetScreenshotDirectory_WithArgument_GotSpecifiedDirectory()
         {
-            CommandLineArgs.CachedCommandLineArgs = new[] { "-testHelperScreenshotDirectory=Test" };
-            var actual = CommandLineArgs.GetScreenshotDirectory();
+            var actual = CommandLineArgs.GetScreenshotDirectory(new[] { "-testHelperScreenshotDirectory", "Test" });
             Assert.That(actual, Is.EqualTo("Test"));
         }
 
         [Test]
         public void GetScreenshotDirectory_WithoutArgument_GotDefaultDirectory()
         {
-            CommandLineArgs.CachedCommandLineArgs = Array.Empty<string>();
-            var actual = CommandLineArgs.GetScreenshotDirectory();
+            var actual = CommandLineArgs.GetScreenshotDirectory(Array.Empty<string>());
             Assert.That(actual, Is.EqualTo(Path.Combine(Application.persistentDataPath, "TestHelper", "Screenshots")));
         }
     }

--- a/Tests/RuntimeInternals/CommandLineArgsTest.cs.meta
+++ b/Tests/RuntimeInternals/CommandLineArgsTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d5ed4cac644d453f86e05caef8008e79
+timeCreated: 1711031297

--- a/Tests/RuntimeInternals/ScreenshotHelperTest.cs
+++ b/Tests/RuntimeInternals/ScreenshotHelperTest.cs
@@ -20,9 +20,7 @@ namespace TestHelper.RuntimeInternals
     {
         internal const string TestScene = "Packages/com.nowsprinting.test-helper/Tests/Scenes/ScreenshotTest.unity";
         private const int FileSizeThreshold = 5441; // VGA size solid color file size
-
-        private readonly string _defaultOutputDirectory =
-            Path.Combine(Application.persistentDataPath, "TestHelper", "Screenshots");
+        private readonly string _defaultOutputDirectory = CommandLineArgs.GetScreenshotDirectory();
 
         private Text _text;
 


### PR DESCRIPTION
Screenshot save directory can be also specified by command line arguments `-testHelperScreenshotDirectory`.