### PR TITLE
Support glob pattern in LoadScene attribute

### DIFF
--- a/Editor/TemporaryBuildScenesUsingInTest.cs
+++ b/Editor/TemporaryBuildScenesUsingInTest.cs
@@ -3,11 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using TestHelper.Attributes;
 using TestHelper.Editor;
+using TestHelper.Utils;
 using UnityEditor;
 using UnityEditor.TestTools;
+using UnityEngine;
 
 [assembly: TestPlayerBuildModifier(typeof(TemporaryBuildScenesUsingInTest))]
 
@@ -58,17 +61,23 @@ namespace TestHelper.Editor
                 .Concat(FindLoadSceneAttributesOnMethods());
             foreach (var attribute in attributes)
             {
-                if (attribute.ScenePath.ToLower().EndsWith(".unity"))
+                string scenePath;
+                try
                 {
-                    yield return attribute.ScenePath;
+                    scenePath = ScenePathFinder.GetExistScenePath(attribute.ScenePath);
                 }
-                else
+                catch (ArgumentException e)
                 {
-                    foreach (var guid in AssetDatabase.FindAssets("t:SceneAsset", new[] { attribute.ScenePath }))
-                    {
-                        yield return AssetDatabase.GUIDToAssetPath(guid);
-                    }
+                    Debug.LogWarning(e.Message);
+                    continue;
                 }
+                catch (FileNotFoundException e)
+                {
+                    Debug.LogWarning(e.Message);
+                    continue;
+                }
+
+                yield return scenePath;
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -211,15 +211,16 @@ public class MyTestClass
 
 #### LoadScene
 
-`LoadSceneAttribute` is an NUnit test attribute class to load scene before running test.
+`LoadSceneAttribute` is a NUnit test attribute class that loads the scene before running the test.
 
 It has the following benefits:
 
-- Can be use same code for running Edit Mode tests, Play Mode tests in Editor, and on Player
-- Can be specified scenes that are **NOT** in "Scenes in Build"
+- Can be use same code for running Edit Mode tests, Play Mode tests in Editor, and on Player.
+- Can be specified scenes that are **NOT** in "Scenes in Build".
+- Can be specified path by glob pattern. However, there are restrictions, top level and scene name cannot be omitted.
 
-This attribute can attached to test method only.
-Can be used with sync Test, async Test, and UnityTest.
+- This attribute can attached to the test method only.
+It can be used with sync Tests, async Tests, and UnityTest.
 
 Usage:
 

--- a/Runtime/Attributes/LoadSceneAttribute.cs
+++ b/Runtime/Attributes/LoadSceneAttribute.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
+using TestHelper.Utils;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
@@ -35,12 +36,14 @@ namespace TestHelper.Attributes
 
         /// <summary>
         /// Load scene before running test.
+        /// Can be specified path by glob pattern. However, there are restrictions, top level and scene name cannot be omitted.
         /// </summary>
         /// <param name="path">Scene file path.
         /// The path starts with `Assets/` or `Packages/`.
         /// And package name using `name` instead of `displayName`, when scenes in the package.
         /// (e.g., `Packages/com.nowsprinting.test-helper/Tests/Scenes/Scene.unity`)
         /// </param>
+        /// <seealso href="https://en.wikipedia.org/wiki/Glob_(programming)"/>
         public LoadSceneAttribute(string path)
         {
             ScenePath = path;
@@ -49,6 +52,7 @@ namespace TestHelper.Attributes
         /// <inheritdoc />
         public IEnumerator BeforeTest(ITest test)
         {
+            var existScenePath = ScenePathFinder.GetExistScenePath(ScenePath);
             AsyncOperation loadSceneAsync = null;
 
             if (Application.isEditor)
@@ -58,20 +62,20 @@ namespace TestHelper.Attributes
                 {
                     // Play Mode tests running in Editor
                     loadSceneAsync = EditorSceneManager.LoadSceneAsyncInPlayMode(
-                        ScenePath,
+                        existScenePath,
                         new LoadSceneParameters(LoadSceneMode.Single));
                 }
                 else
                 {
                     // Edit Mode tests
-                    EditorSceneManager.OpenScene(ScenePath);
+                    EditorSceneManager.OpenScene(existScenePath);
                 }
 #endif
             }
             else
             {
                 // Play Mode tests running on Player
-                loadSceneAsync = SceneManager.LoadSceneAsync(ScenePath);
+                loadSceneAsync = SceneManager.LoadSceneAsync(existScenePath);
             }
 
             yield return loadSceneAsync;

--- a/Runtime/Utils/ScenePathFinder.cs
+++ b/Runtime/Utils/ScenePathFinder.cs
@@ -1,0 +1,137 @@
+// Copyright (c) 2023-2024 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace TestHelper.Utils
+{
+    internal static class ScenePathFinder
+    {
+        /// <summary>
+        /// Get existing scene file path matches a glob pattern.
+        /// </summary>
+        /// <param name="path">Scene file path. Can be specified path by glob pattern. However, there are restrictions, top level and scene name cannot be omitted.</param>
+        /// <returns>Existing scene file path</returns>
+        /// <exception cref="ArgumentException">Invalid path format</exception>
+        /// <exception cref="FileNotFoundException">Scene file not found</exception>
+        public static string GetExistScenePath(string path)
+        {
+            ValidatePath(path);
+#if UNITY_EDITOR
+            return GetExistScenePathInEditor(path);
+#else
+            return GetExistScenePathOnPlayer(path);
+#endif
+        }
+
+        private static void ValidatePath(string path)
+        {
+            if (!path.StartsWith("Assets/") && !path.StartsWith("Packages/"))
+            {
+                throw new ArgumentException($"Scene path must start with `Assets/` or `Packages/`. path: {path}");
+            }
+
+            var split = path.Split('/');
+            if (split[0].Equals("Packages") && split[1].IndexOfAny(new[] { '*', '?' }) >= 0)
+            {
+                throw new ArgumentException($"Wildcards cannot be used in the package name of path: {path}");
+            }
+
+            if (!path.EndsWith(".unity"))
+            {
+                throw new ArgumentException($"Scene path must ends with `.unity`. path: {path}");
+            }
+
+            if (split.Last().IndexOfAny(new[] { '*', '?' }) >= 0)
+            {
+                throw new ArgumentException($"Wildcards cannot be used in the most right section of path: {path}");
+            }
+        }
+
+        private static string SearchFolder(string path)
+        {
+            var searchFolder = new StringBuilder();
+            var split = path.Split('/');
+            for (var i = 0; i < split.Length - 1; i++)
+            {
+                var s = split[i];
+                if (s.IndexOfAny(new[] { '*', '?' }) >= 0)
+                {
+                    break;
+                }
+
+                searchFolder.Append($"{s}/");
+            }
+
+            return searchFolder.ToString();
+        }
+
+        private static Regex ConvertRegexFromGlob(string glob)
+        {
+            var regex = new StringBuilder();
+            foreach (var c in glob)
+            {
+                switch (c)
+                {
+                    case '*':
+                        regex.Append("[^/]*");
+                        break;
+                    case '?':
+                        regex.Append("[^/]");
+                        break;
+                    case '.':
+                        regex.Append("\\.");
+                        break;
+                    case '\\':
+                        regex.Append("\\\\");
+                        break;
+                    default:
+                        regex.Append(c);
+                        break;
+                }
+            }
+
+            regex.Replace("[^/]*[^/]*", ".*"); // globstar (**)
+            regex.Insert(0, "^");
+            regex.Append("$");
+            return new Regex(regex.ToString());
+        }
+
+#if UNITY_EDITOR
+        /// <summary>
+        /// For the run in editor, use <c>AssetDatabase</c> to search scenes and compare paths.
+        /// </summary>
+        /// <param name="path"></param>
+        private static string GetExistScenePathInEditor(string path)
+        {
+            var regex = ConvertRegexFromGlob(path);
+            foreach (var guid in AssetDatabase.FindAssets("t:SceneAsset", new[] { SearchFolder(path) }))
+            {
+                var existScenePath = AssetDatabase.GUIDToAssetPath(guid);
+                if (regex.IsMatch(existScenePath))
+                {
+                    return existScenePath;
+                }
+            }
+
+            throw new FileNotFoundException($"Scene `{path}` is not found in AssetDatabase");
+        }
+#endif
+
+        /// <summary>
+        /// For the run on player, returns scene name from the path.
+        /// </summary>
+        /// <param name="path"></param>
+        internal static string GetExistScenePathOnPlayer(string path)
+        {
+            return path.Split('/').Last().Split('.').First();
+        }
+    }
+}

--- a/Runtime/Utils/ScenePathFinder.cs.meta
+++ b/Runtime/Utils/ScenePathFinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6038685c18ff47b2b5cfde489f9dedac
+timeCreated: 1711253913

--- a/Tests/Editor/LoadSceneAttributeTest.cs
+++ b/Tests/Editor/LoadSceneAttributeTest.cs
@@ -15,7 +15,7 @@ namespace TestHelper.Editor
 
         [Test]
         [LoadScene(TestScene)]
-        public void Attach_AlreadyLoadedSceneNotInBuild()
+        public void Attach_LoadedSceneNotInBuild()
         {
             var cube = GameObject.Find(ObjectName);
             Assert.That(cube, Is.Not.Null);

--- a/Tests/Editor/TemporaryBuildScenesUsingInTestTest.cs
+++ b/Tests/Editor/TemporaryBuildScenesUsingInTestTest.cs
@@ -8,12 +8,13 @@ namespace TestHelper.Editor
     [TestFixture]
     public class TemporaryBuildScenesUsingInTestTest
     {
+        private const string TestScene = "Packages/com.nowsprinting.test-helper/Tests/Scenes/NotInScenesInBuild.unity";
+
         [Test]
         public void GetScenesUsingInTest_AttachedToMethod_ReturnScenesSpecifiedByAttribute()
         {
             var actual = TemporaryBuildScenesUsingInTest.GetScenesUsingInTest();
-            Assert.That(actual,
-                Does.Contain("Packages/com.nowsprinting.test-helper/Tests/Scenes/NotInScenesInBuild.unity"));
+            Assert.That(actual, Does.Contain(TestScene));
         }
     }
 }

--- a/Tests/Runtime/Attributes/LoadSceneAttributeTest.cs
+++ b/Tests/Runtime/Attributes/LoadSceneAttributeTest.cs
@@ -17,7 +17,7 @@ namespace TestHelper.Attributes
 
         [Test]
         [LoadScene(TestScene)]
-        public void Attach_AlreadyLoadedSceneNotInBuild()
+        public void Attach_LoadedSceneNotInBuild()
         {
             var cube = GameObject.Find(ObjectName);
             Assert.That(cube, Is.Not.Null);
@@ -27,7 +27,7 @@ namespace TestHelper.Attributes
 
         [Test]
         [LoadScene(TestScene)]
-        public async Task AttachToAsyncTest_AlreadyLoadedSceneNotInBuild()
+        public async Task AttachToAsyncTest_LoadedSceneNotInBuild()
         {
             var cube = GameObject.Find(ObjectName);
             Assert.That(cube, Is.Not.Null);
@@ -38,13 +38,23 @@ namespace TestHelper.Attributes
 
         [UnityTest]
         [LoadScene(TestScene)]
-        public IEnumerator AttachToUnityTest_AlreadyLoadedSceneNotInBuild()
+        public IEnumerator AttachToUnityTest_LoadedSceneNotInBuild()
         {
             var cube = GameObject.Find(ObjectName);
             Assert.That(cube, Is.Not.Null);
 
             Object.Destroy(cube); // For not giving false negatives in subsequent tests.
             yield return null;
+        }
+
+        [Test]
+        [LoadScene("Packages/com.nowsprinting.test-helper/**/NotInScenesInBuild.unity")]
+        public void UsingGlob_LoadedSceneNotInBuild()
+        {
+            var cube = GameObject.Find(ObjectName);
+            Assert.That(cube, Is.Not.Null);
+
+            Object.Destroy(cube); // For not giving false negatives in subsequent tests.
         }
     }
 }

--- a/Tests/Runtime/Utils.meta
+++ b/Tests/Runtime/Utils.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 14bd4144206d412ba38950fc3ea64b0a
+timeCreated: 1711257235

--- a/Tests/Runtime/Utils/ScenePathFinderTest.cs
+++ b/Tests/Runtime/Utils/ScenePathFinderTest.cs
@@ -1,0 +1,56 @@
+// Copyright (c) 2023-2024 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.IO;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace TestHelper.Utils
+{
+    [TestFixture]
+    public class ScenePathFinderTest
+    {
+        [TestCase("Packages/com.nowsprinting.test-helper/Tests/Scenes/NotInScenesInBuild.unity")]
+        [TestCase("Packages/com.nowsprinting.test-helper/Tes?s/S?enes/NotInScenesInBuild.unity")]
+        [TestCase("Packages/com.nowsprinting.test-helper/*/*/NotInScenesInBuild.unity")]
+        [TestCase("Packages/com.nowsprinting.test-helper/**/NotInScenesInBuild.unity")]
+        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
+        public void GetExistScenePath_InEditor_GotExistScenePath(string path)
+        {
+            const string ExistScenePath = "Packages/com.nowsprinting.test-helper/Tests/Scenes/NotInScenesInBuild.unity";
+
+            var actual = ScenePathFinder.GetExistScenePath(path);
+            Assert.That(actual, Is.EqualTo(ExistScenePath));
+        }
+
+        [TestCase("Tests/com.nowsprinting.test-helper/Tests/Scenes/NotInScenesInBuild.unity")]
+        [TestCase("Packages/**/NotInScenesInBuild.unity")]
+        [TestCase("Packages/com.nowsprinting.test-helper/Tests/Scenes/NotInScenesInBuild")]
+        [TestCase("Packages/com.nowsprinting.test-helper/Tests/Scenes/Not??ScenesInBuild.unity")]
+        [TestCase("Packages/com.nowsprinting.test-helper/Tests/Scenes/*InScenesInBuild.unity")]
+        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
+        public void GetExistScenePath_InEditor_ThrowsArgumentException(string path)
+        {
+            Assert.That(() => ScenePathFinder.GetExistScenePath(path), Throws.TypeOf<ArgumentException>());
+        }
+
+        [TestCase("Packages/com.nowsprinting.test-helper/Tests/Scenes/NotExistScene.unity")]
+        [TestCase("Packages/com.nowsprinting.test-helper/*/NotInScenesInBuild.unity")] // Not match path pattern
+        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
+        public void GetExistScenePath_InEditor_ThrowsFileNotFoundException(string path)
+        {
+            Assert.That(() => ScenePathFinder.GetExistScenePath(path), Throws.TypeOf<FileNotFoundException>());
+        }
+
+        [TestCase("Packages/com.nowsprinting.test-helper/Tests/Scenes/NotInScenesInBuild.unity")]
+        public void GetExistScenePathOnPlayer_GotSceneName(string path)
+        {
+            const string SceneName = "NotInScenesInBuild";
+
+            var actual = ScenePathFinder.GetExistScenePathOnPlayer(path);
+            Assert.That(actual, Is.EqualTo(SceneName));
+        }
+    }
+}

--- a/Tests/Runtime/Utils/ScenePathFinderTest.cs
+++ b/Tests/Runtime/Utils/ScenePathFinderTest.cs
@@ -4,8 +4,6 @@
 using System;
 using System.IO;
 using NUnit.Framework;
-using UnityEngine;
-using UnityEngine.TestTools;
 
 namespace TestHelper.Utils
 {
@@ -16,8 +14,7 @@ namespace TestHelper.Utils
         [TestCase("Packages/com.nowsprinting.test-helper/Tes?s/S?enes/NotInScenesInBuild.unity")]
         [TestCase("Packages/com.nowsprinting.test-helper/*/*/NotInScenesInBuild.unity")]
         [TestCase("Packages/com.nowsprinting.test-helper/**/NotInScenesInBuild.unity")]
-        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
-        public void GetExistScenePath_InEditor_GotExistScenePath(string path)
+        public void GetExistScenePath_ExistPath_GotExistScenePath(string path)
         {
             const string ExistScenePath = "Packages/com.nowsprinting.test-helper/Tests/Scenes/NotInScenesInBuild.unity";
 
@@ -25,21 +22,19 @@ namespace TestHelper.Utils
             Assert.That(actual, Is.EqualTo(ExistScenePath));
         }
 
-        [TestCase("Tests/com.nowsprinting.test-helper/Tests/Scenes/NotInScenesInBuild.unity")]
         [TestCase("Packages/**/NotInScenesInBuild.unity")]
+        [TestCase("**/NotInScenesInBuild.unity")]
         [TestCase("Packages/com.nowsprinting.test-helper/Tests/Scenes/NotInScenesInBuild")]
         [TestCase("Packages/com.nowsprinting.test-helper/Tests/Scenes/Not??ScenesInBuild.unity")]
         [TestCase("Packages/com.nowsprinting.test-helper/Tests/Scenes/*InScenesInBuild.unity")]
-        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
-        public void GetExistScenePath_InEditor_ThrowsArgumentException(string path)
+        public void GetExistScenePath_InvalidGlobPattern_ThrowsArgumentException(string path)
         {
             Assert.That(() => ScenePathFinder.GetExistScenePath(path), Throws.TypeOf<ArgumentException>());
         }
 
-        [TestCase("Packages/com.nowsprinting.test-helper/Tests/Scenes/NotExistScene.unity")]
+        [TestCase("Packages/com.nowsprinting.test-helper/Tests/Scenes/NotExistScene.unity")] // Not exist path
         [TestCase("Packages/com.nowsprinting.test-helper/*/NotInScenesInBuild.unity")] // Not match path pattern
-        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
-        public void GetExistScenePath_InEditor_ThrowsFileNotFoundException(string path)
+        public void GetExistScenePath_NotExistPath_ThrowsFileNotFoundException(string path)
         {
             Assert.That(() => ScenePathFinder.GetExistScenePath(path), Throws.TypeOf<FileNotFoundException>());
         }

--- a/Tests/Runtime/Utils/ScenePathFinderTest.cs
+++ b/Tests/Runtime/Utils/ScenePathFinderTest.cs
@@ -4,6 +4,8 @@
 using System;
 using System.IO;
 using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace TestHelper.Utils
 {
@@ -16,7 +18,11 @@ namespace TestHelper.Utils
         [TestCase("Packages/com.nowsprinting.test-helper/**/NotInScenesInBuild.unity")]
         public void GetExistScenePath_ExistPath_GotExistScenePath(string path)
         {
+#if UNITY_EDITOR
             const string ExistScenePath = "Packages/com.nowsprinting.test-helper/Tests/Scenes/NotInScenesInBuild.unity";
+#else
+            const string ExistScenePath = "NotInScenesInBuild"; // Scene name only
+#endif
 
             var actual = ScenePathFinder.GetExistScenePath(path);
             Assert.That(actual, Is.EqualTo(ExistScenePath));
@@ -34,9 +40,11 @@ namespace TestHelper.Utils
 
         [TestCase("Packages/com.nowsprinting.test-helper/Tests/Scenes/NotExistScene.unity")] // Not exist path
         [TestCase("Packages/com.nowsprinting.test-helper/*/NotInScenesInBuild.unity")] // Not match path pattern
-        public void GetExistScenePath_NotExistPath_ThrowsFileNotFoundException(string path)
+        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
+        public void GetExistScenePath_NotExistPath_InEditor_ThrowsFileNotFoundException(string path)
         {
             Assert.That(() => ScenePathFinder.GetExistScenePath(path), Throws.TypeOf<FileNotFoundException>());
+            // Note: Returns scene name when running on player.
         }
 
         [TestCase("Packages/com.nowsprinting.test-helper/Tests/Scenes/NotInScenesInBuild.unity")]

--- a/Tests/Runtime/Utils/ScenePathFinderTest.cs.meta
+++ b/Tests/Runtime/Utils/ScenePathFinderTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1dddee15564c4e0087fe606c91937050
+timeCreated: 1711257242


### PR DESCRIPTION
### Changes

Can be specified path by glob pattern in `LoadSceneAttribute`.
However, there are restrictions, top level and scene name cannot be omitted.