### PR TITLE
Suppress double quote in screenshot filename

### DIFF
--- a/RuntimeInternals/ScreenshotHelper.cs
+++ b/RuntimeInternals/ScreenshotHelper.cs
@@ -25,7 +25,8 @@ namespace TestHelper.RuntimeInternals
             return TestContext.CurrentTestExecutionContext.CurrentTest.Name
                 .Replace('(', '_')
                 .Replace(')', '_')
-                .Replace(',', '-');
+                .Replace(',', '-')
+                .Replace("\"", "");
             // Note: Same as the file name created under ActualImages of the Graphics Tests Framework package.
 #else
             return callerMemberName;


### PR DESCRIPTION
It will be inserted if there is a string parameter in a parameterized test.
It is also suppressed by the Graphics Tests Framework package.