### PR TITLE
Mod run tests as embedded package on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Koji Hasegawa.
+# Copyright (c) 2023-2024 Koji Hasegawa.
 # This software is released under the MIT License.
 
 name: Test
@@ -17,6 +17,9 @@ on:
       - '**.md'
       - '.github/**'
       - '!.github/workflows/test.yml'
+
+env:
+  PACKAGE_NAME: com.nowsprinting.test-helper
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -42,12 +45,6 @@ jobs:
             octocov: true
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: false
-          lfs: false
-
       - name: Crete project for tests
         uses: nowsprinting/create-unity-project-action@v3
         with:
@@ -60,9 +57,14 @@ jobs:
           restore-keys: |
             Library-
 
-      - name: Set package name
-        run: |
-          echo "package_name=$(grep -o -E '"name": "(.+)"' ./package.json | cut -d ' ' -f2)" >> "$GITHUB_ENV"
+      - name: Checkout repository as embedded package
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+          lfs: false
+          path: ${{ env.CREATED_PROJECT_PATH }}/Packages/${{ env.PACKAGE_NAME }}
+          # In Linux editor, there is a problem that assets in local packages cannot be found with `AssetDatabase.FindAssets`.
+          # As a workaround, I have made it into an embedded package.
 
       - name: Install dependencies
         run: |
@@ -70,12 +72,11 @@ jobs:
           openupm add -f com.unity.test-framework
           openupm add -f com.unity.testtools.codecoverage
           openupm add -f com.cysharp.unitask
-          openupm add -ft "${{ env.package_name }}"@file:../../
         working-directory: ${{ env.CREATED_PROJECT_PATH }}
 
       - name: Set coverage assembly filters
         run: |
-          assemblies=$(find . -name "*.asmdef" -maxdepth 3 | sed -e s/.*\\//\+/ | sed -e s/\\.asmdef// | sed -e s/^.*\\.Tests//)
+          assemblies=$(find ${{ env.CREATED_PROJECT_PATH }}/Packages/${{ env.PACKAGE_NAME }} -name "*.asmdef" | sed -e s/.*\\//\+/ | sed -e s/\\.asmdef// | sed -e s/^.*\\.Tests//)
           # shellcheck disable=SC2001,SC2048,SC2086
           echo "assembly_filters=$(echo ${assemblies[*]} | sed -e s/\ /,/g),+<assets>,-*.Tests" >> "$GITHUB_ENV"
 
@@ -99,7 +100,9 @@ jobs:
         id: test
 
       - name: Set coverage path for octocov
-        run: sed -i -r 's/UnityProject~\/Logs/${{ steps.test.outputs.coveragePath }}/' .octocov.yml
+        run: |
+          mv ${{ env.CREATED_PROJECT_PATH }}/Packages/${{ env.PACKAGE_NAME }}/.octocov.yml .
+          sed -i -r 's/UnityProject~\/Logs/${{ steps.test.outputs.coveragePath }}/' .octocov.yml
         if: ${{ matrix.octocov }}
 
       - name: Run octocov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,7 @@ jobs:
         id: test
 
       - name: Set coverage path for octocov
-        run: sed -i -r 's/\.\/Logs/${{ steps.test.outputs.coveragePath }}/' .octocov.yml
+        run: sed -i -r 's/UnityProject~\/Logs/${{ steps.test.outputs.coveragePath }}/' .octocov.yml
         if: ${{ matrix.octocov }}
 
       - name: Run octocov

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -2,18 +2,20 @@
 coverage:
   if: true
   paths:
-    - ./Logs/Report/lcov.info # Warning: This path is replace by regex in test.yml
+    - UnityProject~/Logs/Report/lcov.info # Warning: This path is to be replaced by regex in test.yml
+
 codeToTestRatio:
   code:
-    - 'Editor/**/*.cs'
-    - 'Runtime/**/*.cs'
-    - 'Samples~/**/*.cs'
-    - '!Samples~/**/Tests/**/*.cs'
+    - '**/*.cs'
+    - '!**/Tests/**'
+    - '!UnityProject~/Library/**'
   test:
-    - 'Tests/**/*.cs'
-    - 'Samples~/**/Tests/**/*.cs'
+    - '**/Tests/**/*.cs'
+    - '!UnityProject~/Library/**'
+
 testExecutionTime:
   if: true
+
 diff:
   datastores:
     - artifact://${GITHUB_REPOSITORY}


### PR DESCRIPTION
### Changes

#### Fix paths in .octocov.yml
- Fix code coverage store directory when running via Makefile.
- `RuntimeInternals` were not counted in the "Code to Test Ratio" setting.

#### Mod run tests as embedded package on CI
In Linux editor, there is a problem that assets in local packages cannot be found with `AssetDatabase.FindAssets`. Refs: #66 
As a workaround, I have made it into an embedded package.