### PR TITLE
Add UnityVersionAttribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,40 @@ public class MyTestClass
 ```
 
 
+#### UnityVersion
+
+`UnityVersionAttribute` is an NUnit test attribute class to skip test run if Unity version is older and/or newer than specified.
+
+This attribute can attached to test method, test class (`TestFixture`) and test assembly.
+Can be used with sync Test, async Test, and UnityTest.
+
+Usage:
+
+```csharp
+using System;
+using NUnit.Framework;
+using TestHelper.Attributes;
+
+[TestFixture]
+public class MyTestClass
+{
+    [Test]
+    [UnityVersion(newerThanOrEqual: "2022")]
+    public void MyTestMethod()
+    {
+        // Test run only for Unity 2022.1.0f1 or later.
+    }
+
+    [Test]
+    [UnityVersion(olderThan: "2019.4.0f1")]
+    public void MyTestMethod()
+    {
+        // Test run only for Unity older than 2019.4.0f1.
+    }
+}
+```
+
+
 #### CreateScene
 
 `CreateSceneAttribute` is an NUnit test attribute class to create new scene before running test.

--- a/Runtime/Attributes/UnityVersionAttribute.cs
+++ b/Runtime/Attributes/UnityVersionAttribute.cs
@@ -1,0 +1,67 @@
+// Copyright (c) 2023-2024 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using UnityEngine;
+
+namespace TestHelper.Attributes
+{
+    /// <summary>
+    /// Skip this test run if Unity version is older and/or newer than specified.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method)]
+    public class UnityVersionAttribute : NUnitAttribute, IApplyToTest
+    {
+        private readonly string _newerThanOrEqual;
+        private readonly string _olderThan;
+
+        /// <summary>
+        /// Skip this test run if Unity version is older and/or newer than specified.
+        /// </summary>
+        /// <param name="newerThanOrEqual">This test will run if the Unity editor version is newer than or equal the specified version.</param>
+        /// <param name="olderThan">This test will run if the Unity editor version is older than the specified version.</param>
+        public UnityVersionAttribute(string newerThanOrEqual = null, string olderThan = null)
+        {
+            _newerThanOrEqual = newerThanOrEqual;
+            _olderThan = olderThan;
+        }
+
+        public void ApplyToTest(Test test)
+        {
+            if (IsSkip(Application.unityVersion))
+            {
+                test.RunState = RunState.Ignored;
+                test.Properties.Set("_SKIPREASON", "Unity editor version is out of range.");
+            }
+        }
+
+        internal bool IsSkip(string unityVersion)
+        {
+            if (!string.IsNullOrEmpty(_newerThanOrEqual) && !IsNewerThanEqual(unityVersion, _newerThanOrEqual))
+            {
+                return true;
+            }
+
+            if (!string.IsNullOrEmpty(_olderThan) && !IsOlderThan(unityVersion, _olderThan))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsNewerThanEqual(string unityVersion, string newerThanEqual)
+        {
+            return string.Compare(unityVersion, newerThanEqual, StringComparison.Ordinal) >= 0;
+        }
+
+        private static bool IsOlderThan(string unityVersion, string olderThan)
+        {
+            var digits = olderThan.Length; // Evaluate only up to olderThan`s digits
+            return string.Compare(unityVersion.Substring(0, digits), olderThan, StringComparison.Ordinal) <= 0;
+        }
+    }
+}

--- a/Runtime/Attributes/UnityVersionAttribute.cs
+++ b/Runtime/Attributes/UnityVersionAttribute.cs
@@ -20,6 +20,7 @@ namespace TestHelper.Attributes
 
         /// <summary>
         /// Skip this test run if Unity version is older and/or newer than specified.
+        /// Valid format, e.g., "2023.2.16f1", "2023.2", and "2023".
         /// </summary>
         /// <param name="newerThanOrEqual">This test will run if the Unity editor version is newer than or equal the specified version.</param>
         /// <param name="olderThan">This test will run if the Unity editor version is older than the specified version.</param>

--- a/Runtime/Attributes/UnityVersionAttribute.cs.meta
+++ b/Runtime/Attributes/UnityVersionAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9325ece4a20de4833a33cd5a23388739

--- a/Tests/Runtime/Attributes/UnityVersionAttributeTest.cs
+++ b/Tests/Runtime/Attributes/UnityVersionAttributeTest.cs
@@ -1,0 +1,71 @@
+// Copyright (c) 2023-2024 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using NUnit.Framework;
+
+namespace TestHelper.Attributes
+{
+    [TestFixture]
+    public class UnityVersionAttributeTest
+    {
+        private const string UnityVersion = "2023.2.16f1";
+
+        [TestCase("2023.2.16f1")] // equal version is not skip
+        [TestCase("2023.2.15f1")]
+        [TestCase("2023.2")]
+        [TestCase("2023")]
+        [TestCase("2022")]
+        public void IsSkip_newerThanOrEqual_NotSkip(string newerThanOrEqual)
+        {
+            var sut = new UnityVersionAttribute(newerThanOrEqual);
+            var actual = sut.IsSkip(UnityVersion);
+            Assert.That(actual, Is.False);
+        }
+
+        [TestCase("2023.2.17f1")]
+        [TestCase("2023.3")]
+        [TestCase("6000")]
+        public void IsSkip_newerThanOrEqual_Skip(string newerThanOrEqual)
+        {
+            var sut = new UnityVersionAttribute(newerThanOrEqual);
+            var actual = sut.IsSkip(UnityVersion);
+            Assert.That(actual, Is.True);
+        }
+
+        [TestCase("2023.2.17f1")]
+        [TestCase("2023.2.16f1")] // equal version is not skip
+        [TestCase("2023.2")]
+        [TestCase("2023")]
+        [TestCase("6000")]
+        public void IsSkip_olderThan_NotSkip(string olderThan)
+        {
+            var sut = new UnityVersionAttribute(olderThan: olderThan);
+            var actual = sut.IsSkip(UnityVersion);
+            Assert.That(actual, Is.False);
+        }
+
+        [TestCase("2023.2.15f1")]
+        [TestCase("2023.1")]
+        [TestCase("2022")]
+        [TestCase("2021")]
+        public void IsSkip_olderThan_Skip(string olderThan)
+        {
+            var sut = new UnityVersionAttribute(olderThan: olderThan);
+            var actual = sut.IsSkip(UnityVersion);
+            Assert.That(actual, Is.True);
+        }
+
+        [Test]
+        [UnityVersion("2019")]
+        public void Attach_newerThanOrEqual2019_NotSkip()
+        {
+        }
+
+        [Test]
+        [UnityVersion(olderThan: "2019.4.0f1")]
+        public void Attach_olderThan2019_4_0f1_Skip()
+        {
+            Assert.Fail("This test should be skipped.");
+        }
+    }
+}

--- a/Tests/Runtime/Attributes/UnityVersionAttributeTest.cs.meta
+++ b/Tests/Runtime/Attributes/UnityVersionAttributeTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5449d92c641e94db6b53f921865b9975


### PR DESCRIPTION
`UnityVersionAttribute` is an NUnit test attribute class to skip test run if Unity version is older and/or newer than specified.

Usage:

```csharp
using System;
using NUnit.Framework;
using TestHelper.Attributes;

[TestFixture]
public class MyTestClass
{
    [Test]
    [UnityVersion(newerThanOrEqual: "2022")]
    public void MyTestMethod()
    {
        // Test run only for Unity 2022.1.0f1 or later.
    }

    [Test]
    [UnityVersion(olderThan: "2019.4.0f1")]
    public void MyTestMethod()
    {
        // Test run only for Unity older than 2019.4.0f1.
    }
}
```