### PR TITLE
Pin test-framework version to v1.4.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm install -g openupm-cli
-          openupm add -f com.unity.test-framework
+          openupm add -f com.unity.test-framework@1.4.4
           openupm add -f com.unity.testtools.codecoverage
           openupm add -f com.cysharp.unitask
         working-directory: ${{ env.CREATED_PROJECT_PATH }}

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ create_project:
 	  -batchmode \
 	  -quit
 	touch UnityProject~/Assets/.gitkeep
-	openupm -c $(PROJECT_HOME) add -f com.unity.test-framework
+	openupm -c $(PROJECT_HOME) add -f com.unity.test-framework@1.4.4
 	openupm -c $(PROJECT_HOME) add -f com.unity.testtools.codecoverage
 	openupm -c $(PROJECT_HOME) add -f com.cysharp.unitask
 	openupm -c $(PROJECT_HOME) add -ft $(PACKAGE_NAME)@file:../../


### PR DESCRIPTION
Reason:
- If not specified, v2 (preview version) is used
- Fail a few tests on test-framework v1.4.5; see #93