### PR TITLE
Fix for Unity 2019

### DIFF
--- a/RuntimeInternals/SceneManagerHelper.cs
+++ b/RuntimeInternals/SceneManagerHelper.cs
@@ -124,8 +124,8 @@ namespace TestHelper.RuntimeInternals
             Debug.LogError($"Can not resolve absolute path. relative: {relativePath}, caller: {callerFilePath}");
             return null;
             // Note: Do not use Exception (and Assert). Because freezes async tests on UTF v1.3.4, See UUM-25085.
-            
-            static string ConvertToUnixPathSeparator(string path)
+
+            string ConvertToUnixPathSeparator(string path)
             {
                 return path.Replace('\\', '/'); // Normalize path separator
             }


### PR DESCRIPTION
Remove `static` from local function (required C#8.0)

refs #91