### PR TITLE
Support test-framework v1.4.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm install -g openupm-cli
-          openupm add -f com.unity.test-framework@1.4.4
+          openupm add -f com.unity.test-framework@1.4.5
           openupm add -f com.unity.testtools.codecoverage
           openupm add -f com.cysharp.unitask
         working-directory: ${{ env.CREATED_PROJECT_PATH }}

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ create_project:
 	  -batchmode \
 	  -quit
 	touch UnityProject~/Assets/.gitkeep
-	openupm -c $(PROJECT_HOME) add -f com.unity.test-framework@1.4.4
+	openupm -c $(PROJECT_HOME) add -f com.unity.test-framework@1.4.5
 	openupm -c $(PROJECT_HOME) add -f com.unity.testtools.codecoverage
 	openupm -c $(PROJECT_HOME) add -f com.cysharp.unitask
 	openupm -c $(PROJECT_HOME) add -ft $(PACKAGE_NAME)@file:../../

--- a/Tests/Runtime/Attributes/GizmosShowOnGameViewAttributeTest.cs
+++ b/Tests/Runtime/Attributes/GizmosShowOnGameViewAttributeTest.cs
@@ -62,6 +62,8 @@ namespace TestHelper.Attributes
             await Task.Yield();
         }
 
+        [IgnoreBatchMode(
+            "The following error occurred since UTF v1.4.5: UnityTest yielded WaitForEndOfFrame, which is not evoked in batchmode.")]
         [UnityTest]
         [CreateScene(camera: true, light: true)]
         [GizmosShowOnGameView]

--- a/Tests/Runtime/Attributes/TakeScreenshotAttributeTest.cs
+++ b/Tests/Runtime/Attributes/TakeScreenshotAttributeTest.cs
@@ -88,6 +88,8 @@ namespace TestHelper.Attributes
             Assert.That(new FileInfo(path), Has.Length.GreaterThan(FileSizeThreshold));
         }
 
+        [IgnoreBatchMode(
+            "The following error occurred since UTF v1.4.5: UnityTest yielded WaitForEndOfFrame, which is not evoked in batchmode.")]
         [UnityTest, Order(0)]
         [LoadScene(TestScene)]
         [TakeScreenshot]
@@ -107,6 +109,8 @@ namespace TestHelper.Attributes
             // Take screenshot after running the test.
         }
 
+        [IgnoreBatchMode(
+            "The following error occurred since UTF v1.4.5: UnityTest yielded WaitForEndOfFrame, which is not evoked in batchmode.")]
         [Test, Order(1)]
         public void AttachToUnityTest_SaveScreenshotToDefaultPath_ExistFile()
         {


### PR DESCRIPTION
- Bump test-framework version to v1.4.5 for running tests
- Ignore two test cases that use WaitForEndOfFrame run tests on batchmode

fixed #93 