### PR TITLE
Add XDocumentComparer and XmlComparer

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ public class MyTestClass
 
 #### GameObjectNameComparer
 
-`GameObjectNameComparer` is an NUnit test comparer class to compare GameObjects by name.
+`GameObjectNameComparer` is a NUnit test comparer class that compares `GameObjects` by name.
 
 Usage:
 
@@ -422,6 +422,77 @@ public class GameObjectNameComparerTest
     {
         var actual = GameObject.FindObjectsOfType<GameObject>();
         Assert.That(actual, Does.Contain(new GameObject("test")).Using(new GameObjectNameComparer()));
+    }
+}
+```
+
+
+#### XDocumentComparer
+
+`XDocumentComparer` is a NUnit test comparer class that loosely compares `XDocument`.
+
+It only compares the attributes and values of each element in the document unordered.
+XML declarations and comments are ignored.
+
+Usage:
+
+```csharp
+using System.Xml.Linq;
+using NUnit.Framework;
+using TestHelper.Comparers;
+
+[TestFixture]
+public class XDocumentComparerTest
+{
+    [Test]
+    public void UsingWithEqualTo_Compare()
+    {
+        var x = XDocument.Parse(@"<root><child>value1</child><child attribute=""attr"">value2</child></root>");
+        var y = XDocument.Parse(@"<?xml version=""1.0"" encoding=""utf-8""?>
+<root><!-- comment --><child attribute=""attr"">value2</child><!-- comment --><child>value1</child></root>");
+        // with XML declaration, comments, and different order
+
+        Assert.That(x, Is.EqualTo(y).Using(new XDocumentComparer()));
+    }
+}
+```
+
+
+#### XmlComparer
+
+`XmlComparer` is a NUnit test comparer class that loosely compares `string` as XML documents.
+
+It only compares the attributes and values of each element in the document unordered.
+XML declarations and comments are ignored, and white spaces, tabs, and newlines before and after the value are ignored.
+
+Usage:
+
+```csharp
+using System.Xml.Linq;
+using NUnit.Framework;
+using TestHelper.Comparers;
+
+[TestFixture]
+public class XDocumentComparerTest
+{
+    [Test]
+    public void UsingWithEqualTo_Compare()
+    {
+        var x = @"<root><child>value1</child><child attribute=""attr"">value2</child></root>";
+        var y = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<root>
+  <!-- comment -->
+  <child attribute=""attr"">
+    value2
+  </child>
+  <!-- comment -->
+  <child>
+    value1
+  </child>
+</root>";
+        // with new-line, white-space, XML declaration, comments, and different order
+
+        Assert.That(x, Is.EqualTo(y).Using(new XmlComparer()));
     }
 }
 ```

--- a/Runtime/Comparers/XDocumentComparer.cs
+++ b/Runtime/Comparers/XDocumentComparer.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
@@ -189,7 +188,7 @@ namespace TestHelper.Comparers
         /// <summary>
         /// Compare two attribute collections.
         /// </summary>
-        private static int Compare([NotNull] IEnumerable<XAttribute> x, [NotNull] IEnumerable<XAttribute> y)
+        private static int Compare(IEnumerable<XAttribute> x, IEnumerable<XAttribute> y)
         {
             var comparisonList = y.ToList();
 
@@ -220,7 +219,7 @@ namespace TestHelper.Comparers
         /// <summary>
         /// Compare two strings.
         /// </summary>
-        private static int Compare([NotNull] string x, [NotNull] string y)
+        private static int Compare(string x, string y)
         {
             return string.Compare(x.Trim(), y.Trim(), StringComparison.CurrentCulture);
         }

--- a/Runtime/Comparers/XDocumentComparer.cs
+++ b/Runtime/Comparers/XDocumentComparer.cs
@@ -112,8 +112,7 @@ namespace TestHelper.Comparers
         private static XElement FindElementAndRemove(XElement target, ref Dictionary<string, List<XElement>> dictionary)
         {
             var xPath = GetXPath(target);
-            var elements = dictionary.GetValueOrDefault(xPath);
-            if (elements == null)
+            if (!dictionary.TryGetValue(xPath, out var elements))
             {
                 return null;
             }

--- a/Runtime/Comparers/XDocumentComparer.cs
+++ b/Runtime/Comparers/XDocumentComparer.cs
@@ -1,0 +1,228 @@
+// Copyright (c) 2023-2024 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace TestHelper.Comparers
+{
+    /// <summary>
+    /// Compare XML documents.
+    ///
+    /// It only compares the attributes and values of each element in the document unordered.
+    /// XML declarations and comments are ignored.
+    /// </summary>
+    public class XDocumentComparer : IComparer<XDocument>
+    {
+        /// <inheritdoc/>
+        public int Compare(XDocument x, XDocument y)
+        {
+            if (x == null && y == null)
+            {
+                return 0;
+            }
+
+            if (x == null)
+            {
+                return -1;
+            }
+
+            if (y == null)
+            {
+                return 1;
+            }
+
+            // Note: Declaration is not compared.
+
+            var comparisonDictionary = CreateComparisonDictionary(y.Root);
+            // Note: key is XPath, value is List<XElement>. Any nodes found are deleted one by one.
+
+            var current = x.Root;
+            while (current != null)
+            {
+                // Find same element in y.
+                var foundElement = FindElementAndRemove(current, ref comparisonDictionary);
+                if (foundElement == null)
+                {
+                    return -1; // The element exists only in x.
+                }
+
+                current = GetChildOrNextElement(current);
+            }
+
+            if (comparisonDictionary.Any())
+            {
+                return 1; // The element exists only in y.
+            }
+
+            return 0;
+        }
+
+        internal static Dictionary<string, List<XElement>> CreateComparisonDictionary(XElement root)
+        {
+            var comparisonDictionary = new Dictionary<string, List<XElement>>();
+            var current = root;
+            while (current != null)
+            {
+                var xPath = GetXPath(current);
+                if (comparisonDictionary.TryGetValue(xPath, out var elements))
+                {
+                    elements.Add(current);
+                }
+                else
+                {
+                    comparisonDictionary.Add(xPath, new List<XElement> { current });
+                }
+
+                current = GetChildOrNextElement(current);
+            }
+
+            return comparisonDictionary;
+        }
+
+        private static XElement GetChildOrNextElement(XElement element)
+        {
+            if (element.HasElements)
+            {
+                return element.Elements().First();
+            }
+
+            var nextNode = element.NextNode;
+            while (nextNode != null)
+            {
+                if (nextNode.NodeType == XmlNodeType.Element)
+                {
+                    return nextNode as XElement;
+                }
+
+                nextNode = nextNode.NextNode;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Find element in comparison dictionary.
+        /// The entries found are removed from the dictionary.
+        /// </summary>
+        /// <returns>XElement if found, Null if not found.</returns>
+        private static XElement FindElementAndRemove(XElement target, ref Dictionary<string, List<XElement>> dictionary)
+        {
+            var xPath = GetXPath(target);
+            var elements = dictionary.GetValueOrDefault(xPath);
+            if (elements == null)
+            {
+                return null;
+            }
+
+            foreach (var element in elements)
+            {
+                var compare = Compare(target, element);
+                if (compare != 0)
+                {
+                    continue;
+                }
+
+                elements.Remove(element);
+                if (elements.Count == 0)
+                {
+                    dictionary.Remove(xPath);
+                }
+
+                return element;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Compare two elements not recursively.
+        /// Do not check child elements.
+        /// </summary>
+        private static int Compare(XElement x, XElement y)
+        {
+            if (GetXPath(x) != GetXPath(y))
+            {
+                return -1;
+            }
+
+            if (x.HasAttributes != y.HasAttributes)
+            {
+                return -1;
+            }
+
+            if (x.HasAttributes && y.HasAttributes)
+            {
+                var compareAttributes = Compare(x.Attributes(), y.Attributes());
+                if (compareAttributes != 0)
+                {
+                    return compareAttributes;
+                }
+            }
+
+            if (x.HasElements && y.HasElements)
+            {
+                return 0;
+            }
+
+            return Compare(x.Value, y.Value);
+        }
+
+        private static string GetXPath(XElement element)
+        {
+            var path = new List<string>();
+            var current = element;
+            while (current != null)
+            {
+                path.Add(current.Name.LocalName);
+                current = current.Parent;
+            }
+
+            path.Reverse();
+            return string.Join("/", path);
+        }
+
+        /// <summary>
+        /// Compare two attribute collections.
+        /// </summary>
+        private static int Compare([NotNull] IEnumerable<XAttribute> x, [NotNull] IEnumerable<XAttribute> y)
+        {
+            var comparisonList = y.ToList();
+
+            foreach (var xAttribute in x)
+            {
+                var yAttribute = comparisonList.FirstOrDefault(attribute => attribute.Name == xAttribute.Name);
+                if (yAttribute == null)
+                {
+                    return -1;
+                }
+
+                if (xAttribute.Value != yAttribute.Value)
+                {
+                    return -1;
+                }
+
+                comparisonList.Remove(yAttribute);
+            }
+
+            if (comparisonList.Any())
+            {
+                return 1;
+            }
+
+            return 0;
+        }
+
+        /// <summary>
+        /// Compare two strings.
+        /// </summary>
+        private static int Compare([NotNull] string x, [NotNull] string y)
+        {
+            return string.Compare(x.Trim(), y.Trim(), StringComparison.CurrentCulture);
+        }
+    }
+}

--- a/Runtime/Comparers/XDocumentComparer.cs.meta
+++ b/Runtime/Comparers/XDocumentComparer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: edee55b1b6a34a66be5ab3d42efdf772
+timeCreated: 1729988823

--- a/Runtime/Comparers/XmlComparer.cs
+++ b/Runtime/Comparers/XmlComparer.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2023-2024 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace TestHelper.Comparers
+{
+    /// <summary>
+    /// Compare strings as an XML document.
+    ///
+    /// It only compares the attributes and values of each element in the document unordered.
+    /// XML declarations and comments are ignored, and white spaces, tabs, and newlines before and after the value are ignored.
+    /// </summary>
+    /// <remarks>
+    /// Internal using <see cref="XDocumentComparer"/>  for comparing <see cref="XDocument"/>.
+    /// </remarks>
+    public class XmlComparer : IComparer<string>
+    {
+        /// <inheritdoc/>
+        public int Compare(string x, string y)
+        {
+            if (x == null && y == null)
+            {
+                return 0;
+            }
+
+            if (x == null)
+            {
+                return -1;
+            }
+
+            if (y == null)
+            {
+                return 1;
+            }
+
+            return new XDocumentComparer().Compare(XDocument.Parse(x), XDocument.Parse(y));
+        }
+    }
+}

--- a/Runtime/Comparers/XmlComparer.cs.meta
+++ b/Runtime/Comparers/XmlComparer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: febadb5599cd4ea89849957011a3749e
+timeCreated: 1729802353

--- a/Tests/Runtime/Comparers/XDocumentComparerTest.cs
+++ b/Tests/Runtime/Comparers/XDocumentComparerTest.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2023-2024 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Xml.Linq;
+using NUnit.Framework;
+
+namespace TestHelper.Comparers
+{
+    /// <summary>
+    /// Test only using constraint with <c>Using</c> modifier in this class.
+    /// Other test cases are implemented in <see cref="XmlComparerTest"/>.
+    /// </summary>
+    [TestFixture]
+    public class XDocumentComparerTest
+    {
+        [Test]
+        public void UsingWithEqualTo_Compare()
+        {
+            var x = XDocument.Parse(@"<root><child>value1</child><child attribute=""attr"">value2</child></root>");
+            var y = XDocument.Parse(@"<?xml version=""1.0"" encoding=""utf-8""?>
+<root><!-- comment --><child attribute=""attr"">value2</child><!-- comment --><child>value1</child></root>");
+            // with XML declaration, comments, and different order
+
+            Assert.That(x, Is.EqualTo(y).Using(new XDocumentComparer()));
+        }
+
+        [Test]
+        public void CreateComparisonDictionary()
+        {
+            const string Xml = @"<root><child/><child/><child><grandchild/></child></root>";
+
+            var sut = XDocument.Parse(Xml);
+            var actual = XDocumentComparer.CreateComparisonDictionary(sut.Root);
+
+            Assert.That(actual, Is.Not.Null);
+            Assert.That(actual.Count, Is.EqualTo(3));
+            Assert.That(actual.ContainsKey("root"), Is.True);
+            Assert.That(actual.ContainsKey("root/child"), Is.True);
+            Assert.That(actual.ContainsKey("root/child/grandchild"), Is.True);
+            Assert.That(actual["root/child"].Count, Is.EqualTo(3));
+            Assert.That(actual["root/child/grandchild"].Count, Is.EqualTo(1));
+        }
+    }
+}

--- a/Tests/Runtime/Comparers/XDocumentComparerTest.cs.meta
+++ b/Tests/Runtime/Comparers/XDocumentComparerTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 385a787076854948838451e7a4ae8590
+timeCreated: 1729988832

--- a/Tests/Runtime/Comparers/XmlComparerTest.cs
+++ b/Tests/Runtime/Comparers/XmlComparerTest.cs
@@ -1,0 +1,104 @@
+// Copyright (c) 2023-2024 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace TestHelper.Comparers
+{
+    [TestFixture]
+    public class XmlComparerTest
+    {
+        private const string BaseXml = @"<root><child>value1</child><child attribute=""attr"">value2</child></root>";
+
+        private static IEnumerable<TestCaseData> s_TestCaseSource()
+        {
+            // Equal: Same
+            yield return new TestCaseData(BaseXml, BaseXml, 0);
+
+            // Equal: Same
+            yield return new TestCaseData(null, null, 0);
+
+            // Missing attribute in the left: Different
+            yield return new TestCaseData(BaseXml,
+                @"<root><child>value1</child><child>value2</child></root>", -1);
+
+            // Different attribute value: Different
+            yield return new TestCaseData(BaseXml,
+                @"<root><child>value1</child><child attribute=""bad attr"">value2</child></root>", -1);
+
+            // Different value: Different
+            yield return new TestCaseData(BaseXml,
+                @"<root><child>bad value</child><child attribute=""attr"">value2</child></root>", -1);
+        }
+
+        private static IEnumerable<TestCaseData> s_TestCaseSourceReversible()
+        {
+            // Different order: Same
+            yield return new TestCaseData(BaseXml,
+                @"<root><child attribute=""attr"">value2</child><child>value1</child></root>", 0);
+
+            // Different comments: Same
+            yield return new TestCaseData(BaseXml,
+                @"<root><!-- comment --><child>value1</child><child attribute=""attr"">value2</child></root>", 0);
+
+            // Different XML declaration: Same
+            yield return new TestCaseData(BaseXml,
+                @"<?xml version=""1.0"" encoding=""utf-8""?>
+<root><child>value1</child><child attribute=""attr"">value2</child></root>", 0);
+
+            // Different white space: Same
+            yield return new TestCaseData(BaseXml, @"<root>
+<child>
+    value1
+</child>
+<child
+        attribute=""attr"">
+    value2
+</child></root>", 0);
+
+            // One side is null: Different
+            yield return new TestCaseData(BaseXml, null, 1);
+
+            // Missing element in the left: Different
+            yield return new TestCaseData(BaseXml,
+                @"<root><child>value1</child></root>", -1);
+        }
+
+        private static IEnumerable<TestCaseData> s_TestCaseSourceReverse()
+        {
+            return s_TestCaseSourceReversible().Select(x =>
+                new TestCaseData(x.Arguments[1], x.Arguments[0], -1 * (int)x.Arguments[2]));
+        }
+
+        [TestCaseSource(nameof(s_TestCaseSource))]
+        [TestCaseSource(nameof(s_TestCaseSourceReversible))]
+        [TestCaseSource(nameof(s_TestCaseSourceReverse))]
+        public void Compare_CompareAsXml(string x, string y, int expected)
+        {
+            var actual = new XmlComparer().Compare(x, y);
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void UsingWithEqualTo_CompareAsXml()
+        {
+            const string XmlString = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<root>
+    <!-- comment -->
+    <child
+            attribute=""attr"">
+        value2
+    </child>
+    <!-- comment -->
+    <child>
+        value1
+    </child>
+</root>";
+            // with new-line, white-space, XML declaration, comments, and different order
+
+            Assert.That(XmlString, Is.EqualTo(BaseXml).Using(new XmlComparer()));
+        }
+    }
+}

--- a/Tests/Runtime/Comparers/XmlComparerTest.cs
+++ b/Tests/Runtime/Comparers/XmlComparerTest.cs
@@ -10,7 +10,8 @@ namespace TestHelper.Comparers
     [TestFixture]
     public class XmlComparerTest
     {
-        private const string BaseXml = @"<root><child>value1</child><child attribute=""attr"">value2</child></root>";
+        private const string BaseXml =
+            @"<root><child>value1</child><child attribute=""attr"" attribute2=""attr2"">value2</child></root>";
 
         private static IEnumerable<TestCaseData> s_TestCaseSource()
         {
@@ -22,31 +23,42 @@ namespace TestHelper.Comparers
 
             // Missing attribute in the left: Different
             yield return new TestCaseData(BaseXml,
+                @"<root><child>value1</child><child attribute2=""attr2"">value2</child></root>", -1);
+
+            // Missing attributes in the left: Different
+            yield return new TestCaseData(BaseXml,
                 @"<root><child>value1</child><child>value2</child></root>", -1);
 
             // Different attribute value: Different
             yield return new TestCaseData(BaseXml,
-                @"<root><child>value1</child><child attribute=""bad attr"">value2</child></root>", -1);
+                @"<root><child>value1</child><child attribute=""bad attr"" attribute2=""attr2"">value2</child></root>",
+                -1);
 
             // Different value: Different
             yield return new TestCaseData(BaseXml,
-                @"<root><child>bad value</child><child attribute=""attr"">value2</child></root>", -1);
+                @"<root><child>bad value</child><child attribute=""attr"" attribute2=""attr2"">value2</child></root>",
+                -1);
         }
 
         private static IEnumerable<TestCaseData> s_TestCaseSourceReversible()
         {
-            // Different order: Same
+            // Different element order: Same
             yield return new TestCaseData(BaseXml,
-                @"<root><child attribute=""attr"">value2</child><child>value1</child></root>", 0);
+                @"<root><child attribute=""attr"" attribute2=""attr2"">value2</child><child>value1</child></root>", 0);
+
+            // Different attribute order: Same
+            yield return new TestCaseData(BaseXml,
+                @"<root><child>value1</child><child attribute2=""attr2"" attribute=""attr"">value2</child></root>", 0);
 
             // Different comments: Same
             yield return new TestCaseData(BaseXml,
-                @"<root><!-- comment --><child>value1</child><child attribute=""attr"">value2</child></root>", 0);
+                @"<root><!-- comment --><child>value1</child><child attribute=""attr"" attribute2=""attr2"">value2</child></root>",
+                0);
 
             // Different XML declaration: Same
             yield return new TestCaseData(BaseXml,
                 @"<?xml version=""1.0"" encoding=""utf-8""?>
-<root><child>value1</child><child attribute=""attr"">value2</child></root>", 0);
+<root><child>value1</child><child attribute=""attr"" attribute2=""attr2"">value2</child></root>", 0);
 
             // Different white space: Same
             yield return new TestCaseData(BaseXml, @"<root>
@@ -54,7 +66,8 @@ namespace TestHelper.Comparers
     value1
 </child>
 <child
-        attribute=""attr"">
+        attribute=""attr""
+        attribute2=""attr2"">
     value2
 </child></root>", 0);
 
@@ -88,6 +101,7 @@ namespace TestHelper.Comparers
 <root>
     <!-- comment -->
     <child
+            attribute2=""attr2""
             attribute=""attr"">
         value2
     </child>

--- a/Tests/Runtime/Comparers/XmlComparerTest.cs.meta
+++ b/Tests/Runtime/Comparers/XmlComparerTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 95bea3766b4840f98839f409a6774f32
+timeCreated: 1729803097


### PR DESCRIPTION
Add two NUnit test comparer implementations.

#### XDocumentComparer

`XDocumentComparer` is a NUnit test comparer class that loosely compares `XDocument`.

It only compares the attributes and values of each element in the document unordered.
XML declarations and comments are ignored.

#### XmlComparer

`XmlComparer` is a NUnit test comparer class that loosely compares `string` as XML documents.

It only compares the attributes and values of each element in the document unordered.
XML declarations and comments are ignored, and white spaces, tabs, and newlines before and after the value are ignored.
