### PR TITLE
Fix to use Application.temporaryCachePath in tests if possible

### DIFF
--- a/Editor/OpenPersistentDataPathMenu.cs
+++ b/Editor/OpenPersistentDataPathMenu.cs
@@ -12,7 +12,7 @@ namespace TestHelper.Editor
     /// </summary>
     public static class OpenPersistentDataPathMenu
     {
-        [MenuItem("Window/Open Persistent Data Directory")]
+        [MenuItem("Window/Test Helper/Open Persistent Data Directory")]
         private static void OpenPersistentDataPathMenuItem()
         {
             EditorUtility.RevealInFinder(Application.persistentDataPath);

--- a/Editor/OpenTemporaryCachePathMenu.cs
+++ b/Editor/OpenTemporaryCachePathMenu.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2023-2024 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using UnityEditor;
+using UnityEngine;
+
+namespace TestHelper.Editor
+{
+    /// <summary>
+    /// Open temporary cache directory in the Finder.
+    /// <see href="https://docs.unity3d.com/ScriptReference/Application-temporaryCachePath.html">Application.temporaryCachePath</see>
+    /// </summary>
+    public static class OpenTemporaryCachePathMenu
+    {
+        [MenuItem("Window/Test Helper/Open Temporary Cache Directory")]
+        private static void OpenTemporaryCachePathMenuItem()
+        {
+            EditorUtility.RevealInFinder(Application.temporaryCachePath);
+        }
+    }
+}

--- a/Editor/OpenTemporaryCachePathMenu.cs.meta
+++ b/Editor/OpenTemporaryCachePathMenu.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c3acfa04883346dfbc73c899b2985e12
+timeCreated: 1732470013

--- a/Tests/Editor/JUnitXml/JUnitXmlWriterTest.cs
+++ b/Tests/Editor/JUnitXml/JUnitXmlWriterTest.cs
@@ -5,6 +5,7 @@ using System.IO;
 using NUnit.Framework;
 using TestHelper.Comparers;
 using TestHelper.Editor.TestDoubles;
+using UnityEngine;
 
 namespace TestHelper.Editor.JUnitXml
 {
@@ -12,20 +13,21 @@ namespace TestHelper.Editor.JUnitXml
     public class JUnitXmlWriterTest
     {
         private const string TestResourcesPath = "Packages/com.nowsprinting.test-helper/Tests/Editor/TestResources";
-        private const string TestOutputDirectoryPath = "Logs/TestHelper/JUnitXmlWriterTest";
-        // Note: relative path from the project root directory.
+
+        private readonly string _testOutputDirectoryPath =
+            Path.Combine(Application.temporaryCachePath, TestContext.CurrentContext.Test.ClassName);
 
         [Test, Order(0)]
         public void WriteTo_CreatedJUnitXmlFormatFile()
         {
-            if (Directory.Exists(TestOutputDirectoryPath))
+            if (Directory.Exists(_testOutputDirectoryPath))
             {
-                Directory.Delete(TestOutputDirectoryPath, true);
+                Directory.Delete(_testOutputDirectoryPath, true);
             }
 
             var nunitXmlPath = Path.Combine(TestResourcesPath, "nunit3.xml");
             var result = new FakeTestResultAdaptor(nunitXmlPath);
-            var path = Path.Combine(TestOutputDirectoryPath, TestContext.CurrentContext.Test.Name + ".xml");
+            var path = Path.Combine(_testOutputDirectoryPath, TestContext.CurrentContext.Test.Name + ".xml");
             JUnitXmlWriter.WriteTo(result, path);
 
             Assume.That(path, Does.Exist);
@@ -40,7 +42,7 @@ namespace TestHelper.Editor.JUnitXml
         {
             var nunitXmlPath = Path.Combine(TestResourcesPath, "nunit3.xml");
             var result = new FakeTestResultAdaptor(nunitXmlPath);
-            var path = Path.Combine(TestOutputDirectoryPath, TestContext.CurrentContext.Test.Name + ".xml");
+            var path = Path.Combine(_testOutputDirectoryPath, TestContext.CurrentContext.Test.Name + ".xml");
 
             // Destroy the output destination file.
             File.Copy(nunitXmlPath, path, true);


### PR DESCRIPTION
### Changes

- Fix to use `Application.temporaryCachePath` in tests if possible
- Add open `Application.temporaryCachePath` menu item