### PR TITLE
Fix scene unload error on AfterTest in CreatedSceneAttribute

### DIFF
--- a/Runtime/Attributes/CreateSceneAttribute.cs
+++ b/Runtime/Attributes/CreateSceneAttribute.cs
@@ -115,6 +115,11 @@ namespace TestHelper.Attributes
         /// <inheritdoc />
         public IEnumerator AfterTest(ITest test)
         {
+            if (!_newScene.isLoaded)
+            {
+                yield break;
+            }
+
             if (_beforeActiveScene.isLoaded)
             {
                 SceneManager.SetActiveScene(_beforeActiveScene);

--- a/Tests/Runtime/Attributes/CreateSceneAttributeTest.cs
+++ b/Tests/Runtime/Attributes/CreateSceneAttributeTest.cs
@@ -81,6 +81,18 @@ namespace TestHelper.Attributes
             yield return null;
         }
 
+        [UnityTest]
+        [CreateScene]
+        public IEnumerator UnloadCreatedSceneInTest_NoErrorInAfterTest()
+        {
+            var createdScene = SceneManager.GetActiveScene();
+
+            var newScene = SceneManager.CreateScene("New Scene");
+            SceneManager.SetActiveScene(newScene);
+
+            yield return SceneManager.UnloadSceneAsync(createdScene);
+        }
+
         [TestFixture]
         public class UnloadOthersOptionTest
         {


### PR DESCRIPTION
### Problem

Can not unload attribute-created-scene on `AfterTest` method in `CreatedSceneAttribute`.

```
AfterTest : System.ArgumentException : Scene to unload is invalid
```

### Condition

Unload attribute-created-scene in test.
e.g., LoadScene

### Fixes

Skip unload if attribute-created-scene was unloaded.

refs #113 