### PR TITLE
Fix to exclude the version specified in olderThan

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,14 +350,14 @@ public class MyTestClass
     [UnityVersion(newerThanOrEqual: "2022")]
     public void MyTestMethod()
     {
-        // Test run only for Unity 2022.1.0f1 or later.
+        // Test run only for Unity 2022.1.0f1 or newer (include specified version).
     }
 
     [Test]
     [UnityVersion(olderThan: "2019.4.0f1")]
     public void MyTestMethod()
     {
-        // Test run only for Unity older than 2019.4.0f1.
+        // Test run only for Unity older than 2019.4.0f1 (exclude specified version).
     }
 }
 ```

--- a/Runtime/Attributes/UnityVersionAttribute.cs
+++ b/Runtime/Attributes/UnityVersionAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Koji Hasegawa.
+// Copyright (c) 2023-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
@@ -62,7 +62,7 @@ namespace TestHelper.Attributes
         private static bool IsOlderThan(string unityVersion, string olderThan)
         {
             var digits = olderThan.Length; // Evaluate only up to olderThan`s digits
-            return string.Compare(unityVersion.Substring(0, digits), olderThan, StringComparison.Ordinal) <= 0;
+            return string.Compare(unityVersion.Substring(0, digits), olderThan, StringComparison.Ordinal) < 0;
         }
     }
 }

--- a/Tests/Runtime/Attributes/UnityVersionAttributeTest.cs
+++ b/Tests/Runtime/Attributes/UnityVersionAttributeTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Koji Hasegawa.
+// Copyright (c) 2023-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using NUnit.Framework;
@@ -10,7 +10,7 @@ namespace TestHelper.Attributes
     {
         private const string UnityVersion = "2023.2.16f1";
 
-        [TestCase("2023.2.16f1")] // equal version is not skip
+        [TestCase("2023.2.16f1")] // include equal version
         [TestCase("2023.2.15f1")]
         [TestCase("2023.2")]
         [TestCase("2023")]
@@ -33,9 +33,6 @@ namespace TestHelper.Attributes
         }
 
         [TestCase("2023.2.17f1")]
-        [TestCase("2023.2.16f1")] // equal version is not skip
-        [TestCase("2023.2")]
-        [TestCase("2023")]
         [TestCase("6000")]
         public void IsSkip_olderThan_NotSkip(string olderThan)
         {
@@ -44,13 +41,31 @@ namespace TestHelper.Attributes
             Assert.That(actual, Is.False);
         }
 
+        [TestCase("2023.2.16f1")] // exclude equal version
         [TestCase("2023.2.15f1")]
-        [TestCase("2023.1")]
-        [TestCase("2022")]
+        [TestCase("2023.2")]
+        [TestCase("2023")]
         [TestCase("2021")]
         public void IsSkip_olderThan_Skip(string olderThan)
         {
             var sut = new UnityVersionAttribute(olderThan: olderThan);
+            var actual = sut.IsSkip(UnityVersion);
+            Assert.That(actual, Is.True);
+        }
+
+        [TestCase("2023.2.16f1", "2023.2.17f1")]
+        public void IsSkip_Both_NotSkip(string newerThanOrEqual, string olderThan)
+        {
+            var sut = new UnityVersionAttribute(newerThanOrEqual, olderThan);
+            var actual = sut.IsSkip(UnityVersion);
+            Assert.That(actual, Is.False);
+        }
+
+        [TestCase("2023.2.16f1", "2023.2.16f1")]
+        [TestCase("2023.2.17f1", "2023.2.17f1")]
+        public void IsSkip_Both_Skip(string newerThanOrEqual, string olderThan)
+        {
+            var sut = new UnityVersionAttribute(newerThanOrEqual, olderThan);
             var actual = sut.IsSkip(UnityVersion);
             Assert.That(actual, Is.True);
         }


### PR DESCRIPTION
### Before

```cs
[Test]
[UnityVersion(olderThan: "2019.4.0f1")]
public void MyTestMethod()
{
  // Runs on Unity 2019.4.0f1 (include equal version)
}
```

### After

```cs
[Test]
[UnityVersion(olderThan: "2019.4.0f1")]
public void MyTestMethod()
{
  // Not runs on Unity 2019.4.0f1 (exclude equal version)
}
```
