### PR TITLE
Change retry method from attribute to command-line argument

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}  # Default is `auto`
           checkName: test result (${{ matrix.unityVersion }}, ${{ matrix.testMode }})
           projectPath: ${{ env.CREATED_PROJECT_PATH }}
-          customParameters: -testCategory "!IgnoreCI" -testHelperScreenshotDirectory /github/workspace/artifacts/Screenshots
+          customParameters: -testCategory "!IgnoreCI" -retry 5 -testHelperScreenshotDirectory /github/workspace/artifacts/Screenshots
           coverageOptions: generateAdditionalMetrics;generateTestReferences;generateHtmlReport;generateAdditionalReports;dontClear;assemblyFilters:${{ env.assembly_filters }}
           # see: https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/manual/CoverageBatchmode.html
           testMode: ${{ matrix.testMode }}

--- a/Tests/Runtime/Statistics/DescriptiveStatisticsTest.cs
+++ b/Tests/Runtime/Statistics/DescriptiveStatisticsTest.cs
@@ -206,7 +206,6 @@ Experimental and Statistical Summary:
         }
 
         [Test]
-        [Retry(2)]
         public void GetSummary_WithIntSampleSpace()
         {
             const int TrialCount = 1 << 20; // 1,048,576 times
@@ -218,6 +217,7 @@ Experimental and Statistical Summary:
 
             var statistics = new DescriptiveStatistics<int>();
             statistics.Calculate(sampleSpace);
+
             Debug.Log(statistics.GetSummary()); // Write to console
 
             Assert.That(statistics.PeakFrequency, Is.EqualTo(TrialCount / 6).Within(Tolerance));
@@ -227,7 +227,6 @@ Experimental and Statistical Summary:
         }
 
         [Test]
-        [Retry(2)]
         [SuppressMessage("ReSharper", "RedundantNameQualifier")]
         public void GetSummary_WithFloatSampleSpace()
         {
@@ -241,6 +240,7 @@ Experimental and Statistical Summary:
 
             var statistics = new DescriptiveStatistics<float>(0.0f, 1.0f, 0.1f);
             statistics.Calculate(sampleSpace);
+
             Debug.Log(statistics.GetSummary()); // Write to console
 
             Assert.That(statistics.PeakFrequency, Is.EqualTo(Expected).Within(Tolerance));
@@ -250,7 +250,6 @@ Experimental and Statistical Summary:
         }
 
         [Test]
-        [Retry(2)]
         public void GetSummary_WithStringSampleSpace()
         {
             var sampleSpace = Experiment.Run(
@@ -259,7 +258,8 @@ Experimental and Statistical Summary:
 
             var statistics = new DescriptiveStatistics<string>();
             statistics.Calculate(sampleSpace);
-            Debug.Log(statistics.GetSummary());
+
+            Debug.Log(statistics.GetSummary()); // Write to console
 
             Assert.That(statistics.PeakFrequency, Is.EqualTo(1));
             Assert.That(statistics.ValleyFrequency, Is.EqualTo(1));


### PR DESCRIPTION
### Before

Using `RetryAttribute`.

### After

Using `-retry` command-line argument (added in test-framework v1.3.5).