### PR TITLE
Add preset display resolution standards and commandline arguments

### DIFF
--- a/Editor/GameViewResolutionSwitcher.cs
+++ b/Editor/GameViewResolutionSwitcher.cs
@@ -1,0 +1,52 @@
+// Copyright (c) 2023-2025 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using TestHelper.Attributes;
+using TestHelper.RuntimeInternals;
+
+namespace TestHelper.Editor
+{
+    public static class GameViewResolutionSwitcher
+    {
+        public static void ParseArgumentsAndSwitchIfNeeded()
+        {
+            // Try by resolution name
+            var resolutionName = CommandLineArgs.GetGameViewResolutionName();
+            if (!string.IsNullOrEmpty(resolutionName))
+            {
+                resolutionName = resolutionName.ToLower();
+                foreach (GameViewResolution resolution in Enum.GetValues(typeof(GameViewResolution)))
+                {
+                    var (width, height, name) = resolution.GetParameter();
+                    if (name.ToLower() == resolutionName)
+                    {
+                        GameViewControlHelper.SetResolution(width, height, name);
+                        return;
+                    }
+                }
+            }
+
+            // Try by width and height
+            var (w, h) = CommandLineArgs.GetGameViewResolutionSize();
+            if (w > 0 && h > 0)
+            {
+                GameViewControlHelper.SetResolution(w, h, GetDefaultName(w, h));
+            }
+        }
+
+        private static string GetDefaultName(uint width, uint height)
+        {
+            foreach (GameViewResolution resolution in Enum.GetValues(typeof(GameViewResolution)))
+            {
+                var (w, h, name) = resolution.GetParameter();
+                if (w == width && h == height)
+                {
+                    return $"{name} ({width}x{height})";
+                }
+            }
+
+            return $"{width}x{height}";
+        }
+    }
+}

--- a/Editor/GameViewResolutionSwitcher.cs.meta
+++ b/Editor/GameViewResolutionSwitcher.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 71493698620a4970a2a1abc3248dfc88
+timeCreated: 1759615292

--- a/Editor/TestRunnerCallbacks.cs
+++ b/Editor/TestRunnerCallbacks.cs
@@ -26,6 +26,7 @@ namespace TestHelper.Editor
         /// </summary>
         public void RunStarted(ITestAdaptor testsToRun)
         {
+            GameViewResolutionSwitcher.ParseArgumentsAndSwitchIfNeeded();
         }
 
         /// <inheritdoc />

--- a/README.md
+++ b/README.md
@@ -718,6 +718,12 @@ If you specify path with `-testHelperJUnitResults` command line option, the test
 > [!NOTE]  
 > The JUnit XML format is the so-called "Legacy." It does not support the "Open Test Reporting format" introduced in JUnit 5.
 
+#### GameView resolution
+
+If you specify display resolution standards (e.g., `VGA`) with the `-testHelperGameViewResolution` command line option, the GameView resolution is set to the specified size when starting the tests.
+
+Or, you can specify width and height with `-testHelperGameViewWidth` and `-testHelperGameViewHeight` command line options.
+
 
 
 ## Installation

--- a/Runtime/Attributes/GameViewResolution.cs
+++ b/Runtime/Attributes/GameViewResolution.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Koji Hasegawa.
+// Copyright (c) 2023-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Diagnostics.CodeAnalysis;
@@ -12,12 +12,15 @@ namespace TestHelper.Attributes
     [SuppressMessage("ReSharper", "MissingXmlDoc")]
     public enum GameViewResolution
     {
-        VGA,
-        XGA,
-        WXGA,
-        FullHD,
-        QHD,
-        FourK_UHD
+        QVGA = 6,
+        WQVGA = 7,
+        VGA = 0,
+        WVGA = 8,
+        XGA = 1,
+        WXGA = 2,
+        FullHD = 3,
+        QHD = 4,
+        FourK_UHD = 5,
     }
 
     /// <summary>
@@ -34,8 +37,14 @@ namespace TestHelper.Attributes
         {
             switch (resolution)
             {
+                case GameViewResolution.QVGA:
+                    return (320, 240, "QVGA");
+                case GameViewResolution.WQVGA:
+                    return (400, 240, "WQVGA");
                 case GameViewResolution.VGA:
                     return (640, 480, "VGA");
+                case GameViewResolution.WVGA:
+                    return (800, 480, "WVGA");
                 case GameViewResolution.XGA:
                     return (1024, 768, "XGA");
                 case GameViewResolution.WXGA:

--- a/Runtime/Attributes/GameViewResolutionAttribute.cs
+++ b/Runtime/Attributes/GameViewResolutionAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Koji Hasegawa.
+// Copyright (c) 2023-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
@@ -17,7 +17,7 @@ namespace TestHelper.Attributes
     {
         private readonly uint _width;
         private readonly uint _height;
-        private readonly string _name;
+        internal readonly string _name;
 
         /// <summary>
         /// Set <c>GameView</c> resolution before running this test.
@@ -27,11 +27,25 @@ namespace TestHelper.Attributes
         /// <param name="width">GameView width [px]</param>
         /// <param name="height">GameView height [px]</param>
         /// <param name="name">GameViewSize name</param>
-        public GameViewResolutionAttribute(uint width, uint height, string name)
+        public GameViewResolutionAttribute(uint width, uint height, string name = null)
         {
             _width = width;
             _height = height;
-            _name = name;
+            _name = name ?? GetDefaultName(width, height);
+        }
+
+        private static string GetDefaultName(uint width, uint height)
+        {
+            foreach (GameViewResolution resolution in Enum.GetValues(typeof(GameViewResolution)))
+            {
+                var (w, h, name) = resolution.GetParameter();
+                if (w == width && h == height)
+                {
+                    return $"{name} ({width}x{height})";
+                }
+            }
+
+            return $"{width}x{height}";
         }
 
         /// <summary>

--- a/RuntimeInternals/CommandLineArgs.cs
+++ b/RuntimeInternals/CommandLineArgs.cs
@@ -93,5 +93,47 @@ namespace TestHelper.RuntimeInternals
                 return null;
             }
         }
+
+        /// <summary>
+        /// <c>GameView</c> resolution name.
+        /// </summary>
+        /// <returns></returns>
+        public static string GetGameViewResolutionName(string[] args = null)
+        {
+            const string ResolutionNameKey = "-testHelperGameViewResolution";
+
+            try
+            {
+                args = args ?? Environment.GetCommandLineArgs();
+                return DictionaryFromCommandLineArgs(args)[ResolutionNameKey];
+            }
+            catch (KeyNotFoundException)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// <c>GameView</c> width and height.
+        /// </summary>
+        /// <returns></returns>
+        public static (uint width, uint height) GetGameViewResolutionSize(string[] args = null)
+        {
+            const string WidthKey = "-testHelperGameViewWidth";
+            const string HeightKey = "-testHelperGameViewHeight";
+
+            args = args ?? Environment.GetCommandLineArgs();
+
+            var dict = DictionaryFromCommandLineArgs(args);
+            if (dict.TryGetValue(WidthKey, out var widthStr) && dict.TryGetValue(HeightKey, out var heightStr))
+            {
+                if (uint.TryParse(widthStr, out var width) && uint.TryParse(heightStr, out var height))
+                {
+                    return (width, height);
+                }
+            }
+
+            return (0, 0);
+        }
     }
 }

--- a/Tests/Runtime/Attributes/GameViewResolutionAttributeTest.cs
+++ b/Tests/Runtime/Attributes/GameViewResolutionAttributeTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Koji Hasegawa.
+// Copyright (c) 2023-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Collections;
@@ -31,6 +31,20 @@ namespace TestHelper.Attributes
 
             Assert.That(Screen.width, Is.EqualTo(640));
             Assert.That(Screen.height, Is.EqualTo(480));
+        }
+
+        [Test]
+        public void Constructor_WithoutName_Defined_ReturnsDefinedNameAndSize()
+        {
+            var actual = new GameViewResolutionAttribute(400, 240);
+            Assert.That(actual._name, Is.EqualTo("WQVGA (400x240)"));
+        }
+
+        [Test]
+        public void Constructor_WithoutName_NotDefined_ReturnsSizeOnly()
+        {
+            var actual = new GameViewResolutionAttribute(23, 57);
+            Assert.That(actual._name, Is.EqualTo("23x57"));
         }
     }
 }

--- a/Tests/RuntimeInternals/CommandLineArgsTest.cs
+++ b/Tests/RuntimeInternals/CommandLineArgsTest.cs
@@ -2,6 +2,7 @@
 // This software is released under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
 using UnityEngine;
@@ -15,10 +16,10 @@ namespace TestHelper.RuntimeInternals
         public void DictionaryFromCommandLineArgs()
         {
             var args = new[] { "-flag1", "-key1", "value1", "-flag2" };
-            var expected = new System.Collections.Generic.Dictionary<string, string>
+            var expected = new Dictionary<string, string>
             {
                 { "-flag1", string.Empty }, //
-                { "-key1", "value1" }, //
+                { "-key1", "value1" },      //
                 { "-flag2", string.Empty },
             };
             var actual = CommandLineArgs.DictionaryFromCommandLineArgs(args);
@@ -66,6 +67,65 @@ namespace TestHelper.RuntimeInternals
         {
             var actual = CommandLineArgs.GetJUnitResultsPath(Array.Empty<string>());
             Assert.That(actual, Is.Null);
+        }
+
+        [Test]
+        public void GetGameViewResolutionName_WithArgument_GotResolutionName()
+        {
+            var actual =
+                CommandLineArgs.GetGameViewResolutionName(new[] { "-testHelperGameViewResolution", "QVGA" });
+            Assert.That(actual, Is.EqualTo("QVGA"));
+        }
+
+        [Test]
+        public void GetGameViewResolutionName_WithoutArgument_ReturnsNull()
+        {
+            var actual = CommandLineArgs.GetGameViewResolutionName(Array.Empty<string>());
+            Assert.That(actual, Is.Null);
+        }
+
+        [Test]
+        public void GetGameViewResolution_WithArguments_GotWidthAndHeight()
+        {
+            var (width, height) = CommandLineArgs.GetGameViewResolutionSize(new[]
+            {
+                "-testHelperGameViewWidth", "23",
+                "-testHelperGameViewHeight", "57"
+            });
+            Assert.That(width, Is.EqualTo(23));
+            Assert.That(height, Is.EqualTo(57));
+        }
+
+        [TestCase("23", "")]
+        [TestCase("23", "string")]
+        [TestCase("", "57")]
+        [TestCase("string", "57")]
+        public void GetGameViewResolution_InvalidArguments_ReturnsZero(string arg1, string arg2)
+        {
+            var (width, height) = CommandLineArgs.GetGameViewResolutionSize(new[]
+            {
+                "-testHelperGameViewWidth", arg1,
+                "-testHelperGameViewHeight", arg2
+            });
+            Assert.That(width, Is.EqualTo(0));
+            Assert.That(height, Is.EqualTo(0));
+        }
+
+        [TestCase("-testHelperGameViewWidth")]
+        [TestCase("-testHelperGameViewHeight")]
+        public void GetGameViewResolution_OneArgument_ReturnsZero(string key)
+        {
+            var (width, height) = CommandLineArgs.GetGameViewResolutionSize(new[] { key, "23" });
+            Assert.That(width, Is.EqualTo(0));
+            Assert.That(height, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void GetGameViewResolution_WithoutArgument_ReturnsZero()
+        {
+            var (width, height) = CommandLineArgs.GetGameViewResolutionSize(Array.Empty<string>());
+            Assert.That(width, Is.EqualTo(0));
+            Assert.That(height, Is.EqualTo(0));
         }
     }
 }


### PR DESCRIPTION
### Changes

### GameViewResolutionAttribute

- Add preset display resolution standards: `QVGA`, `WQVGA`, and `WVGA`
- Resolution name to optional

#### Commandline Arguments

You can set GameView to the specified resolution when starting the tests.

- `-testHelperGameViewResolution` allows you to specify the standard display resolution
- `-testHelperGameViewWidth` and `-testHelperGameViewHeight` allow you to size
