### PR TITLE
Add RecordVideo attribute (optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ public class MyTestClass
     public void MyTestMethod()
     {
         // Recording a video while running the test.
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -274,6 +274,41 @@ public class MyTestClass
 > If you want to load during `SetUp` and testing, use [BuildSceneAttribute](#buildscene) and [SceneManagerHelper](#scenemanagerhelper) method instead.
 
 
+#### RecordVideo (optional)
+
+`RecordVideoAttribute` is an NUnit test attribute class for recording a video while running the test.
+
+Default save path is "`Application.persistentDataPath`/TestHelper/Screenshots/`TestContext.Test.Name`.mp4".
+You can specify the save directory by arguments.
+Directory can also be specified by command line arguments `-testHelperScreenshotDirectory`.
+
+This attribute can be placed on the test method only.
+Can be used with sync `Test`, async `Test`, and `UnityTest`.
+
+Usage:
+
+```csharp
+[TestFixture]
+public class MyTestClass
+{
+    [Test]
+    [RecordVideo]
+    public void MyTestMethod()
+    {
+        // Recording a video while running the test.
+}
+```
+
+> [!IMPORTANT]  
+> `RecordVideoAttribute` is an optional functionality. To use it, you need to install the [Instant Replay for Unity](https://github.com/CyberAgentGameEntertainment/InstantReplay) package v1.0.0 or newer separately via the Package Manager window.
+
+> [!WARNING]  
+> `GameView` must be visible. Use [FocusGameViewAttribute](#focusgameview) or [GameViewResolutionAttribute](#gameviewresolution) if running on batchmode.
+
+> [!WARNING]  
+> Do not place on Edit Mode tests.
+
+
 #### TakeScreenshot
 
 `TakeScreenshotAttribute` is an NUnit test attribute class to take a screenshot and save it to a file after running the test.
@@ -301,10 +336,10 @@ public class MyTestClass
 ```
 
 > [!WARNING]  
-> Do not place on Edit Mode tests.
+> `GameView` must be visible. Use [FocusGameViewAttribute](#focusgameview) or [GameViewResolutionAttribute](#gameviewresolution) if running on batchmode.
 
 > [!WARNING]  
-> `GameView` must be visible. Use [FocusGameViewAttribute](#focusgameview) or [GameViewResolutionAttribute](#gameviewresolution) if running on batchmode.
+> Do not place on Edit Mode tests.
 
 > [!NOTE]  
 > If you want to take screenshots at any time, use the [ScreenshotHelper](#screenshothelper) class.
@@ -682,17 +717,17 @@ public class MyTestClass
 ```
 
 > [!WARNING]  
-> Do not place on Edit Mode tests.
-> And must be called from main thread.
+> `GameView` must be visible. Use [FocusGameViewAttribute](#focusgameview) or [GameViewResolutionAttribute](#gameviewresolution) if running on batchmode.
 
 > [!WARNING]  
-> `GameView` must be visible. Use [FocusGameViewAttribute](#focusgameview) or [GameViewResolutionAttribute](#gameviewresolution) if running on batchmode.
+> Do not place on Edit Mode tests.
+> And must be called from main thread.
 
 > [!WARNING]  
 > Files with the same name will be overwritten. Please specify filename argument when calling over twice in one method.
 
 > [!WARNING]  
-> `UniTask` is required to be used from the async method. And also needs coroutineRunner (any MonoBehaviour) because TakeScreenshot method uses `WaitForEndOfFrame` inside. See more information: https://github.com/Cysharp/UniTask#ienumeratortounitask-limitation
+> `UniTask` is required to be used from the async method. And also needs coroutineRunner (any `MonoBehaviour`) because TakeScreenshot method uses `WaitForEndOfFrame` inside. See more information: https://github.com/Cysharp/UniTask#ienumeratortounitask-limitation
 
 
 #### PathHelper

--- a/Runtime/Attributes/RecordVideoAttribute.cs
+++ b/Runtime/Attributes/RecordVideoAttribute.cs
@@ -1,0 +1,85 @@
+// Copyright (c) 2023-2025 Koji Hasegawa.
+// This software is released under the MIT License.
+
+#if ENABLE_INSTANT_REPLAY
+using System;
+using System.Collections;
+using System.IO;
+using InstantReplay;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using TestHelper.RuntimeInternals;
+using UnityEngine.TestTools;
+
+namespace TestHelper.Attributes
+{
+    /// <summary>
+    /// Record a video and save it to file after running this test.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class RecordVideoAttribute : NUnitAttribute, IOuterUnityTestAction, IDisposable
+    {
+        private readonly string _baseDirectory;
+        private readonly bool _namespaceToDirectory;
+
+        private RealtimeInstantReplaySession _session;
+
+        /// <summary>
+        /// Record a video and save it to file after running this test.
+        /// <p/>
+        /// Requires <see href="https://github.com/CyberAgentGameEntertainment/InstantReplay">Instant Replay for Unity</see> package v1.0.0 or newer.
+        /// </summary>
+        /// <param name="baseDirectory">Directory to save video.
+        /// If omitted, the directory specified by command line argument "-testHelperScreenshotDirectory" is used.
+        /// If the command line argument is also omitted, <c>Application.persistentDataPath</c> + "/TestHelper/Screenshots/" is used.</param>
+        /// <param name="namespaceToDirectory">Insert subdirectory named from test namespace if true.</param>
+        public RecordVideoAttribute(string baseDirectory = null, bool namespaceToDirectory = false)
+        {
+            if (baseDirectory != null)
+            {
+                _baseDirectory = Path.GetFullPath(baseDirectory);
+            }
+            else
+            {
+                _baseDirectory = CommandLineArgs.GetScreenshotDirectory();
+            }
+
+            _namespaceToDirectory = namespaceToDirectory;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _session?.Dispose();
+        }
+
+        /// <inheritdoc/>
+        public IEnumerator BeforeTest(ITest test)
+        {
+            _session?.Dispose();
+            _session = RealtimeInstantReplaySession.CreateDefault();
+            yield break;
+        }
+
+        /// <inheritdoc/>
+        public IEnumerator AfterTest(ITest test)
+        {
+            var outputPath = PathHelper.CreateFilePath(
+                baseDirectory: _baseDirectory,
+                extension: "mp4",
+                namespaceToDirectory: _namespaceToDirectory);
+
+            var task = _session.StopAndExportAsync(outputPath: outputPath);
+            while (!task.IsCompleted)
+            {
+                yield return null;
+            }
+
+            _session.Dispose();
+
+            var properties = TestContext.CurrentContext.Test.Properties;
+            properties.Add("Video", outputPath);
+        }
+    }
+}
+#endif

--- a/Runtime/Attributes/RecordVideoAttribute.cs
+++ b/Runtime/Attributes/RecordVideoAttribute.cs
@@ -9,6 +9,8 @@ using InstantReplay;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using TestHelper.RuntimeInternals;
+using UniEnc;
+using UnityEngine;
 using UnityEngine.TestTools;
 
 namespace TestHelper.Attributes
@@ -21,6 +23,12 @@ namespace TestHelper.Attributes
     {
         private readonly string _baseDirectory;
         private readonly bool _namespaceToDirectory;
+        private readonly bool _gizmos;
+        private readonly uint _width;
+        private readonly uint _height;
+        private readonly uint _fpsHint;
+
+        private bool _beforeGizmos;
 
         private RealtimeInstantReplaySession _session;
 
@@ -33,7 +41,17 @@ namespace TestHelper.Attributes
         /// If omitted, the directory specified by command line argument "-testHelperScreenshotDirectory" is used.
         /// If the command line argument is also omitted, <c>Application.persistentDataPath</c> + "/TestHelper/Screenshots/" is used.</param>
         /// <param name="namespaceToDirectory">Insert subdirectory named from test namespace if true.</param>
-        public RecordVideoAttribute(string baseDirectory = null, bool namespaceToDirectory = false)
+        /// <param name="gizmos">Show Gizmos on <c>GameView</c> if true.</param>
+        /// <param name="width">Video output max width. If omit, use <see cref="Screen.width"/>.</param>
+        /// <param name="height">Video output max height. If omit, use <see cref="Screen.height"/>.</param>
+        /// <param name="fpsHint">Video output frame rate hint.</param>
+        public RecordVideoAttribute(
+            string baseDirectory = null,
+            bool namespaceToDirectory = false,
+            bool gizmos = false,
+            uint width = 0,
+            uint height = 0,
+            uint fpsHint = 30)
         {
             if (baseDirectory != null)
             {
@@ -45,6 +63,10 @@ namespace TestHelper.Attributes
             }
 
             _namespaceToDirectory = namespaceToDirectory;
+            _gizmos = gizmos;
+            _width = width != 0 ? width : (uint)Screen.width;
+            _height = height != 0 ? height : (uint)Screen.height;
+            _fpsHint = fpsHint;
         }
 
         /// <inheritdoc/>
@@ -56,29 +78,69 @@ namespace TestHelper.Attributes
         /// <inheritdoc/>
         public IEnumerator BeforeTest(ITest test)
         {
+            if (_gizmos)
+            {
+                _beforeGizmos = GameViewControlHelper.GetGizmos();
+                GameViewControlHelper.SetGizmos(true);
+            }
+
             _session?.Dispose();
-            _session = RealtimeInstantReplaySession.CreateDefault();
+            _session = new RealtimeInstantReplaySession(CreateOptions());
             yield break;
         }
 
         /// <inheritdoc/>
         public IEnumerator AfterTest(ITest test)
         {
+            if (_gizmos)
+            {
+                GameViewControlHelper.SetGizmos(_beforeGizmos);
+            }
+
             var outputPath = PathHelper.CreateFilePath(
                 baseDirectory: _baseDirectory,
                 extension: "mp4",
                 namespaceToDirectory: _namespaceToDirectory);
 
-            var task = _session.StopAndExportAsync(outputPath: outputPath);
-            while (!task.IsCompleted)
+            try
             {
-                yield return null;
+                var task = _session.StopAndExportAsync(outputPath: outputPath);
+                while (!task.IsCompleted)
+                {
+                    yield return null;
+                }
+
+                var properties = TestContext.CurrentContext.Test.Properties;
+                properties.Add("Video", outputPath);
             }
+            finally
+            {
+                _session.Dispose();
+            }
+        }
 
-            _session.Dispose();
-
-            var properties = TestContext.CurrentContext.Test.Properties;
-            properties.Add("Video", outputPath);
+        private RealtimeEncodingOptions CreateOptions()
+        {
+            return new RealtimeEncodingOptions
+            {
+                VideoOptions = new VideoEncoderOptions
+                {
+                    Width = Math.Min(_width, (uint)Screen.width),
+                    Height = Math.Min(_height, (uint)Screen.height),
+                    FpsHint = _fpsHint,
+                    Bitrate = 2500000 // 2.5 Mbps
+                },
+                AudioOptions = new AudioEncoderOptions
+                {
+                    SampleRate = 44100,
+                    Channels = 2,
+                    Bitrate = 128000 // 128 kbps
+                },
+                MaxMemoryUsageBytes = 20 * 1024 * 1024, // 20 MiB
+                FixedFrameRate = 30.0, // null if not using fixed frame rate
+                VideoInputQueueSize = 5, // Maximum number of raw frames to keep before encoding
+                AudioInputQueueSize = 60, // Maximum number of raw audio sample frames to keep before encoding
+            };
         }
     }
 }

--- a/Runtime/Attributes/RecordVideoAttribute.cs.meta
+++ b/Runtime/Attributes/RecordVideoAttribute.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e0a987dd539b4fffab2e4e89d58eb297
+timeCreated: 1759773038

--- a/Runtime/Attributes/TakeScreenshotAttribute.cs
+++ b/Runtime/Attributes/TakeScreenshotAttribute.cs
@@ -46,7 +46,7 @@ namespace TestHelper.Attributes
         /// Using caller method name when run in runtime context.</param>
         /// <param name="superSize">The factor to increase resolution with.</param>
         /// <param name="stereoCaptureMode">The eye texture to capture when stereo rendering is enabled.</param>
-        /// <param name="gizmos">True: show Gizmos on <c>GameView</c>.</param>
+        /// <param name="gizmos">Show Gizmos on <c>GameView</c> if true.</param>
         /// <param name="namespaceToDirectory">Insert subdirectory named from test namespace if true.</param>
         public TakeScreenshotAttribute(
             string directory = null,

--- a/Runtime/TestHelper.asmdef
+++ b/Runtime/TestHelper.asmdef
@@ -5,7 +5,8 @@
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
         "TestHelper.RuntimeInternals",
-        "InstantReplay"
+        "InstantReplay",
+        "UniEnc"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Runtime/TestHelper.asmdef
+++ b/Runtime/TestHelper.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
-        "TestHelper.RuntimeInternals"
+        "TestHelper.RuntimeInternals",
+        "InstantReplay"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -22,6 +23,11 @@
             "name": "com.unity.test-framework",
             "expression": "",
             "define": "UNITY_TESTS_FRAMEWORK"
+        },
+        {
+            "name": "jp.co.cyberagent.instant-replay",
+            "expression": "1.0.0",
+            "define": "ENABLE_INSTANT_REPLAY"
         }
     ],
     "noEngineReferences": false

--- a/RuntimeInternals/AssemblyInfo.cs
+++ b/RuntimeInternals/AssemblyInfo.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
     @"This assembly can be used from the runtime code because it does not depend on test-framework.
 This assembly is named ""Internal"", however, the included classes are public.")]
 
+[assembly: InternalsVisibleTo("TestHelper")]
 [assembly: InternalsVisibleTo("TestHelper.Editor")]
 [assembly: InternalsVisibleTo("TestHelper.RuntimeInternals.Tests")]
 [assembly: InternalsVisibleTo("TestHelper.Tests")]

--- a/Tests/Runtime/Attributes/RecordVideoAttributeTest.cs
+++ b/Tests/Runtime/Attributes/RecordVideoAttributeTest.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2023-2025 Koji Hasegawa.
+// This software is released under the MIT License.
+
+#if ENABLE_INSTANT_REPLAY
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using TestHelper.RuntimeInternals;
+
+namespace TestHelper.Attributes
+{
+    [TestFixture]
+    public class RecordVideoAttributeTest
+    {
+        private const string TestScene = "../../Scenes/ScreenshotTest.unity";
+        private readonly string _defaultOutputDirectory = CommandLineArgs.GetScreenshotDirectory();
+
+        private static string SubdirectoryFromNamespace =>
+            nameof(TestHelper) + Path.DirectorySeparatorChar +
+            nameof(Attributes) + Path.DirectorySeparatorChar +
+            nameof(RecordVideoAttributeTest);
+
+        [Test, Order(0)]
+        [LoadScene(TestScene)]
+        [RecordVideo]
+        public async Task Attach_WithoutArguments()
+        {
+            var path = Path.Combine(_defaultOutputDirectory, $"{nameof(Attach_WithoutArguments)}.mp4");
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+
+            Assume.That(path, Does.Not.Exist);
+
+            await Task.Delay(TimeSpan.FromSeconds(1D));
+
+            // output video after running this test.
+        }
+
+        [Test, Order(1)]
+        public void Attach_WithoutArguments_OutputVideoToDefaultPath()
+        {
+            var path = Path.Combine(_defaultOutputDirectory, $"{nameof(Attach_WithoutArguments)}.mp4");
+            Assert.That(path, Does.Exist);
+        }
+    }
+}
+#endif

--- a/Tests/Runtime/Attributes/RecordVideoAttributeTest.cs
+++ b/Tests/Runtime/Attributes/RecordVideoAttributeTest.cs
@@ -2,24 +2,52 @@
 // This software is released under the MIT License.
 
 #if ENABLE_INSTANT_REPLAY
-using System;
 using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.RuntimeInternals;
+using UnityEngine;
+using UnityEngine.UI;
 
 namespace TestHelper.Attributes
 {
     [TestFixture]
+    [GameViewResolution(GameViewResolution.VGA)]
     public class RecordVideoAttributeTest
     {
         private const string TestScene = "../../Scenes/ScreenshotTest.unity";
+        private const string SpecifyRelativeDirectory = "Logs/TestHelper.Tests/" + nameof(RecordVideoAttributeTest);
         private readonly string _defaultOutputDirectory = CommandLineArgs.GetScreenshotDirectory();
 
         private static string SubdirectoryFromNamespace =>
             nameof(TestHelper) + Path.DirectorySeparatorChar +
             nameof(Attributes) + Path.DirectorySeparatorChar +
             nameof(RecordVideoAttributeTest);
+
+        [SetUp]
+        public void SetUp()
+        {
+            var textObject = GameObject.Find("Text");
+            Assume.That(textObject, Is.Not.Null);
+
+            var text = textObject.GetComponent<Text>();
+            text.text = TestContext.CurrentContext.Test.Name;
+        }
+
+        private static async Task RotateCube()
+        {
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.transform.position = new Vector3(0, -0.5f, 0);
+
+            var startTime = Time.time;
+            while (Time.time - startTime < 1.0f)
+            {
+                cube.transform.Rotate(new Vector3(0, 90, 0) * Time.deltaTime);
+                await Task.Yield();
+            }
+
+            Object.Destroy(cube);
+        }
 
         [Test, Order(0)]
         [LoadScene(TestScene)]
@@ -34,7 +62,7 @@ namespace TestHelper.Attributes
 
             Assume.That(path, Does.Not.Exist);
 
-            await Task.Delay(TimeSpan.FromSeconds(1D));
+            await RotateCube();
 
             // output video after running this test.
         }
@@ -44,6 +72,82 @@ namespace TestHelper.Attributes
         {
             var path = Path.Combine(_defaultOutputDirectory, $"{nameof(Attach_WithoutArguments)}.mp4");
             Assert.That(path, Does.Exist);
+        }
+
+        [Test, Order(0)]
+        [LoadScene(TestScene)]
+        [RecordVideo(baseDirectory: SpecifyRelativeDirectory)]
+        public async Task Attach_WithBaseDirectory()
+        {
+            var path = Path.Combine(
+                Path.GetFullPath(SpecifyRelativeDirectory),
+                $"{nameof(Attach_WithBaseDirectory)}.mp4");
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+
+            Assume.That(path, Does.Not.Exist);
+
+            await RotateCube();
+
+            // output video after running this test.
+        }
+
+        [Test, Order(1)]
+        public void Attach_WithBaseDirectory_OutputVideoToSpecifiedPath()
+        {
+            var path = Path.Combine(
+                Path.GetFullPath(SpecifyRelativeDirectory),
+                $"{nameof(Attach_WithBaseDirectory)}.mp4");
+            Assert.That(path, Does.Exist);
+        }
+
+        [Test, Order(0)]
+        [LoadScene(TestScene)]
+        [RecordVideo(namespaceToDirectory: true)]
+        public async Task Attach_WithNamespaceToDirectory()
+        {
+            var path = Path.Combine(_defaultOutputDirectory,
+                SubdirectoryFromNamespace,
+                $"{nameof(Attach_WithNamespaceToDirectory)}.mp4");
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+
+            Assume.That(path, Does.Not.Exist);
+
+            await RotateCube();
+
+            // output video after running this test.
+        }
+
+        [Test, Order(1)]
+        public void Attach_WithNamespaceToDirectory_OutputVideoToSpecifiedPath()
+        {
+            var path = Path.Combine(_defaultOutputDirectory,
+                SubdirectoryFromNamespace,
+                $"{nameof(Attach_WithNamespaceToDirectory)}.mp4");
+            Assert.That(path, Does.Exist);
+        }
+
+        [Test]
+        [LoadScene(TestScene)]
+        [RecordVideo(gizmos: true)]
+        public async Task Attach_WithGizmos_OutputVideoWithGizmos()
+        {
+            await RotateCube();
+            // output video after running this test.
+        }
+
+        [Test]
+        [LoadScene(TestScene)]
+        [RecordVideo(width: 320, height: 240, fpsHint: 5)]
+        public async Task Attach_WithSizeWQVGA_OutputVideoWQVGA()
+        {
+            await RotateCube();
+            // output video after running this test.
         }
     }
 }

--- a/Tests/Runtime/Attributes/RecordVideoAttributeTest.cs.meta
+++ b/Tests/Runtime/Attributes/RecordVideoAttributeTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f07b86ac005e47a1a7e2b7357b6d0db8
+timeCreated: 1759773060

--- a/Tests/Runtime/Attributes/TakeScreenshotAttributeTest.cs
+++ b/Tests/Runtime/Attributes/TakeScreenshotAttributeTest.cs
@@ -27,16 +27,14 @@ namespace TestHelper.Attributes
             nameof(Attributes) + Path.DirectorySeparatorChar +
             nameof(TakeScreenshotAttributeTest);
 
-        private Text _text;
-
         [SetUp]
         public void SetUp()
         {
             var textObject = GameObject.Find("Text");
             Assume.That(textObject, Is.Not.Null);
 
-            _text = textObject.GetComponent<Text>();
-            _text.text = TestContext.CurrentContext.Test.Name;
+            var text = textObject.GetComponent<Text>();
+            text.text = TestContext.CurrentContext.Test.Name;
         }
 
         [Test, Order(0)]

--- a/Tests/Runtime/TestHelper.Tests.asmdef
+++ b/Tests/Runtime/TestHelper.Tests.asmdef
@@ -19,6 +19,12 @@
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"
     ],
-    "versionDefines": [],
+    "versionDefines": [
+      {
+        "name": "jp.co.cyberagent.instant-replay",
+        "expression": "1.0.0",
+        "define": "ENABLE_INSTANT_REPLAY"
+      }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
### Added

#### RecordVideo (optional)

`RecordVideoAttribute` is an NUnit test attribute class for recording a video while running the test.

Default save path is "`Application.persistentDataPath`/TestHelper/Screenshots/`TestContext.Test.Name`.mp4".
You can specify the save directory by arguments.
Directory can also be specified by command line arguments `-testHelperScreenshotDirectory`.

This attribute can be placed on the test method only.
Can be used with sync `Test`, async `Test`, and `UnityTest`.

Usage:

```csharp
[TestFixture]
public class MyTestClass
{
    [Test]
    [RecordVideo]
    public void MyTestMethod()
    {
        // Recording a video while running the test.
    }
}
```

> [!IMPORTANT]  
> `RecordVideoAttribute` is an optional functionality. To use it, you need to install the [Instant Replay for Unity](https://github.com/CyberAgentGameEntertainment/InstantReplay) package v1.0.0 or newer separately via the Package Manager window.

> [!WARNING]  
> `GameView` must be visible. Use [FocusGameViewAttribute](#focusgameview) or [GameViewResolutionAttribute](#gameviewresolution) if running on batchmode.

> [!WARNING]  
> Do not place on Edit Mode tests.