### PR TITLE
Add LoadAsset attribute

### DIFF
--- a/Editor/TemporaryBuildScenesUsingInTest.cs
+++ b/Editor/TemporaryBuildScenesUsingInTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Koji Hasegawa.
+// Copyright (c) 2023-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
@@ -17,7 +17,7 @@ using UnityEngine;
 namespace TestHelper.Editor
 {
     /// <summary>
-    /// Temporarily build scenes specified by <c>LoadSceneAttribute</c> when running play mode tests on standalone player.
+    /// Temporarily build scenes specified by <c>LoadSceneAttribute</c> when running play mode tests on player.
     /// </summary>
     public class TemporaryBuildScenesUsingInTest : ITestPlayerBuildModifier
     {
@@ -82,7 +82,8 @@ namespace TestHelper.Editor
         }
 
         /// <summary>
-        /// Add temporary scenes to build when running play mode tests on standalone player.
+        /// Temporarily build scenes specified by <c>LoadSceneAttribute</c> when running play mode tests on player.
+        /// And temporarily copy asset files specified by <c>LoadAssetAttribute</c> to the Resources folder.
         /// </summary>
         /// <remarks>
         /// Required Unity Test Framework package v1.1.13 or higher is to use this script.
@@ -90,6 +91,10 @@ namespace TestHelper.Editor
         /// </remarks>
         public BuildPlayerOptions ModifyOptions(BuildPlayerOptions playerOptions)
         {
+            // Temporarily copy asset files specified by LoadAssetAttribute to the Resources folder
+            TemporaryCopyAssetsForPlayer.CopyAssetFiles();
+
+            // Temporarily build scenes specified by LoadSceneAttribute
             var scenesInBuild = new List<string>(playerOptions.scenes);
             foreach (var scenePath in GetScenesUsingInTest())
             {

--- a/Editor/TemporaryCopyAssetsForPlayer.cs
+++ b/Editor/TemporaryCopyAssetsForPlayer.cs
@@ -1,0 +1,49 @@
+// Copyright (c) 2023-2025 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using TestHelper.Attributes;
+using UnityEditor;
+
+namespace TestHelper.Editor
+{
+    /// <summary>
+    /// Temporarily copy asset files specified by <c>LoadAssetAttribute</c> to the Resources folder when running play mode tests on player.
+    /// </summary>
+    /// <remarks>
+    /// Deleting copied files is in <see cref="TestRunnerCallbacks.RunFinished"/> method.
+    /// </remarks>
+    internal static class TemporaryCopyAssetsForPlayer
+    {
+        internal const string ResourcesRoot = "Assets/com.nowsprinting.test-helper";
+
+        private static IEnumerable<T> FindAttributesOnFields<T>() where T : Attribute
+        {
+            var symbols = TypeCache.GetFieldsWithAttribute<T>();
+            foreach (var attribute in symbols
+                         .Select(symbol => symbol.GetCustomAttributes(typeof(T), false))
+                         .SelectMany(attributes => attributes))
+            {
+                yield return attribute as T;
+            }
+        }
+
+        internal static void CopyAssetFiles()
+        {
+            foreach (var attribute in FindAttributesOnFields<LoadAssetAttribute>())
+            {
+                var destFileName = Path.Combine(ResourcesRoot, "Resources", attribute.AssetPath);
+                var destDir = Path.GetDirectoryName(destFileName);
+                if (destDir != null && !Directory.Exists(destDir))
+                {
+                    Directory.CreateDirectory(destDir);
+                }
+
+                File.Copy(attribute.AssetPath, destFileName, true);
+            }
+        }
+    }
+}

--- a/Editor/TemporaryCopyAssetsForPlayer.cs.meta
+++ b/Editor/TemporaryCopyAssetsForPlayer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 23027300e13045008fd5d38a4e22c9c3
+timeCreated: 1759870341

--- a/Editor/TestRunnerCallbacks.cs
+++ b/Editor/TestRunnerCallbacks.cs
@@ -1,6 +1,7 @@
-// Copyright (c) 2023-2024 Koji Hasegawa.
+// Copyright (c) 2023-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using System.IO;
 using TestHelper.Editor.JUnitXml;
 using TestHelper.RuntimeInternals;
 using UnityEditor;
@@ -21,9 +22,7 @@ namespace TestHelper.Editor
             api.RegisterCallbacks(new TestRunnerCallbacks());
         }
 
-        /// <summary>
-        /// Not implemented.
-        /// </summary>
+        /// <inheritdoc />
         public void RunStarted(ITestAdaptor testsToRun)
         {
             GameViewResolutionSwitcher.ParseArgumentsAndSwitchIfNeeded();
@@ -36,6 +35,13 @@ namespace TestHelper.Editor
             if (path != null)
             {
                 JUnitXmlWriter.WriteTo(result, path);
+            }
+
+            // Delete temporary copied asset files for running play mode tests on player.
+            if (Directory.Exists(TemporaryCopyAssetsForPlayer.ResourcesRoot))
+            {
+                AssetDatabase.DeleteAsset(TemporaryCopyAssetsForPlayer.ResourcesRoot);
+                // Note: delete with .meta file.
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,54 @@ public class MyTestClass
 ```
 
 
+#### LoadAsset
+
+`LoadAssetAttribute` is a NUnit test attribute class that loads an asset before running the test.
+
+It has the following benefits:
+
+- The same code can be used for Edit Mode tests and Play Mode tests in Editor and on Player.
+- The asset file path can be specified as a relative path from the test class file.
+
+This attribute can be placed on the field only.
+
+Usage:
+
+```csharp
+[TestFixture]
+public class MyTestClass
+{
+    [LoadAsset("Assets/Path/To/Tests/Prefabs/Cube.prefab")]
+    private GameObject _prefab;
+
+    [LoadAsset("../../Prefabs/Sphere.prefab")]
+    private GameObject _relative;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        LoadAssetAttribute.LoadAssets(this);
+    }
+
+    [Test]
+    public void MyTestMethod()
+    {
+        Assume.That(_prefab, Is.Not.Null);  // already loaded and set to the field.
+    }
+}
+```
+
+> [!IMPORTANT]  
+> Tests that use this attribute must call the `LoadAssets` static method from the `OneTimeSetUp`.
+
+> [!NOTE]  
+> Properties are not supported. You can place attributes in fields by specifying `[field: LoadAsset]`.
+
+> [!NOTE]  
+> The Resources folder copied to run tests on the player is deleted after the run finishes.
+> However, if post-processing is not performed, such as if the Unity editor crashes, the "Assets/com.nowsprinting.test-helper/Resources" folder will remain.
+> Recommend adding "/Assets/com.nowsprinting.test-helper*" to your project .gitignore file.
+
 #### LoadScene
 
 `LoadSceneAttribute` is a NUnit test attribute class that loads a scene before running the test.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,8 @@ Required Unity 2019 LTS or later.
 
 It has the following benefits:
 
-- Scenes that are **NOT** in "Scenes in Build" can be specified.
-- The scene path can be specified as a relative path from the test class file.
-- The scene path can be specified by [glob](https://en.wikipedia.org/wiki/Glob_(programming)) pattern. However, there are restrictions, top level and scene name cannot be omitted.
+- Scene that are **NOT** in "Scenes in Build" can be specified.
+- The scene file path can be specified as a relative path from the test class file.
 
 This attribute can be placed on the test method, the test class (`TestFixture`), and the test assembly.
 Can be used with sync `Test`, async `Test`, and `UnityTest`.
@@ -34,15 +33,22 @@ Usage:
 public class MyTestClass
 {
     [Test]
-    [BuildScene("../../Scenes/SampleScene.unity")]
+    [BuildScene("Assets/Path/To/Tests/Scenes/TestScene.unity")]
     public void MyTestMethod()
     {
         // Setup before load scene
 
         // Load scene
-        await SceneManagerHelper.LoadSceneAsync("../../Scenes/SampleScene.unity");
+        await SceneManagerHelper.LoadSceneAsync("Assets/Path/To/Tests/Scenes/TestScene.unity");
 
         // Excercise the test
+    }
+
+    [Test]
+    [BuildScene("../../Scenes/SampleScene.unity")]
+    public void UsingRelativePath()
+    {
+        // snip
     }
 }
 ```
@@ -232,9 +238,8 @@ public class MyTestClass
 It has the following benefits:
 
 - The same code can be used for Edit Mode tests and Play Mode tests in Editor and on Player.
-- Scenes that are **NOT** in "Scenes in Build" can be specified.
-- The scene path can be specified by [glob](https://en.wikipedia.org/wiki/Glob_(programming)) pattern. However, there are restrictions, top level and scene name cannot be omitted.
-- The scene path can be specified as a relative path from the test class file.
+- Scene that are **NOT** in "Scenes in Build" can be specified.
+- The scene file path can be specified as a relative path from the test class file.
 
 This attribute can be placed on the test method only.
 Can be used with sync `Test`, async `Test`, and `UnityTest`.
@@ -246,18 +251,11 @@ Usage:
 public class MyTestClass
 {
     [Test]
-    [LoadScene("Assets/MyTests/Scenes/TestScene.unity")]
+    [LoadScene("Assets/Path/To/Tests/Scenes/TestScene.unity")]
     public void MyTestMethod()
     {
         var cube = GameObject.Find("Cube in TestScene");
         Assert.That(cube, Is.Not.Null);
-    }
-
-    [Test]
-    [LoadScene("Packages/YourPackageName/**/SampleScene.unity")]
-    public void UsingGlobPattern()
-    {
-        // snip
     }
 
     [Test]
@@ -659,8 +657,7 @@ The classes in the `TestHelper.RuntimeInternals` assembly can be used from the r
 It has the following benefits:
 
 - The same code can be used for Edit Mode tests and Play Mode tests in Editor and on Player.
-- The scene path can be specified as a relative path from the test class file.
-- The scene path can be specified by [glob](https://en.wikipedia.org/wiki/Glob_(programming)) pattern. However, there are restrictions, top level and scene name cannot be omitted.
+- The scene file path can be specified as a relative path from the test class file.
 
 Usage:
 
@@ -674,8 +671,19 @@ public class MyTestClass
         // Setup before load scene
 
         // Load scene
+        await SceneManagerHelper.LoadSceneAsync("Assets/Path/To/Tests/Scenes/TestScene.unity");
+
+        // Excercise the test
+    }
+
+    [Test]
+    public void UsingRelativePath()
+    {
+        // Setup before load scene
+
+        // Load scene
         await SceneManagerHelper.LoadSceneAsync("../../Scenes/SampleScene.unity");
-        
+
         // Excercise the test
     }
 }

--- a/Runtime/Attributes/BuildSceneAttribute.cs
+++ b/Runtime/Attributes/BuildSceneAttribute.cs
@@ -20,24 +20,24 @@ namespace TestHelper.Attributes
 
         /// <summary>
         /// Build a scene before running this test on the player.
-        ///
+        /// <p/>
         /// This attribute has the following benefits:
         /// <list type="bullet">
-        ///     <item>Scenes that are **NOT** in "Scenes in Build" can be specified.</item>
-        ///     <item>The scene path can be specified by [glob](https://en.wikipedia.org/wiki/Glob_(programming)) pattern. However, there are restrictions, top level and scene name cannot be omitted.</item>
-        ///     <item>The scene path can be specified as a relative path from the test class file.</item>
+        ///     <item>Scene that are **NOT** in "Scenes in Build" can be specified.</item>
+        ///     <item>The scene file path can be specified as a relative path from the test class file.</item>
         /// </list>
         /// </summary>
         /// <param name="path">Scene file path (optional).
-        /// The path starts with `Assets/` or `Packages/` or `.`.
-        /// And package name using `name` instead of `displayName`, when scenes in the package
+        /// The path must starts with `Assets/` or `Packages/` or `.`.
+        /// And package name using `name` instead of `displayName`, when scene file in the package
         /// (e.g., `Packages/com.nowsprinting.test-helper/Tests/Scenes/Scene.unity`).
         /// If the value is omitted, the scene name will be derived from the test file name
-        /// (e.g., `Asset/Tests/ScreenshotTest.cs` will load `Asset/Tests/ScreenshotTest.unity`).</param>
+        /// (e.g., `Asset/Tests/ScreenshotTest.cs` will load `Asset/Tests/ScreenshotTest.unity`).
+        /// </param>
+        /// <param name="callerFilePath">Test file path set by <see cref="CallerFilePathAttribute"/></param>
         /// <remarks>
         /// For the process of including a Scene not in "Scenes in Build" to a build for player, see: <see cref="TestHelper.Editor.TemporaryBuildScenesUsingInTest"/>.
         /// </remarks>
-        [SuppressMessage("ReSharper", "InvalidXmlDocComment")]
         public BuildSceneAttribute(string path = null, [CallerFilePath] string callerFilePath = null)
         {
             ScenePath = ResolveScenePath(path, callerFilePath);

--- a/Runtime/Attributes/LoadAssetAttribute.cs
+++ b/Runtime/Attributes/LoadAssetAttribute.cs
@@ -1,0 +1,121 @@
+// Copyright (c) 2023-2025 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace TestHelper.Attributes
+{
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+    public class LoadAssetAttribute : Attribute
+    {
+        internal string AssetPath { get; private set; }
+
+        /// <summary>
+        /// Load an asset file at the specified path into the field.
+        /// Tests that use this attribute must call the <see cref="LoadAssets"/> static method from the <c>OneTimeSetUp</c> method.
+        /// <p/>
+        /// This attribute has the following benefits:
+        /// <list type="bullet">
+        ///     <item>The same code can be used for Edit Mode tests and Play Mode tests in Editor and on Player.</item>
+        ///     <item>The asset file path can be specified as a relative path from the test class file.</item>
+        /// </list>
+        /// </summary>
+        /// <param name="path">Asset file path.
+        /// The path must starts with `Assets/` or `Packages/` or `.`.
+        /// And package name using `name` instead of `displayName`, when asset file in the package (e.g., `Packages/com.nowsprinting.test-helper/Tests/Scenes/Scene.unity`).
+        /// </param>
+        /// <param name="callerFilePath">Test file path set by <see cref="CallerFilePathAttribute"/></param>
+        /// <remarks>
+        /// When running tests on the player, it temporarily copies asset files to the <c>Resources</c> folder by <see cref="TestHelper.Editor.TemporaryCopyAssetsForPlayer"/>.
+        /// </remarks>
+        public LoadAssetAttribute(string path, [CallerFilePath] string callerFilePath = null)
+        {
+            if (path.StartsWith("."))
+            {
+                AssetPath = GetAbsolutePath(path, callerFilePath);
+            }
+            else
+            {
+                AssetPath = path;
+            }
+        }
+
+        internal static string GetAbsolutePath(string relativePath, string callerFilePath)
+        {
+            var callerDirectory = Path.GetDirectoryName(callerFilePath);
+            // ReSharper disable once AssignNullToNotNullAttribute
+            var absolutePath = Path.GetFullPath(Path.Combine(callerDirectory, relativePath));
+
+            var assetsIndexOf = absolutePath.IndexOf("Assets", StringComparison.Ordinal);
+            if (assetsIndexOf > 0)
+            {
+                return ConvertToUnixPathSeparator(absolutePath.Substring(assetsIndexOf));
+            }
+
+            var packageIndexOf = absolutePath.IndexOf("Packages", StringComparison.Ordinal);
+            if (packageIndexOf > 0)
+            {
+                return ConvertToUnixPathSeparator(absolutePath.Substring(packageIndexOf));
+            }
+
+            Debug.LogError($"Can not resolve absolute path. relative: {relativePath}, caller: {callerFilePath}");
+            return null;
+            // Note: Do not use Exception (and Assert). Because freezes async tests on UTF v1.3.4, See UUM-25085.
+
+            string ConvertToUnixPathSeparator(string path)
+            {
+                return path.Replace('\\', '/'); // Normalize path separator
+            }
+        }
+
+        /// <summary>
+        /// Loads the asset file specified by <see cref="LoadAssetAttribute"/> and sets it to the field.
+        /// It is recommended to call this method from the <c>OneTimeSetUp</c> method.
+        /// e.g.,
+        /// <code>
+        /// [OneTimeSetUp]
+        /// public void OneTimeSetUp()
+        /// {
+        ///     LoadAssetAttribute.LoadAssets(this);
+        /// }
+        /// </code>
+        /// </summary>
+        public static void LoadAssets(object testClassInstance)
+        {
+            var type = testClassInstance.GetType();
+            var fields = type.GetFields(
+                BindingFlags.Public | BindingFlags.NonPublic |
+                BindingFlags.Instance | BindingFlags.Static);
+            foreach (var field in fields)
+            {
+                var attribute = GetCustomAttribute(field, typeof(LoadAssetAttribute)) as LoadAssetAttribute;
+                if (attribute == null)
+                {
+                    continue;
+                }
+#if UNITY_EDITOR
+                var asset = AssetDatabase.LoadAssetAtPath(attribute.AssetPath, field.FieldType);
+#else
+                var resourcePath = Path.Combine(
+                    Path.GetDirectoryName(attribute.AssetPath) ?? string.Empty,
+                    Path.GetFileNameWithoutExtension(attribute.AssetPath));
+                var asset = Resources.Load(resourcePath, field.FieldType);
+#endif
+                if (asset == null)
+                {
+                    Debug.LogError($"Failed to load asset at path: {attribute.AssetPath} type: {field.FieldType}");
+                    continue;
+                }
+
+                field.SetValue(testClassInstance, asset);
+            }
+        }
+    }
+}

--- a/Runtime/Attributes/LoadAssetAttribute.cs.meta
+++ b/Runtime/Attributes/LoadAssetAttribute.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b8bb2147875a41968d85c8e72850787e
+timeCreated: 1759850925

--- a/Runtime/Attributes/LoadSceneAttribute.cs
+++ b/Runtime/Attributes/LoadSceneAttribute.cs
@@ -20,29 +20,29 @@ namespace TestHelper.Attributes
     {
         /// <summary>
         /// Load a scene before running this test.
-        ///
+        /// <p/>
         /// This process runs after <c>OneTimeSetUp</c> and before <c>SetUp</c>.
         /// If you want to load during <c>SetUp</c> and testing, use <see cref="BuildSceneAttribute"/> and <see cref="SceneManagerHelper.LoadSceneAsync"/> instead.
-        ///
+        /// <p/>
         /// This attribute has the following benefits:
         /// <list type="bullet">
         ///     <item>The same code can be used for Edit Mode tests and Play Mode tests in Editor and on Player.</item>
-        ///     <item>Scenes that are **NOT** in "Scenes in Build" can be specified.</item>
-        ///     <item>The scene path can be specified by [glob](https://en.wikipedia.org/wiki/Glob_(programming)) pattern. However, there are restrictions, top level and scene name cannot be omitted.</item>
-        ///     <item>The scene path can be specified as a relative path from the test class file.</item>
+        ///     <item>Scene that are **NOT** in "Scenes in Build" can be specified.</item>
+        ///     <item>The scene file path can be specified as a relative path from the test class file.</item>
         /// </list>
         /// </summary>
         /// <param name="path">Scene file path (optional).
-        /// The path starts with `Assets/` or `Packages/` or `.`.
-        /// And package name using `name` instead of `displayName`, when scenes in the package
+        /// The path must starts with `Assets/` or `Packages/` or `.`.
+        /// And package name using `name` instead of `displayName`, when scene file in the package
         /// (e.g., `Packages/com.nowsprinting.test-helper/Tests/Scenes/Scene.unity`).
         /// If the value is omitted, the scene name will be derived from the test file name
-        /// (e.g., `Asset/Tests/ScreenshotTest.cs` will load `Asset/Tests/ScreenshotTest.unity`).</param>
+        /// (e.g., `Asset/Tests/ScreenshotTest.cs` will load `Asset/Tests/ScreenshotTest.unity`).
+        /// </param>
+        /// <param name="callerFilePath">Test file path set by <see cref="CallerFilePathAttribute"/></param>
         /// <remarks>
         /// For the process of including a Scene not in "Scenes in Build" to a build for player, see: <see cref="TestHelper.Editor.TemporaryBuildScenesUsingInTest"/>.
         /// </remarks>
         [SuppressMessage("ReSharper", "ExplicitCallerInfoArgument")]
-        [SuppressMessage("ReSharper", "InvalidXmlDocComment")]
         public LoadSceneAttribute(string path = null, [CallerFilePath] string callerFilePath = null)
             : base(path, callerFilePath)
         {

--- a/RuntimeInternals/SceneManagerHelper.cs
+++ b/RuntimeInternals/SceneManagerHelper.cs
@@ -23,17 +23,17 @@ namespace TestHelper.RuntimeInternals
     public static class SceneManagerHelper
     {
         /// <summary>
-        /// Loading scene file.
+        /// Load a scene.
+        /// <p/>
         /// This attribute has the following benefits:
         /// <list type="bullet">
         ///     <item>The same code can be used for Edit Mode tests and Play Mode tests in Editor and on Player.</item>
-        ///     <item>The scene path can be specified by [glob](https://en.wikipedia.org/wiki/Glob_(programming)) pattern. However, there are restrictions, top level and scene name cannot be omitted.</item>
-        ///     <item>The scene path can be specified as a relative path from the test class file.</item>
+        ///     <item>The scene file path can be specified as a relative path from the test class file.</item>
         /// </list>
         /// </summary>
         /// <param name="path">Scene file path.
-        /// The path starts with `Assets/` or `Packages/` or `.`.
-        /// And package name using `name` instead of `displayName`, when scenes in the package
+        /// The path must starts with `Assets/` or `Packages/` or `.`.
+        /// And package name using `name` instead of `displayName`, when scene file in the package
         /// (e.g., `Packages/com.nowsprinting.test-helper/Tests/Scenes/Scene.unity`).
         /// </param>
         /// <param name="mode">See LoadSceneMode. Not used when called from Edit Mode tests</param>

--- a/Tests/Prefabs.meta
+++ b/Tests/Prefabs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: dfde74a7fdca40b3aabd2a001cf2f38f
+timeCreated: 1759857212

--- a/Tests/Prefabs/Cube.prefab
+++ b/Tests/Prefabs/Cube.prefab
@@ -1,0 +1,110 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4661780220277465302
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8781834426368477492}
+  - component: {fileID: 4377663293640474828}
+  - component: {fileID: 6365332318373769939}
+  - component: {fileID: 8732202031633129458}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8781834426368477492
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4661780220277465302}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4377663293640474828
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4661780220277465302}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &6365332318373769939
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4661780220277465302}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &8732202031633129458
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4661780220277465302}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Tests/Prefabs/Cube.prefab.meta
+++ b/Tests/Prefabs/Cube.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3d515fba48fed4eac834d93c13e3a4be
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/Attributes/LoadAssetAttributeTest.cs
+++ b/Tests/Runtime/Attributes/LoadAssetAttributeTest.cs
@@ -1,0 +1,84 @@
+// Copyright (c) 2023-2025 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace TestHelper.Attributes
+{
+    [TestFixture]
+    public class LoadAssetAttributeTest
+    {
+        [LoadAsset("Packages/com.nowsprinting.test-helper/Tests/Prefabs/Cube.prefab")]
+        private GameObject _prefab;
+
+        [LoadAsset("../../Prefabs/Cube.prefab")]
+        private GameObject _relative;
+
+        [LoadAsset("../../Prefabs/Cube.prefab")]
+        private static GameObject s_static;
+
+        [field: LoadAsset("../../Prefabs/Cube.prefab")]
+        [SuppressMessage("ReSharper", "UnassignedGetOnlyAutoProperty")]
+        private GameObject Prefab { get; }
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            LoadAssetAttribute.LoadAssets(this);
+        }
+
+        [Test]
+        public void LoadAssets_Field_SetAssetField()
+        {
+            Assume.That(_prefab, Is.Not.Null);
+            Assert.That(_prefab.name, Is.EqualTo("Cube"));
+        }
+
+        [Test]
+        public void LoadAssets_FieldWithRelativePath_SetAssetField()
+        {
+            Assume.That(_relative, Is.Not.Null);
+            Assert.That(_relative.name, Is.EqualTo("Cube"));
+        }
+
+        [Test]
+        public void LoadAssets_StaticField_SetAssetField()
+        {
+            Assume.That(s_static, Is.Not.Null);
+            Assert.That(s_static.name, Is.EqualTo("Cube"));
+        }
+
+        [Test]
+        public void LoadAssets_Property_SetAssetField()
+        {
+            Assume.That(Prefab, Is.Not.Null);
+            Assert.That(Prefab.name, Is.EqualTo("Cube"));
+        }
+
+        #region internal methods tests
+
+        private static IEnumerable<TestCaseData> GetAbsolutePathTestCases()
+        {
+            yield return new TestCaseData("./Foo.txt",
+                    "Assets/Tests/Runtime/Caller.cs",
+                    "Assets/Tests/Runtime/Foo.txt")
+                .SetName(nameof(GetAbsolutePath) + "(current path)");
+            yield return new TestCaseData("../../DummyDirectory/../Foo/Bar.txt",
+                    "Packages/com.nowsprinting.test-helper/Tests/Runtime/Attributes/Caller.cs",
+                    "Packages/com.nowsprinting.test-helper/Tests/Foo/Bar.txt")
+                .SetName(nameof(GetAbsolutePath) + "(upstream path)");
+        }
+
+        [TestCaseSource(nameof(GetAbsolutePathTestCases))]
+        public void GetAbsolutePath(string relativePath, string callerFilePath, string expected)
+        {
+            var actual = LoadAssetAttribute.GetAbsolutePath(relativePath, callerFilePath);
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        #endregion
+    }
+}

--- a/Tests/Runtime/Attributes/LoadAssetAttributeTest.cs.meta
+++ b/Tests/Runtime/Attributes/LoadAssetAttributeTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 40964e8684c549838c78c1a6e0ea5de0
+timeCreated: 1759852703


### PR DESCRIPTION
### Added

#### LoadAsset

`LoadAssetAttribute` is a NUnit test attribute class that loads an asset before running the test.

It has the following benefits:

- The same code can be used for Edit Mode tests and Play Mode tests in Editor and on Player.
- The asset file path can be specified as a relative path from the test class file.

This attribute can be placed on the field only.

Usage:

```csharp
[TestFixture]
public class MyTestClass
{
    [LoadAsset("Assets/Path/To/Tests/Prefabs/Cube.prefab")]
    private GameObject _prefab;

    [LoadAsset("../../Prefabs/Sphere.prefab")]
    private GameObject _relative;

    [OneTimeSetUp]
    public void OneTimeSetUp()
    {
        LoadAssetAttribute.LoadAssets(this);
    }

    [Test]
    public void MyTestMethod()
    {
        Assume.That(_prefab, Is.Not.Null);  // already loaded and set to the field.
    }
}
```

> [!IMPORTANT]  
> Tests that use this attribute must call the `LoadAssets` static method from the `OneTimeSetUp`.

> [!NOTE]  
> Properties are not supported. You can place attributes in fields by specifying `[field: LoadAsset]`.

> [!NOTE]  
> The Resources folder copied to run tests on the player is deleted after the run finishes.
> However, if post-processing is not performed, such as if the Unity editor crashes, the "Assets/com.nowsprinting.test-helper/Resources" folder will remain.
> Recommend adding "/Assets/com.nowsprinting.test-helper*" to your project .gitignore file.
