### PR TITLE
Fix relative paths when called from package cache and local packages

### DIFF
--- a/Editor/TemporaryCopyAssetsForPlayer.cs
+++ b/Editor/TemporaryCopyAssetsForPlayer.cs
@@ -5,10 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using TestHelper.Attributes;
 using UnityEditor;
 using UnityEngine;
+#if !UNITY_2020_1_OR_NEWER
+using System.Reflection;
+#endif
 
 namespace TestHelper.Editor
 {
@@ -20,7 +22,7 @@ namespace TestHelper.Editor
     /// </remarks>
     internal static class TemporaryCopyAssetsForPlayer
     {
-        internal const string ResourcesRoot = "Assets/com.nowsprinting.test-helper";
+        internal const string ResourcesParent = "Assets/com.nowsprinting.test-helper";
 
         private static IEnumerable<T> FindAttributesOnFields<T>() where T : Attribute
         {
@@ -44,97 +46,22 @@ namespace TestHelper.Editor
 #endif
         }
 
-        private static IEnumerable<(LoadAssetAttribute attribute, string originalPath)>
-            FindAttributesOnFieldsWithOriginalPath()
-        {
-#if UNITY_2020_1_OR_NEWER
-            var fields = TypeCache.GetFieldsWithAttribute<LoadAssetAttribute>();
-            foreach (var field in fields)
-            {
-                var attribute = field.GetCustomAttribute<LoadAssetAttribute>();
-                if (attribute == null)
-                {
-                    continue;
-                }
-
-                var attrData = field.GetCustomAttributesData()
-                    .FirstOrDefault(a => a.AttributeType == typeof(LoadAssetAttribute));
-                var originalPath = attrData?.ConstructorArguments[0].Value as string;
-
-                yield return (attribute, originalPath);
-            }
-#else
-            foreach (var field in AppDomain.CurrentDomain.GetAssemblies()
-                         .SelectMany(x => x.GetTypes())
-                         .SelectMany(x => x.GetFields(
-                             BindingFlags.Public | BindingFlags.NonPublic |
-                             BindingFlags.Instance | BindingFlags.Static)))
-            {
-                var attribute = field.GetCustomAttribute<LoadAssetAttribute>();
-                if (attribute == null)
-                {
-                    continue;
-                }
-
-                var attrData = field.GetCustomAttributesData()
-                    .FirstOrDefault(a => a.AttributeType == typeof(LoadAssetAttribute));
-                var originalPath = attrData?.ConstructorArguments[0].Value as string;
-
-                yield return (attribute, originalPath);
-            }
-#endif
-        }
-
         internal static void CopyAssetFiles()
         {
-            foreach (var (attribute, originalPath) in FindAttributesOnFieldsWithOriginalPath())
+            foreach (var attribute in FindAttributesOnFields<LoadAssetAttribute>())
             {
-                var realPath = CalculateRealPath(attribute, originalPath);
-                var destFileName = Path.Combine(ResourcesRoot, "Resources", realPath);
-                var destDir = Path.GetDirectoryName(destFileName);
+                var destFilePath = Path.Combine(ResourcesParent, "Resources", attribute.ResourcePath);
+                var destDir = Path.GetDirectoryName(destFilePath);
                 if (destDir != null && !Directory.Exists(destDir))
                 {
                     Directory.CreateDirectory(destDir);
                 }
 
-                if (!AssetDatabase.CopyAsset(attribute.AssetPath, destFileName))
+                if (!AssetDatabase.CopyAsset(attribute.AssetPath, destFilePath))
                 {
-                    Debug.LogError($"Failed to copy asset file from '{attribute.AssetPath}' to '{destFileName}'");
+                    Debug.LogError($"Failed to copy asset file from '{attribute.AssetPath}' to '{destFilePath}'");
                 }
             }
-        }
-
-        private static string CalculateRealPath(LoadAssetAttribute attribute, string originalPath)
-        {
-            if (originalPath != null && originalPath.StartsWith("."))
-            {
-                var callerFilePath = attribute.CallerFilePath;
-                var callerDirectory = Path.GetDirectoryName(callerFilePath);
-
-                // Use Uri to resolve relative paths
-                var baseUri = new Uri($"file:///{callerDirectory?.Replace('\\', '/')}/");
-                var relativeUri = new Uri(baseUri, originalPath);
-                var resolvedPath = relativeUri.LocalPath.TrimStart('/').Replace('\\', '/');
-
-                // Get project root
-                var projectRoot = Path.GetFullPath(Directory.GetCurrentDirectory()).Replace('\\', '/');
-                if (!projectRoot.EndsWith("/"))
-                {
-                    projectRoot += "/";
-                }
-
-                // Convert to relative path from project root if it's absolute
-                if (resolvedPath.Contains(":") && resolvedPath.StartsWith(projectRoot))
-                {
-                    return resolvedPath.Substring(projectRoot.Length);
-                }
-
-                // Already a relative path
-                return resolvedPath;
-            }
-
-            // Fallback: use originalPath if available, otherwise use AssetPath
-            return originalPath ?? attribute.AssetPath;
         }
     }
 }

--- a/Editor/TestRunnerCallbacks.cs
+++ b/Editor/TestRunnerCallbacks.cs
@@ -42,9 +42,9 @@ namespace TestHelper.Editor
             }
 
             // Delete temporary copied asset files for running play mode tests on player.
-            if (Directory.Exists(TemporaryCopyAssetsForPlayer.ResourcesRoot))
+            if (Directory.Exists(TemporaryCopyAssetsForPlayer.ResourcesParent))
             {
-                AssetDatabase.DeleteAsset(TemporaryCopyAssetsForPlayer.ResourcesRoot);
+                AssetDatabase.DeleteAsset(TemporaryCopyAssetsForPlayer.ResourcesParent);
                 // Note: delete with .meta file.
             }
         }

--- a/Runtime/Attributes/LoadAssetAttribute.cs
+++ b/Runtime/Attributes/LoadAssetAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
@@ -44,39 +44,11 @@ namespace TestHelper.Attributes
         {
             if (path.StartsWith("."))
             {
-                AssetPath = GetAbsolutePath(path, callerFilePath);
+                AssetPath = RuntimeInternals.PathHelper.ResolveUnityPath(path, callerFilePath);
             }
             else
             {
                 AssetPath = path;
-            }
-        }
-
-        internal static string GetAbsolutePath(string relativePath, string callerFilePath)
-        {
-            var callerDirectory = Path.GetDirectoryName(callerFilePath);
-            // ReSharper disable once AssignNullToNotNullAttribute
-            var absolutePath = Path.GetFullPath(Path.Combine(callerDirectory, relativePath));
-
-            var assetsIndexOf = absolutePath.IndexOf("Assets", StringComparison.Ordinal);
-            if (assetsIndexOf > 0)
-            {
-                return ConvertToUnixPathSeparator(absolutePath.Substring(assetsIndexOf));
-            }
-
-            var packageIndexOf = absolutePath.IndexOf("Packages", StringComparison.Ordinal);
-            if (packageIndexOf > 0)
-            {
-                return ConvertToUnixPathSeparator(absolutePath.Substring(packageIndexOf));
-            }
-
-            Debug.LogError($"Can not resolve absolute path. relative: {relativePath}, caller: {callerFilePath}");
-            return null;
-            // Note: Do not use Exception (and Assert). Because freezes async tests on UTF v1.3.4, See UUM-25085.
-
-            string ConvertToUnixPathSeparator(string path)
-            {
-                return path.Replace('\\', '/'); // Normalize path separator
             }
         }
 

--- a/Runtime/Attributes/LoadAssetAttribute.cs
+++ b/Runtime/Attributes/LoadAssetAttribute.cs
@@ -2,11 +2,10 @@
 // This software is released under the MIT License.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using TestHelper.RuntimeInternals;
 using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -17,9 +16,10 @@ namespace TestHelper.Attributes
     [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
     public class LoadAssetAttribute : Attribute
     {
+#if UNITY_EDITOR
         internal string AssetPath { get; private set; }
-
-        internal string CallerFilePath { get; private set; }
+#endif
+        internal string ResourcePath { get; private set; }
 
         /// <summary>
         /// Loads an asset file at the specified path into the field.
@@ -41,25 +41,63 @@ namespace TestHelper.Attributes
         /// </param>
         /// <param name="callerFilePath">Test file path set by <see cref="CallerFilePathAttribute"/></param>
         /// <remarks>
-        /// When running tests on the player, it temporarily copies asset files to the <c>Resources</c> folder by <see cref="TestHelper.Editor.TemporaryCopyAssetsForPlayer"/>.
+        /// When running tests on the player, it temporarily copies asset files to the <c>Resources</c> folder by <see cref="Editor.TemporaryCopyAssetsForPlayer"/>.
         /// </remarks>
         public LoadAssetAttribute(string path, [CallerFilePath] string callerFilePath = null)
         {
-            CallerFilePath = callerFilePath;
-
-            if (path.StartsWith("."))
-            {
 #if UNITY_EDITOR
-                AssetPath = RuntimeInternals.PathHelper.ResolveUnityPath(path, callerFilePath);
-#else
-                // Will be resolved at runtime in GetResourcePath() for standalone player
-                AssetPath = null;
-#endif
+            if (path != null && path.StartsWith("."))
+            {
+                AssetPath = PathHelper.ResolveUnityPath(path, callerFilePath);
             }
             else
             {
-                AssetPath = path;
+                AssetPath = PathHelper.ResolveUnityPath(path);
             }
+#endif
+            if (path != null && path.StartsWith("."))
+            {
+                ResourcePath = BuildResourcePath(path, callerFilePath);
+            }
+            else
+            {
+                ResourcePath = BuildResourcePath(path);
+            }
+        }
+
+        private static string BuildResourcePath(string relativePath, string callerFilePath)
+        {
+            var callerDirectory = Path.GetDirectoryName(callerFilePath);
+            var absolutePath = Path.GetFullPath(Path.Combine(callerDirectory!, relativePath));
+
+            var assetsIndexOf = absolutePath.IndexOf(
+                $"{Path.DirectorySeparatorChar}Assets{Path.DirectorySeparatorChar}",
+                StringComparison.Ordinal);
+            if (assetsIndexOf >= 0)
+            {
+                return BuildResourcePath(absolutePath.Substring(assetsIndexOf + 1));
+            }
+
+            // Next, look for Packages/ (ensure it's a directory, not part of another name like "LocalPackages")
+            var packageIndexOf =
+                absolutePath.IndexOf($"{Path.DirectorySeparatorChar}Packages{Path.DirectorySeparatorChar}",
+                    StringComparison.Ordinal);
+            if (packageIndexOf >= 0)
+            {
+                return BuildResourcePath(absolutePath.Substring(packageIndexOf + 1));
+            }
+
+            return BuildResourcePath(absolutePath);
+        }
+
+        private static string BuildResourcePath(string absolutePath)
+        {
+            // Convert to resource path (remove extension)
+            var directoryName = Path.Join("com.nowsprinting.test-helper", Path.GetDirectoryName(absolutePath)); // TODO: Path.Join
+            var filenameWithoutExtension = Path.GetFileNameWithoutExtension(absolutePath);
+            return string.IsNullOrEmpty(directoryName)
+                ? filenameWithoutExtension
+                : $"{directoryName.Replace('\\', '/')}/{filenameWithoutExtension}";
         }
 
         /// <summary>
@@ -89,70 +127,21 @@ namespace TestHelper.Attributes
                 }
 #if UNITY_EDITOR
                 var asset = AssetDatabase.LoadAssetAtPath(attribute.AssetPath, field.FieldType);
-#else
-                var originalPath = GetOriginalPathFromAttribute(field);
-                var resourcePath = GetResourcePath(attribute, originalPath);
-                var asset = Resources.Load(resourcePath, field.FieldType);
-#endif
                 if (asset == null)
                 {
                     Debug.LogError($"Failed to load asset at path: {attribute.AssetPath} type: {field.FieldType}");
                     continue;
                 }
-
+#else
+                var asset = Resources.Load(attribute.ResourcePath, field.FieldType);
+                if (asset == null)
+                {
+                    Debug.LogError($"Failed to load asset at path: {attribute.ResourcePath} type: {field.FieldType}");
+                    continue;
+                }
+#endif
                 field.SetValue(testClassInstance, asset);
             }
-        }
-
-        [SuppressMessage("ReSharper", "UnusedMember.Local")]
-        private static string GetOriginalPathFromAttribute(FieldInfo field)
-        {
-            var attrData = field.GetCustomAttributesData()
-                .FirstOrDefault(a => a.AttributeType == typeof(LoadAssetAttribute));
-            return attrData?.ConstructorArguments[0].Value as string;
-        }
-
-        [SuppressMessage("ReSharper", "UnusedMember.Local")]
-        private static string GetResourcePath(LoadAssetAttribute attribute, string originalPath)
-        {
-            var callerFilePath = attribute.CallerFilePath;
-            if (callerFilePath != null && originalPath != null && originalPath.StartsWith("."))
-            {
-                // Remove leading "./" from CallerFilePath if present
-                callerFilePath = callerFilePath.TrimStart('.', '/', '\\');
-
-                var callerDirectory = Path.GetDirectoryName(callerFilePath);
-
-                // Use Uri to resolve relative paths without depending on file system
-                var baseUri = new Uri($"file:///{callerDirectory?.Replace('\\', '/')}/");
-                var relativeUri = new Uri(baseUri, originalPath);
-                var realPath = relativeUri.LocalPath.TrimStart('/').Replace('\\', '/');
-
-                // Convert to resource path (remove extension)
-                var directoryName = Path.GetDirectoryName(realPath);
-                var filenameWithoutExtension = Path.GetFileNameWithoutExtension(realPath);
-                return string.IsNullOrEmpty(directoryName)
-                    ? filenameWithoutExtension
-                    : $"{directoryName.Replace('\\', '/')}/{filenameWithoutExtension}";
-            }
-
-            // Fallback to legacy behavior
-            return GetLegacyResourcePath(attribute.AssetPath);
-        }
-
-        [SuppressMessage("ReSharper", "UnusedMember.Local")]
-        private static string GetLegacyResourcePath(string assetPath)
-        {
-            if (assetPath == null)
-            {
-                return null;
-            }
-
-            var directoryName = Path.GetDirectoryName(assetPath);
-            var filenameWithoutExtension = Path.GetFileNameWithoutExtension(assetPath);
-            return string.IsNullOrEmpty(directoryName)
-                ? filenameWithoutExtension
-                : $"{directoryName.Replace('\\', '/')}/{filenameWithoutExtension}";
         }
     }
 }

--- a/RuntimeInternals/PathHelper.cs
+++ b/RuntimeInternals/PathHelper.cs
@@ -156,18 +156,18 @@ namespace TestHelper.RuntimeInternals
             // ReSharper disable once AssignNullToNotNullAttribute
             var absolutePath = Path.GetFullPath(Path.Combine(callerDirectory, relativePath));
 
-            // First, look for Assets/
-            var assetsIndexOf = absolutePath.IndexOf("Assets", StringComparison.Ordinal);
-            if (assetsIndexOf > 0)
+            // First, look for Assets/ (ensure it's a directory, not part of another name)
+            var assetsIndexOf = absolutePath.IndexOf($"{Path.DirectorySeparatorChar}Assets{Path.DirectorySeparatorChar}", StringComparison.Ordinal);
+            if (assetsIndexOf >= 0)
             {
-                return ConvertToUnixPathSeparator(absolutePath.Substring(assetsIndexOf));
+                return ConvertToUnixPathSeparator(absolutePath.Substring(assetsIndexOf + 1));
             }
 
-            // Next, look for Packages/
-            var packageIndexOf = absolutePath.IndexOf("Packages", StringComparison.Ordinal);
-            if (packageIndexOf > 0)
+            // Next, look for Packages/ (ensure it's a directory, not part of another name like "LocalPackages")
+            var packageIndexOf = absolutePath.IndexOf($"{Path.DirectorySeparatorChar}Packages{Path.DirectorySeparatorChar}", StringComparison.Ordinal);
+            if (packageIndexOf >= 0)
             {
-                return ConvertToUnixPathSeparator(absolutePath.Substring(packageIndexOf));
+                return ConvertToUnixPathSeparator(absolutePath.Substring(packageIndexOf + 1));
             }
 
             // If neither found, it might be an Embedded package

--- a/RuntimeInternals/PathHelper.cs
+++ b/RuntimeInternals/PathHelper.cs
@@ -157,14 +157,18 @@ namespace TestHelper.RuntimeInternals
             var absolutePath = Path.GetFullPath(Path.Combine(callerDirectory, relativePath));
 
             // First, look for Assets/ (ensure it's a directory, not part of another name)
-            var assetsIndexOf = absolutePath.IndexOf($"{Path.DirectorySeparatorChar}Assets{Path.DirectorySeparatorChar}", StringComparison.Ordinal);
+            var assetsIndexOf =
+                absolutePath.IndexOf($"{Path.DirectorySeparatorChar}Assets{Path.DirectorySeparatorChar}",
+                    StringComparison.Ordinal);
             if (assetsIndexOf >= 0)
             {
                 return ConvertToUnixPathSeparator(absolutePath.Substring(assetsIndexOf + 1));
             }
 
             // Next, look for Packages/ (ensure it's a directory, not part of another name like "LocalPackages")
-            var packageIndexOf = absolutePath.IndexOf($"{Path.DirectorySeparatorChar}Packages{Path.DirectorySeparatorChar}", StringComparison.Ordinal);
+            var packageIndexOf =
+                absolutePath.IndexOf($"{Path.DirectorySeparatorChar}Packages{Path.DirectorySeparatorChar}",
+                    StringComparison.Ordinal);
             if (packageIndexOf >= 0)
             {
                 return ConvertToUnixPathSeparator(absolutePath.Substring(packageIndexOf + 1));
@@ -175,7 +179,8 @@ namespace TestHelper.RuntimeInternals
             var projectRoot = FindProjectRoot(absolutePath);
             if (projectRoot != null)
             {
-                var relativeFromRoot = absolutePath.Substring(projectRoot.Length).TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                var relativeFromRoot = absolutePath.Substring(projectRoot.Length)
+                    .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
                 var unityPath = ConvertToUnityPath(relativeFromRoot, projectRoot);
                 if (unityPath != null)
                 {

--- a/RuntimeInternals/PathHelper.cs
+++ b/RuntimeInternals/PathHelper.cs
@@ -153,8 +153,28 @@ namespace TestHelper.RuntimeInternals
         internal static string ResolveUnityPath(string relativePath, string callerFilePath)
         {
             var callerDirectory = Path.GetDirectoryName(callerFilePath);
-            // ReSharper disable once AssignNullToNotNullAttribute
-            var absolutePath = Path.GetFullPath(Path.Combine(callerDirectory, relativePath));
+            var absolutePath = Path.GetFullPath(Path.Combine(callerDirectory!, relativePath));
+            return ResolveUnityPath(absolutePath);
+        }
+
+        /// <summary>
+        /// Resolves an absolute path to Unity path format (Assets/ or Packages/).
+        /// </summary>
+        /// <param name="absolutePath">Absolute file path</param>
+        /// <returns>Unity path format (e.g., "Assets/...", "Packages/...")</returns>
+        internal static string ResolveUnityPath(string absolutePath)
+        {
+            if (!Application.isEditor)
+            {
+                throw new InvalidOperationException("ResolveUnityPath can be used only in the Editor.");
+            }
+
+            if (absolutePath.StartsWith($"Assets{Path.DirectorySeparatorChar}") ||
+                absolutePath.StartsWith($"Packages{Path.DirectorySeparatorChar}"))
+            {
+                // Already in Unity path format
+                return absolutePath;
+            }
 
             // First, look for Assets/ (ensure it's a directory, not part of another name)
             var assetsIndexOf =
@@ -188,10 +208,11 @@ namespace TestHelper.RuntimeInternals
                 }
             }
 
-            Debug.LogError($"Can not resolve absolute path. relative: {relativePath}, caller: {callerFilePath}");
+            Debug.LogError($"Can not resolve from absolute path: {absolutePath}");
             return null;
             // Note: Do not use Exception (and Assert). Because freezes async tests on UTF v1.3.4, See UUM-25085.
 
+            // Local function
             string ConvertToUnixPathSeparator(string path)
             {
                 return path.Replace('\\', '/');

--- a/RuntimeInternals/SceneManagerHelper.cs
+++ b/RuntimeInternals/SceneManagerHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
@@ -90,7 +90,7 @@ namespace TestHelper.RuntimeInternals
         {
             if (path.StartsWith("."))
             {
-                path = GetAbsolutePath(path, callerFilePath);
+                path = PathHelper.ResolveUnityPath(path, callerFilePath);
             }
 
             if (!ValidatePath(path))
@@ -102,34 +102,6 @@ namespace TestHelper.RuntimeInternals
 #else
             return GetExistScenePathOnPlayer(path);
 #endif
-        }
-
-        internal static string GetAbsolutePath(string relativePath, string callerFilePath)
-        {
-            var callerDirectory = Path.GetDirectoryName(callerFilePath);
-            // ReSharper disable once AssignNullToNotNullAttribute
-            var absolutePath = Path.GetFullPath(Path.Combine(callerDirectory, relativePath));
-
-            var assetsIndexOf = absolutePath.IndexOf("Assets", StringComparison.Ordinal);
-            if (assetsIndexOf > 0)
-            {
-                return ConvertToUnixPathSeparator(absolutePath.Substring(assetsIndexOf));
-            }
-
-            var packageIndexOf = absolutePath.IndexOf("Packages", StringComparison.Ordinal);
-            if (packageIndexOf > 0)
-            {
-                return ConvertToUnixPathSeparator(absolutePath.Substring(packageIndexOf));
-            }
-
-            Debug.LogError($"Can not resolve absolute path. relative: {relativePath}, caller: {callerFilePath}");
-            return null;
-            // Note: Do not use Exception (and Assert). Because freezes async tests on UTF v1.3.4, See UUM-25085.
-
-            string ConvertToUnixPathSeparator(string path)
-            {
-                return path.Replace('\\', '/'); // Normalize path separator
-            }
         }
 
         private static bool ValidatePath(string path)

--- a/RuntimeInternals/SceneManagerHelper.cs
+++ b/RuntimeInternals/SceneManagerHelper.cs
@@ -88,6 +88,7 @@ namespace TestHelper.RuntimeInternals
         /// <exception cref="FileNotFoundException">Scene file not found</exception>
         internal static string GetExistScenePath(string path, string callerFilePath)
         {
+#if UNITY_EDITOR
             if (path.StartsWith("."))
             {
                 path = PathHelper.ResolveUnityPath(path, callerFilePath);
@@ -97,9 +98,11 @@ namespace TestHelper.RuntimeInternals
             {
                 return null;
             }
-#if UNITY_EDITOR
+
             return GetExistScenePathInEditor(path);
 #else
+            // On player, skip path resolution and validation
+            // GetExistScenePathOnPlayer() extracts only the scene name from the path
             return GetExistScenePathOnPlayer(path);
 #endif
         }

--- a/Tests/Runtime/Attributes/LoadAssetAttributeTest.cs
+++ b/Tests/Runtime/Attributes/LoadAssetAttributeTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Collections.Generic;
@@ -69,28 +69,5 @@ namespace TestHelper.Attributes
             Assert.That(_texture2d.width, Is.EqualTo(640));
             Assert.That(_texture2d.height, Is.EqualTo(480));
         }
-
-        #region internal methods tests
-
-        private static IEnumerable<TestCaseData> GetAbsolutePathTestCases()
-        {
-            yield return new TestCaseData("./Foo.txt",
-                    "Assets/Tests/Runtime/Caller.cs",
-                    "Assets/Tests/Runtime/Foo.txt")
-                .SetName(nameof(GetAbsolutePath) + "(current path)");
-            yield return new TestCaseData("../../DummyDirectory/../Foo/Bar.txt",
-                    "Packages/com.nowsprinting.test-helper/Tests/Runtime/Attributes/Caller.cs",
-                    "Packages/com.nowsprinting.test-helper/Tests/Foo/Bar.txt")
-                .SetName(nameof(GetAbsolutePath) + "(upstream path)");
-        }
-
-        [TestCaseSource(nameof(GetAbsolutePathTestCases))]
-        public void GetAbsolutePath(string relativePath, string callerFilePath, string expected)
-        {
-            var actual = LoadAssetAttribute.GetAbsolutePath(relativePath, callerFilePath);
-            Assert.That(actual, Is.EqualTo(expected));
-        }
-
-        #endregion
     }
 }

--- a/Tests/Runtime/Attributes/LoadAssetAttributeTest.cs
+++ b/Tests/Runtime/Attributes/LoadAssetAttributeTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using NUnit.Framework;
 using UnityEngine;

--- a/Tests/RuntimeInternals/PathHelperTest.cs
+++ b/Tests/RuntimeInternals/PathHelperTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.IO;
@@ -207,6 +207,24 @@ namespace TestHelper.RuntimeInternals
 
             PathHelper.CreateFilePath(baseDirectory: baseDirectory, createDirectory: false);
             Assert.That(baseDirectory, Does.Not.Exist);
+        }
+
+        [TestCase("./Scene.unity",
+            "Assets/Tests/Runtime/Caller.cs",
+            "Assets/Tests/Runtime/Scene.unity")]
+        [TestCase("../../BadPath/../Scenes/Scene.unity",
+            "Packages/com.nowsprinting.test-helper/Tests/Runtime/Attributes/Caller.cs",
+            "Packages/com.nowsprinting.test-helper/Tests/Scenes/Scene.unity")]
+        [TestCase("./Foo.txt",
+            "Assets/Tests/Runtime/Caller.cs",
+            "Assets/Tests/Runtime/Foo.txt")]
+        [TestCase("../../DummyDirectory/../Foo/Bar.txt",
+            "Packages/com.nowsprinting.test-helper/Tests/Runtime/Attributes/Caller.cs",
+            "Packages/com.nowsprinting.test-helper/Tests/Foo/Bar.txt")]
+        public void ResolveUnityPath(string relativePath, string callerFilePath, string expected)
+        {
+            var actual = PathHelper.ResolveUnityPath(relativePath, callerFilePath);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         #endregion

--- a/Tests/RuntimeInternals/PathHelperTest.cs
+++ b/Tests/RuntimeInternals/PathHelperTest.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace TestHelper.RuntimeInternals
 {
@@ -209,18 +210,19 @@ namespace TestHelper.RuntimeInternals
             Assert.That(baseDirectory, Does.Not.Exist);
         }
 
+        [TestCase("Assets/AbsolutePath/Scene.unity",
+            "Assets/Tests/Runtime/Caller.cs",
+            "Assets/AbsolutePath/Scene.unity")] // equals relative path
+        [TestCase("Packages/com.nowsprinting.test-helper/AbsolutePath/Scene.unity",
+            "Packages/com.nowsprinting.test-helper/Tests/Runtime/Caller.cs",
+            "Packages/com.nowsprinting.test-helper/AbsolutePath/Scene.unity")] // equals relative path
         [TestCase("./Scene.unity",
             "Assets/Tests/Runtime/Caller.cs",
-            "Assets/Tests/Runtime/Scene.unity")]
+            "Assets/Tests/Runtime/Scene.unity")] // relative path
         [TestCase("../../BadPath/../Scenes/Scene.unity",
             "Packages/com.nowsprinting.test-helper/Tests/Runtime/Attributes/Caller.cs",
-            "Packages/com.nowsprinting.test-helper/Tests/Scenes/Scene.unity")]
-        [TestCase("./Foo.txt",
-            "Assets/Tests/Runtime/Caller.cs",
-            "Assets/Tests/Runtime/Foo.txt")]
-        [TestCase("../../DummyDirectory/../Foo/Bar.txt",
-            "Packages/com.nowsprinting.test-helper/Tests/Runtime/Attributes/Caller.cs",
-            "Packages/com.nowsprinting.test-helper/Tests/Foo/Bar.txt")]
+            "Packages/com.nowsprinting.test-helper/Tests/Scenes/Scene.unity")] // relative path need normalization
+        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
         public void ResolveUnityPath(string relativePath, string callerFilePath, string expected)
         {
             var actual = PathHelper.ResolveUnityPath(relativePath, callerFilePath);

--- a/Tests/RuntimeInternals/SceneManagerHelperTest.cs
+++ b/Tests/RuntimeInternals/SceneManagerHelperTest.cs
@@ -1,12 +1,14 @@
-// Copyright (c) 2023-2024 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Cysharp.Threading.Tasks; // Required for Unity 2022 or older
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
+#if !UNITY_2022_1_OR_NEWER
+using Cysharp.Threading.Tasks; // Required for Unity 2022 or older
+#endif
 
 namespace TestHelper.RuntimeInternals
 {
@@ -23,18 +25,6 @@ namespace TestHelper.RuntimeInternals
             await SceneManagerHelper.LoadSceneAsync(path);
             var cube = GameObject.Find("CubeInNotInScenesInBuild");
             Assume.That(cube, Is.Not.Null);
-        }
-
-        [TestCase("./Scene.unity", // include `./`
-            "Assets/Tests/Runtime/Caller.cs",
-            "Assets/Tests/Runtime/Scene.unity")]
-        [TestCase("../../BadPath/../Scenes/Scene.unity", // include `../`
-            "Packages/com.nowsprinting.test-helper/Tests/Runtime/Attributes/Caller.cs",
-            "Packages/com.nowsprinting.test-helper/Tests/Scenes/Scene.unity")]
-        public void GetAbsolutePath(string relativePath, string callerFilePath, string expected)
-        {
-            var actual = SceneManagerHelper.GetAbsolutePath(relativePath, callerFilePath);
-            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [TestCase("Packages/com.nowsprinting.test-helper/Tests/Scenes/NotInScenesInBuild.unity")]

--- a/Tests/RuntimeInternals/SceneManagerHelperTest.cs
+++ b/Tests/RuntimeInternals/SceneManagerHelperTest.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
-#if !UNITY_2022_1_OR_NEWER
+#if !UNITY_2023_1_OR_NEWER
 using Cysharp.Threading.Tasks; // Required for Unity 2022 or older
 #endif
 
@@ -60,7 +60,7 @@ namespace TestHelper.RuntimeInternals
         }
 
         [TestCase("Packages/com.nowsprinting.test-helper/Tests/Scenes/NotExistScene.unity")] // Not exist path
-        [TestCase("Packages/com.nowsprinting.test-helper/*/NotInScenesInBuild.unity")] // Not match path pattern
+        [TestCase("Packages/com.nowsprinting.test-helper/*/NotInScenesInBuild.unity")]       // Not match path pattern
         [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
         // Note: Returns scene name when running on player.
         public void GetExistScenePath_NotExistPath_InEditor_OutputLogError(string path)

--- a/Tests/RuntimeInternals/SceneManagerHelperTest.cs
+++ b/Tests/RuntimeInternals/SceneManagerHelperTest.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 #if !UNITY_2023_1_OR_NEWER
-using Cysharp.Threading.Tasks; // Required for Unity 2022 or older
+using Cysharp.Threading.Tasks;
 #endif
 
 namespace TestHelper.RuntimeInternals

--- a/Tests/RuntimeInternals/ScreenshotHelperTest.cs
+++ b/Tests/RuntimeInternals/ScreenshotHelperTest.cs
@@ -199,6 +199,7 @@ namespace TestHelper.RuntimeInternals
 
 #if UNITY_2023_1_OR_NEWER
         [Test]
+        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
         [GameViewResolution(GameViewResolution.VGA)]
         [LoadScene(TestScene)]
         public async Task TakeScreenshotAsPngBytesAsync_ReturnsPngBytes()


### PR DESCRIPTION
### Problem

When using local packages (referenced via `file:` in manifest) or packages from the cache (`Library/PackageCache/`), `Path.GetFullPath` returns the actual filesystem path instead of the Unity virtual path.

For example, with a local package:

- Unity virtual path: `Packages/com.nowsprinting.test-helper/Tests/Scenes/Scene.unity`
- Actual filesystem path: `/Users/.../project-root/test-helper/Tests/Scenes/Scene.unity`

The previous implementation searched for `Assets/` or `Packages/` in the resolved absolute path, but neither exists in the actual filesystem path.

### Fixes

- Add PathHelper.ResolveUnityPath() to resolve relative paths to Unity format
- Remove duplicate GetAbsolutePath() from LoadAssetAttribute and SceneManagerHelper
- Support Embedded packages by detecting package.json and converting paths