### PR TITLE
Respect EXCLUDE_INSTANTREPLAY scripting symbol

### DIFF
--- a/Runtime/Attributes/RecordVideoAttribute.cs
+++ b/Runtime/Attributes/RecordVideoAttribute.cs
@@ -1,7 +1,7 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
-#if ENABLE_INSTANT_REPLAY
+#if ENABLE_INSTANT_REPLAY && !EXCLUDE_INSTANTREPLAY
 using System;
 using System.Collections;
 using System.IO;

--- a/Tests/Runtime/Attributes/RecordVideoAttributeTest.cs
+++ b/Tests/Runtime/Attributes/RecordVideoAttributeTest.cs
@@ -1,7 +1,7 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
-#if ENABLE_INSTANT_REPLAY
+#if ENABLE_INSTANT_REPLAY && !EXCLUDE_INSTANTREPLAY
 using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;


### PR DESCRIPTION
### Changes

Disable the `RecordVideo` attribute if the `EXCLUDE_INSTANTREPLAY` scripting symbol is specified.

see: https://github.com/CyberAgentGameEntertainment/InstantReplay#excluding-from-the-release-builds