### PR TITLE
Treat CS0618 (obsolete) as error and unuse obsolete properties

### DIFF
--- a/Editor/TestHelper.Editor.globalconfig
+++ b/Editor/TestHelper.Editor.globalconfig
@@ -1,0 +1,2 @@
+is_global = true
+dotnet_diagnostic.CS0618.severity = error

--- a/Editor/TestHelper.Editor.globalconfig.meta
+++ b/Editor/TestHelper.Editor.globalconfig.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ba1485395115e4401b6cb6a58ba00f22
+RoslynAnalyzerConfigImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Attributes/RecordVideoAttribute.cs
+++ b/Runtime/Attributes/RecordVideoAttribute.cs
@@ -9,7 +9,6 @@ using InstantReplay;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using TestHelper.RuntimeInternals;
-using UniEnc;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -106,26 +105,13 @@ namespace TestHelper.Attributes
 
         private RealtimeEncodingOptions CreateOptions()
         {
-            return new RealtimeEncodingOptions
-            {
-                VideoOptions = new VideoEncoderOptions
-                {
-                    Width = Math.Min(_width, (uint)Screen.width),
-                    Height = Math.Min(_height, (uint)Screen.height),
-                    FpsHint = _fpsHint,
-                    Bitrate = 2500000 // 2.5 Mbps
-                },
-                AudioOptions = new AudioEncoderOptions
-                {
-                    SampleRate = 44100,
-                    Channels = 2,
-                    Bitrate = 128000 // 128 kbps
-                },
-                MaxMemoryUsageBytes = 20 * 1024 * 1024, // 20 MiB
-                FixedFrameRate = 30.0, // null if not using fixed frame rate
-                VideoInputQueueSize = 5, // Maximum number of raw frames to keep before encoding
-                AudioInputQueueSize = 60, // Maximum number of raw audio sample frames to keep before encoding
-            };
+            var options = RealtimeEncodingOptions.Default;
+            var videoOptions = options.VideoOptions;
+            videoOptions.Width = Math.Min(_width, (uint)Screen.width);
+            videoOptions.Height = Math.Min(_height, (uint)Screen.height);
+            videoOptions.FpsHint = _fpsHint;
+            options.VideoOptions = videoOptions;
+            return options;
         }
     }
 }

--- a/Runtime/TestHelper.globalconfig
+++ b/Runtime/TestHelper.globalconfig
@@ -1,0 +1,2 @@
+is_global = true
+dotnet_diagnostic.CS0618.severity = error

--- a/Runtime/TestHelper.globalconfig.meta
+++ b/Runtime/TestHelper.globalconfig.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9f6607e197f784c39b723d1e81420722
+RoslynAnalyzerConfigImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RuntimeInternals/TestHelper.RuntimeInternals.globalconfig
+++ b/RuntimeInternals/TestHelper.RuntimeInternals.globalconfig
@@ -1,0 +1,2 @@
+is_global = true
+dotnet_diagnostic.CS0618.severity = error

--- a/RuntimeInternals/TestHelper.RuntimeInternals.globalconfig.meta
+++ b/RuntimeInternals/TestHelper.RuntimeInternals.globalconfig.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: af36e9dd5b2dc462484396db8076d071
+RoslynAnalyzerConfigImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/TestHelper.Editor.Tests.globalconfig
+++ b/Tests/Editor/TestHelper.Editor.Tests.globalconfig
@@ -1,0 +1,2 @@
+is_global = true
+dotnet_diagnostic.CS0618.severity = error

--- a/Tests/Editor/TestHelper.Editor.Tests.globalconfig.meta
+++ b/Tests/Editor/TestHelper.Editor.Tests.globalconfig.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5412600a0948c4342901c67f678b4be4
+RoslynAnalyzerConfigImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/TestHelper.Tests.globalconfig
+++ b/Tests/Runtime/TestHelper.Tests.globalconfig
@@ -1,0 +1,2 @@
+is_global = true
+dotnet_diagnostic.CS0618.severity = error

--- a/Tests/Runtime/TestHelper.Tests.globalconfig.meta
+++ b/Tests/Runtime/TestHelper.Tests.globalconfig.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9ddecb7c452da40a7bfc2e2779b0fe2f
+RoslynAnalyzerConfigImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/RuntimeInternals/TestHelper.RuntimeInternals.Tests.globalconfig
+++ b/Tests/RuntimeInternals/TestHelper.RuntimeInternals.Tests.globalconfig
@@ -1,0 +1,2 @@
+is_global = true
+dotnet_diagnostic.CS0618.severity = error

--- a/Tests/RuntimeInternals/TestHelper.RuntimeInternals.Tests.globalconfig.meta
+++ b/Tests/RuntimeInternals/TestHelper.RuntimeInternals.Tests.globalconfig.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a6cddd4b1998f4cc9b1ae95a39e4e2fa
+RoslynAnalyzerConfigImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

- Add `.globalconfig` files to each assembly to treat CS0618 (use of obsolete API) as a compile error, preventing accidental use of deprecated members
- Update `RecordVideoAttribute` to drop obsolete `MaxMemoryUsageBytes` / `AudioInputQueueSize` properties and simplify `CreateOptions()` to start from `RealtimeEncodingOptions.Default`, overriding only user-specified video dimensions and frame rate

## Test plan

- [x] Verify the project compiles without CS0618 warnings/errors after the change
- [x] Confirm `RecordVideoAttribute` records video correctly in Play Mode tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)