### PR TITLE
Restrict VGA-only tests to Editor platforms

### DIFF
--- a/Tests/RuntimeInternals/ScreenshotHelperTest.cs
+++ b/Tests/RuntimeInternals/ScreenshotHelperTest.cs
@@ -200,6 +200,7 @@ namespace TestHelper.RuntimeInternals
 #if UNITY_2023_1_OR_NEWER
         [Test]
         [GameViewResolution(GameViewResolution.VGA)]
+        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
         [LoadScene(TestScene)]
         public async Task TakeScreenshotAsPngBytesAsync_ReturnsPngBytes()
         {
@@ -308,6 +309,7 @@ namespace TestHelper.RuntimeInternals
 
         [Test]
         [GameViewResolution(GameViewResolution.VGA)]
+        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
         [GizmosShowOnGameView(false)]
         [LoadScene(TestScene)]
         public async Task TakeScreenshotAsync_WithScale_ImagesMatch()
@@ -330,6 +332,7 @@ namespace TestHelper.RuntimeInternals
 
         [Test]
         [GameViewResolution(GameViewResolution.VGA)]
+        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
         [LoadScene(TestScene)]
         public async Task TakeScreenshotAsJpegBytesAsync_ReturnsJpegBytes()
         {


### PR DESCRIPTION
### Changes

TakeScreenshotAsPngBytesAsync_ReturnsPngBytes, TakeScreenshotAsJpegBytesAsync_ReturnsJpegBytes,
and TakeScreenshotAsync_WithScale_ImagesMatch assert a fixed VGA (640x480) screenshot size but
have no on-player branch, unlike TakeScreenshot_ImagesMatch/TakeScreenshotAsync_ImagesMatch.
GameViewResolution has no effect on a standalone player, so these tests only hold in the
Editor; running them on a player fails once the player is launched at a non-VGA resolution.