### PR TITLE
Enable IL2CPP high stripping for standalone player tests, preserve FileInfo.Length via link.xml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,9 +57,12 @@ jobs:
 
     steps:
       - name: Create project for test
-        uses: nowsprinting/create-unity-project-action@95f60602e491564583a15ee611a21c23c2f5d5d4 # v4
+        uses: nowsprinting/create-unity-project-action@c086a110a56fd0600a6051e709d99e635e3f208e # v4.1
         with:
           project-path: .
+          scripting-backend: 1        # IL2CPP
+          il2cpp-code-generation: 1   # Optimize for code size and build time
+          managed-stripping-level: 3  # High
 
       - name: Get package checkout path
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,23 @@ jobs:
           il2cpp-code-generation: 1   # Optimize for code size and build time
           managed-stripping-level: 3  # High
 
+      - name: Create link.xml to preserve FileInfo.Length under IL2CPP high stripping
+        # Has.Length asserts resolve FileInfo.Length via reflection at runtime; High stripping
+        # removes the getter and NUnit throws "Property Length was not found". Preserve it here
+        # instead of rewriting the idiomatic Has.Length assertions in the test code.
+        run: |
+          mkdir -p "$CREATED_PROJECT_PATH/Assets"
+          cat > "$CREATED_PROJECT_PATH/Assets/link.xml" <<'EOF'
+          <linker>
+            <assembly fullname="mscorlib">
+              <type fullname="System.IO.FileInfo">
+                <method name="get_Length" />
+              </type>
+            </assembly>
+          </linker>
+          EOF
+        if: matrix.testMode == 'Standalone'
+
       - name: Get package checkout path
         run: |
           name=com.$(echo "${GITHUB_REPOSITORY}" | sed 's/\//\./g')


### PR DESCRIPTION
## Purpose

Enable IL2CPP + Managed Code Stripping (High) for the standalone player test job in CI, so tests validate against the same stripping configuration users are likely to ship with.

## Changes

- Set `scripting-backend: IL2CPP`, `il2cpp-code-generation: 1` (optimize for size/build time), and `managed-stripping-level: 3` (High) when creating the test project for the Standalone matrix entry.
- Add a step that generates `Assets/link.xml` in the created test project, preserving `System.IO.FileInfo.get_Length`.

## Why link.xml

`Assert.That(new FileInfo(path), Has.Length...)` resolves `FileInfo.Length` via reflection (`Has.Property("Length")`) at runtime. High stripping removes the getter since it has no static reference, so the assertion throws `ArgumentException: Property Length was not found` — the file itself is written correctly; this is purely a reflection-vs-stripping issue in the test assertion.

Rather than rewriting the idiomatic `Has.Length` assertions to a static `.Length` reference, `link.xml` preserves the getter so the existing test code is unaffected.