### PR TITLE
Add 4 UI layout constraints (WithinScreen, FullyWithin, Overlapping, TextOverflowing)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -264,6 +264,12 @@ resharper_csharp_keep_existing_initializer_arrangement = true
 # Some values of the enum are not processed inside 'switch' statement and are handled via default section
 resharper_switch_statement_handles_some_known_enum_values_with_default_highlighting = warning
 
+# Type and member is never used (for coding agents)
+resharper_unused_type_local_highlighting = warning
+resharper_unused_type_global_highlighting = warning
+resharper_unused_member_global_highlighting = warning
+resharper_unused_member_local_highlighting = warning
+
 # BannedApiAnalyzers
 dotnet_diagnostic.RS0030.severity = error
 
@@ -282,6 +288,11 @@ resharper_access_to_static_member_via_derived_type_highlighting = none
 
 # NUnit2045: Use Assert.Multiple
 dotnet_diagnostic.NUnit2045.severity = none
+
+# VSTHRD200: Use "Async" suffix for async methods
+# Test methods follow the Subject_Scenario naming convention and are invoked by the test runner via
+# reflection, not awaited by caller code, so the "Async" suffix convention does not apply to them.
+dotnet_diagnostic.VSTHRD200.severity = none
 
 [src/{Compilers,ExpressionEvaluator,Scripting}/**Test**/*.{cs,vb}]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,10 +64,12 @@ jobs:
           il2cpp-code-generation: 1   # Optimize for code size and build time
           managed-stripping-level: 3  # High
 
-      - name: Create link.xml to preserve FileInfo.Length under IL2CPP high stripping
-        # Has.Length asserts resolve FileInfo.Length via reflection at runtime; High stripping
-        # removes the getter and NUnit throws "Property Length was not found". Preserve it here
-        # instead of rewriting the idiomatic Has.Length assertions in the test code.
+      - name: Create link.xml to preserve reflection-only APIs under IL2CPP high stripping
+        # Has.Length and Throws.TypeOf<ArgumentException>().With.Property("ParamName") resolve
+        # FileInfo.Length / ArgumentException.ParamName via reflection at runtime; High stripping
+        # removes the getters and NUnit throws "Property <Name> was not found". Preserve them here
+        # instead of rewriting the idiomatic assertions in the test code. ArgumentNullException
+        # inherits ParamName from ArgumentException, so one entry covers both.
         run: |
           mkdir -p "$CREATED_PROJECT_PATH/Assets"
           cat > "$CREATED_PROJECT_PATH/Assets/link.xml" <<'EOF'
@@ -75,6 +77,9 @@ jobs:
             <assembly fullname="mscorlib">
               <type fullname="System.IO.FileInfo">
                 <method name="get_Length" />
+              </type>
+              <type fullname="System.ArgumentException">
+                <method name="get_ParamName" />
               </type>
             </assembly>
           </linker>

--- a/README.md
+++ b/README.md
@@ -491,6 +491,136 @@ public class MyTestClass
 > [!NOTE]\
 > When used with operators, use it in method style. e.g., `Is.Not.Destroyed()`
 
+#### WithinScreen
+
+`WithinScreenConstraint` tests that a `RectTransform` (or a `GameObject`/`Component` with one) is fully within the screen.
+
+Usage:
+
+```csharp
+using Is = TestHelper.Constraints.Is;
+
+[TestFixture]
+public class MyTestClass
+{
+    [Test]
+    public void MyTestMethod()
+    {
+        var confirmDialog = GameObject.Find("ConfirmDialog");
+
+        Assert.That(confirmDialog, Is.WithinScreen);
+    }
+}
+```
+
+Chain `.Within(float)` to widen the tolerance in pixels (default `0.5f`), e.g., `Is.WithinScreen.Within(2f)`.
+
+> [!IMPORTANT]\
+> This constraint is intended for scenes and prefabs authored by coding agents.
+> Do not use it where the layout intentionally overflows the screen.
+
+> [!NOTE]\
+> When used with operators, use it in method style. e.g., `Is.Not.WithinScreen()`
+
+#### FullyWithin
+
+`FullyWithinConstraint` tests that a `RectTransform` (or a `GameObject`/`Component` with one) is fully within another `RectTransform`'s screen rect.
+
+Usage:
+
+```csharp
+using Is = TestHelper.Constraints.Is;
+
+[TestFixture]
+public class MyTestClass
+{
+    [Test]
+    public void MyTestMethod()
+    {
+        var viewport = GameObject.Find("Viewport").GetComponent<RectTransform>();
+        var card = GameObject.Find("Card (0)");
+
+        Assert.That(card, Is.FullyWithin(viewport));
+    }
+}
+```
+
+Chain `.Horizontally()` or `.Vertically()` to narrow the check to a single axis (calling both is equivalent to specifying neither — both axes are checked by default), and `.Within(float)` to widen the tolerance in pixels (default `0.5f`), e.g., `Is.FullyWithin(viewport).Horizontally().Within(2f)`.
+
+> [!IMPORTANT]\
+> This constraint is intended for scenes and prefabs authored by coding agents.
+> Do not use it where the layout intentionally overflows its container.
+
+#### Overlapping
+
+`OverlappingConstraint` tests that any pair in a collection of `RectTransform`s overlaps.
+
+Usage:
+
+```csharp
+using Is = TestHelper.Constraints.Is;
+
+[TestFixture]
+public class MyTestClass
+{
+    [Test]
+    public void MyTestMethod()
+    {
+        var cards = GameObject.Find("CardGrid").GetComponentsInChildren<Image>();
+
+        Assert.That(cards, Is.Not.Overlapping());
+    }
+}
+```
+
+Chain `.Ignoring(group)` to exclude pairs where both members belong to `group` (a member is still checked against elements outside the group; call it more than once to register multiple groups), and `.Within(float)` to widen the tolerance in pixels (default `0.5f`), e.g.:
+
+```csharp
+// SkipButton must not overlap any card, but cards overlapping each other is a different test's concern.
+Assert.That(cards.Prepend(skipButton), Is.Not.Overlapping().Ignoring(cards));
+```
+
+> [!IMPORTANT]\
+> This constraint is intended for scenes and prefabs authored by coding agents.
+> Do not use it where the layout intentionally allows elements to overlap.
+
+> [!NOTE]\
+> When used with operators, use it in method style. e.g., `Is.Not.Overlapping()`
+
+#### TextOverflowing (optional)
+
+`TextOverflowingConstraint` tests that a uGUI `Text` or TextMeshPro `TMP_Text` component overflows its own `RectTransform` — its preferred size exceeds the rect, or characters are truncated.
+
+Usage:
+
+```csharp
+using Is = TestHelper.Constraints.Is;
+
+[TestFixture]
+public class MyTestClass
+{
+    [Test]
+    public void MyTestMethod()
+    {
+        var flavorText = GameObject.Find("Flavor Text");
+
+        Assert.That(flavorText, Is.Not.TextOverflowing());
+    }
+}
+```
+
+Chain `.Within(float)` to widen the tolerance in pixels (default `0.5f`), e.g., `Is.Not.TextOverflowing().Within(1f)`.
+
+> [!IMPORTANT]\
+> `TextOverflowingConstraint` is an optional functionality. It supports uGUI `Text` and TextMeshPro `TMP_Text`, both optional dependencies of this package ([com.unity.ugui](https://docs.unity3d.com/Packages/com.unity.ugui@latest), [com.unity.textmeshpro](https://docs.unity3d.com/Packages/com.unity.textmeshpro@latest) — or `com.unity.ugui` 2.0.0+ alone, which bundles TextMeshPro).
+
+> [!IMPORTANT]\
+> This constraint is intended for scenes and prefabs authored by coding agents.
+> Do not use it where the layout intentionally lets text overflow its container.
+
+> [!NOTE]\
+> When used with operators, use it in method style. e.g., `Is.Not.TextOverflowing()`
+
 
 
 ### Comparers

--- a/README.md
+++ b/README.md
@@ -1077,6 +1077,9 @@ UNITY_VERSION=2019.4.40f1 make -k test
 > - [FlipBinding.CSharp](https://www.nuget.org/packages/FlipBinding.CSharp) NuGet package v1.0.0 or newer.
 > - [Instant Replay for Unity](https://github.com/CyberAgentGameEntertainment/InstantReplay) package v1.0.0 or newer
 
+> [!TIP]\
+> When running tests on a player with IL2CPP and managed stripping enabled, reflection-based assertions (e.g. `Has.Length`, `Throws.TypeOf<ArgumentException>().With.Property("ParamName")`) can fail with "Property X was not found" once the member is stripped. Create an `Assets/link.xml` in your project to preserve the affected members — see the link.xml generation step in [test.yml](.github/workflows/test.yml) for the entries this repository needs.
+
 
 ### Release workflow
 

--- a/Runtime/Constraints/ConstraintExtensions.cs
+++ b/Runtime/Constraints/ConstraintExtensions.cs
@@ -29,7 +29,9 @@ namespace TestHelper.Constraints
         /// <returns>constraint to <see cref="RectTransform"/> within the screen</returns>
         public static WithinScreenConstraint WithinScreen(this ConstraintExpression expression)
         {
-            return default;
+            var constraint = new WithinScreenConstraint();
+            expression.Append(constraint);
+            return constraint;
         }
 
         /// <summary>
@@ -41,7 +43,9 @@ namespace TestHelper.Constraints
         /// <returns>constraint to <see cref="RectTransform"/> fully within <paramref name="container"/></returns>
         public static FullyWithinConstraint FullyWithin(this ConstraintExpression expression, RectTransform container)
         {
-            return default;
+            var constraint = new FullyWithinConstraint(container);
+            expression.Append(constraint);
+            return constraint;
         }
 
         /// <summary>
@@ -52,7 +56,9 @@ namespace TestHelper.Constraints
         /// <returns>constraint to a collection of <see cref="RectTransform"/> where any pair overlaps</returns>
         public static OverlappingConstraint Overlapping(this ConstraintExpression expression)
         {
-            return default;
+            var constraint = new OverlappingConstraint();
+            expression.Append(constraint);
+            return constraint;
         }
 
         /// <summary>
@@ -63,7 +69,9 @@ namespace TestHelper.Constraints
         /// <returns>constraint to text overflowing its own <see cref="RectTransform"/></returns>
         public static TextOverflowingConstraint TextOverflowing(this ConstraintExpression expression)
         {
-            return default;
+            var constraint = new TextOverflowingConstraint();
+            expression.Append(constraint);
+            return constraint;
         }
     }
 }

--- a/Runtime/Constraints/ConstraintExtensions.cs
+++ b/Runtime/Constraints/ConstraintExtensions.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) 2023-2025 Koji Hasegawa.
+﻿// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using NUnit.Framework.Constraints;
+using UnityEngine;
 
 namespace TestHelper.Constraints
 {
@@ -18,6 +19,51 @@ namespace TestHelper.Constraints
             var constraint = new DestroyedConstraint();
             expression.Append(constraint);
             return constraint;
+        }
+
+        /// <summary>
+        /// Create constraint to <see cref="RectTransform"/> within the screen.
+        /// When used with operators, use it in method style. e.g., `Is.Not.WithinScreen()`
+        /// </summary>
+        /// <param name="expression"></param>
+        /// <returns>constraint to <see cref="RectTransform"/> within the screen</returns>
+        public static WithinScreenConstraint WithinScreen(this ConstraintExpression expression)
+        {
+            return default;
+        }
+
+        /// <summary>
+        /// Create constraint to <see cref="RectTransform"/> fully within <paramref name="container"/>.
+        /// When used with operators, use it in method style. e.g., `Is.Not.FullyWithin(container)`
+        /// </summary>
+        /// <param name="expression"></param>
+        /// <param name="container">Container to check containment against.</param>
+        /// <returns>constraint to <see cref="RectTransform"/> fully within <paramref name="container"/></returns>
+        public static FullyWithinConstraint FullyWithin(this ConstraintExpression expression, RectTransform container)
+        {
+            return default;
+        }
+
+        /// <summary>
+        /// Create constraint to a collection of <see cref="RectTransform"/> where any pair overlaps.
+        /// When used with operators, use it in method style. e.g., `Is.Not.Overlapping()`
+        /// </summary>
+        /// <param name="expression"></param>
+        /// <returns>constraint to a collection of <see cref="RectTransform"/> where any pair overlaps</returns>
+        public static OverlappingConstraint Overlapping(this ConstraintExpression expression)
+        {
+            return default;
+        }
+
+        /// <summary>
+        /// Create constraint to text overflowing its own <see cref="RectTransform"/>.
+        /// When used with operators, use it in method style. e.g., `Is.Not.TextOverflowing()`
+        /// </summary>
+        /// <param name="expression"></param>
+        /// <returns>constraint to text overflowing its own <see cref="RectTransform"/></returns>
+        public static TextOverflowingConstraint TextOverflowing(this ConstraintExpression expression)
+        {
+            return default;
         }
     }
 }

--- a/Runtime/Constraints/ConstraintMessageFormatter.cs
+++ b/Runtime/Constraints/ConstraintMessageFormatter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using System.Globalization;
 using UnityEngine;
 
 namespace TestHelper.Constraints
@@ -13,32 +14,45 @@ namespace TestHelper.Constraints
     {
         internal static string Format(Rect rect)
         {
-            return default;
+            return $"({Format(rect.x)}, {Format(rect.y)}, {Format(rect.width)}, {Format(rect.height)})";
         }
 
+        /// <summary>
+        /// Formats a rect with whole-number components, e.g. "(0, 0, 960, 540)" for the screen bounds.
+        /// </summary>
         internal static string FormatIntegral(Rect rect)
         {
-            return default;
+            return $"({FormatIntegral(rect.x)}, {FormatIntegral(rect.y)}, {FormatIntegral(rect.width)}, {FormatIntegral(rect.height)})";
         }
 
         internal static string Format(Vector2 vector)
         {
-            return default;
+            return $"({Format(vector.x)}, {Format(vector.y)})";
         }
 
         internal static string Format(float value)
         {
-            return default;
+            return value.ToString("F1", CultureInfo.InvariantCulture);
+        }
+
+        private static string FormatIntegral(float value)
+        {
+            return Mathf.RoundToInt(value).ToString(CultureInfo.InvariantCulture);
         }
 
         internal static string Quote(Object obj)
         {
-            return default;
+            return $"\"{obj.name}\"";
         }
 
+        /// <summary>
+        /// Describes an actual value that could not be resolved to a supported type. Not a call to
+        /// <c>MsgUtils.FormatValue</c> (internal in this NUnit build) or <c>ToString()</c> because the
+        /// value could be arbitrarily large or locale-dependent; only its type name is reported.
+        /// </summary>
         internal static string DescribeActual(object actual)
         {
-            return default;
+            return actual == null ? "null" : $"<{actual.GetType().FullName}>";
         }
     }
 }

--- a/Runtime/Constraints/ConstraintMessageFormatter.cs
+++ b/Runtime/Constraints/ConstraintMessageFormatter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Globalization;

--- a/Runtime/Constraints/ConstraintMessageFormatter.cs
+++ b/Runtime/Constraints/ConstraintMessageFormatter.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using UnityEngine;
+
+namespace TestHelper.Constraints
+{
+    /// <summary>
+    /// Formats rects, vectors, and actual values for constraint failure messages using a fixed,
+    /// culture-invariant, single-decimal representation.
+    /// </summary>
+    internal static class ConstraintMessageFormatter
+    {
+        internal static string Format(Rect rect)
+        {
+            return default;
+        }
+
+        internal static string FormatIntegral(Rect rect)
+        {
+            return default;
+        }
+
+        internal static string Format(Vector2 vector)
+        {
+            return default;
+        }
+
+        internal static string Format(float value)
+        {
+            return default;
+        }
+
+        internal static string Quote(Object obj)
+        {
+            return default;
+        }
+
+        internal static string DescribeActual(object actual)
+        {
+            return default;
+        }
+    }
+}

--- a/Runtime/Constraints/ConstraintMessageFormatter.cs
+++ b/Runtime/Constraints/ConstraintMessageFormatter.cs
@@ -22,7 +22,8 @@ namespace TestHelper.Constraints
         /// </summary>
         internal static string FormatIntegral(Rect rect)
         {
-            return $"({FormatIntegral(rect.x)}, {FormatIntegral(rect.y)}, {FormatIntegral(rect.width)}, {FormatIntegral(rect.height)})";
+            return
+                $"({FormatIntegral(rect.x)}, {FormatIntegral(rect.y)}, {FormatIntegral(rect.width)}, {FormatIntegral(rect.height)})";
         }
 
         internal static string Format(Vector2 vector)

--- a/Runtime/Constraints/ConstraintMessageFormatter.cs.meta
+++ b/Runtime/Constraints/ConstraintMessageFormatter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9fe3dad44949f40b68e4fde7ac9bc566

--- a/Runtime/Constraints/ConstraintReport.cs
+++ b/Runtime/Constraints/ConstraintReport.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+namespace TestHelper.Constraints
+{
+    /// <summary>
+    /// Carries a human-readable diagnostic message as the actual value of a constraint result.
+    /// </summary>
+    /// <remarks>
+    /// Not a <see cref="string"/> because NUnit's default value formatter quotes and clips string actual
+    /// values; wrapping the message in this type lets it print verbatim via <see cref="ToString"/>.
+    /// </remarks>
+    internal sealed class ConstraintReport
+    {
+        internal ConstraintReport(string message)
+        {
+        }
+
+        public override string ToString()
+        {
+            return default;
+        }
+    }
+}

--- a/Runtime/Constraints/ConstraintReport.cs
+++ b/Runtime/Constraints/ConstraintReport.cs
@@ -12,13 +12,16 @@ namespace TestHelper.Constraints
     /// </remarks>
     internal sealed class ConstraintReport
     {
+        private readonly string _message;
+
         internal ConstraintReport(string message)
         {
+            _message = message;
         }
 
         public override string ToString()
         {
-            return default;
+            return _message;
         }
     }
 }

--- a/Runtime/Constraints/ConstraintReport.cs
+++ b/Runtime/Constraints/ConstraintReport.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 namespace TestHelper.Constraints

--- a/Runtime/Constraints/ConstraintReport.cs.meta
+++ b/Runtime/Constraints/ConstraintReport.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bacea8442dfc740f1bf1f4fd7c1705f9

--- a/Runtime/Constraints/FullyWithinConstraint.cs
+++ b/Runtime/Constraints/FullyWithinConstraint.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using System;
 using NUnit.Framework.Constraints;
 using UnityEngine;
 
@@ -75,19 +76,18 @@ namespace TestHelper.Constraints
         }
 
         /// <inheritdoc/>
+        /// <exception cref="ArgumentNullException">The container passed to the constructor is null or
+        /// destroyed, or <paramref name="actual"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="actual"/> cannot be resolved to a
+        /// <see cref="RectTransform"/>.</exception>
         public override ConstraintResult ApplyTo(object actual)
         {
             if (_container == null)
             {
-                return new ReportingConstraintResult(this, new ConstraintReport("container is null or destroyed"),
-                    false);
+                throw new ArgumentNullException("container");
             }
 
-            var failure = RectTransformResolver.TryResolveOrFail(actual, this, out var rectTransform);
-            if (failure != null)
-            {
-                return failure;
-            }
+            var rectTransform = RectTransformResolver.ResolveOrThrow(actual, nameof(actual));
 
             var elementRect = ScreenRectHelper.GetScreenRect(rectTransform);
             var containerRect = ScreenRectHelper.GetScreenRect(_container);

--- a/Runtime/Constraints/FullyWithinConstraint.cs
+++ b/Runtime/Constraints/FullyWithinConstraint.cs
@@ -83,20 +83,17 @@ namespace TestHelper.Constraints
                     false);
             }
 
-            if (actual == null)
+            var failure = RectTransformResolver.TryResolveOrFail(actual, this, out var rectTransform);
+            if (failure != null)
             {
-                return new ReportingConstraintResult(this, null, false);
-            }
-
-            if (!RectTransformResolver.TryResolve(actual, out var rectTransform, out var failureReason))
-            {
-                return new ReportingConstraintResult(this, new ConstraintReport(failureReason), false);
+                return failure;
             }
 
             var elementRect = ScreenRectHelper.GetScreenRect(rectTransform);
             var containerRect = ScreenRectHelper.GetScreenRect(_container);
-            var effectiveAxes = _axes == RectAxes.None ? RectAxes.Both : _axes;
-            var overshoot = RectGeometry.GetOvershoot(elementRect, containerRect, effectiveAxes, _tolerance);
+
+            // RectAxes.None is treated the same as Both by RectGeometry.GetOvershoot, so no conversion needed.
+            var overshoot = RectGeometry.GetOvershoot(elementRect, containerRect, _axes, _tolerance);
             var elementText =
                 $"{ConstraintMessageFormatter.Quote(rectTransform)} {ConstraintMessageFormatter.Format(elementRect)}";
             var message = overshoot == null ? elementText : $"{elementText} {overshoot}";

--- a/Runtime/Constraints/FullyWithinConstraint.cs
+++ b/Runtime/Constraints/FullyWithinConstraint.cs
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using NUnit.Framework.Constraints;
+using UnityEngine;
+
+namespace TestHelper.Constraints
+{
+    /// <summary>
+    /// An NUnit test constraint class to a <see cref="RectTransform"/> fully within another
+    /// <see cref="RectTransform"/>'s screen rect.
+    /// </summary>
+    public class FullyWithinConstraint : Constraint
+    {
+        private RectAxes _axes;
+        private float _tolerance;
+
+        public FullyWithinConstraint(RectTransform container) : base(container)
+        {
+        }
+
+        /// <summary>
+        /// Narrow the check to the horizontal axis.
+        /// </summary>
+        /// <returns>this</returns>
+        public FullyWithinConstraint Horizontally()
+        {
+            return default;
+        }
+
+        /// <summary>
+        /// Narrow the check to the vertical axis.
+        /// </summary>
+        /// <returns>this</returns>
+        public FullyWithinConstraint Vertically()
+        {
+            return default;
+        }
+
+        /// <summary>
+        /// Set the tolerance in pixels. Negative values are clamped to 0. Default is 0.5f.
+        /// </summary>
+        /// <param name="tolerance">Tolerance in pixels.</param>
+        /// <returns>this</returns>
+        public FullyWithinConstraint Within(float tolerance)
+        {
+            return default;
+        }
+
+        /// <inheritdoc/>
+        public override string Description => default;
+
+        /// <inheritdoc/>
+        public override ConstraintResult ApplyTo(object actual)
+        {
+            return default;
+        }
+    }
+}

--- a/Runtime/Constraints/FullyWithinConstraint.cs
+++ b/Runtime/Constraints/FullyWithinConstraint.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using NUnit.Framework.Constraints;

--- a/Runtime/Constraints/FullyWithinConstraint.cs
+++ b/Runtime/Constraints/FullyWithinConstraint.cs
@@ -12,11 +12,14 @@ namespace TestHelper.Constraints
     /// </summary>
     public class FullyWithinConstraint : Constraint
     {
+        private const float DefaultTolerance = 0.5f;
+        private readonly RectTransform _container;
         private RectAxes _axes;
-        private float _tolerance;
+        private float _tolerance = DefaultTolerance;
 
         public FullyWithinConstraint(RectTransform container) : base(container)
         {
+            _container = container;
         }
 
         /// <summary>
@@ -25,7 +28,8 @@ namespace TestHelper.Constraints
         /// <returns>this</returns>
         public FullyWithinConstraint Horizontally()
         {
-            return default;
+            _axes |= RectAxes.Horizontal;
+            return this;
         }
 
         /// <summary>
@@ -34,7 +38,8 @@ namespace TestHelper.Constraints
         /// <returns>this</returns>
         public FullyWithinConstraint Vertically()
         {
-            return default;
+            _axes |= RectAxes.Vertical;
+            return this;
         }
 
         /// <summary>
@@ -44,16 +49,59 @@ namespace TestHelper.Constraints
         /// <returns>this</returns>
         public FullyWithinConstraint Within(float tolerance)
         {
-            return default;
+            _tolerance = Mathf.Max(0f, tolerance);
+            return this;
         }
 
         /// <inheritdoc/>
-        public override string Description => default;
+        public override string Description
+        {
+            get
+            {
+                if (_container == null)
+                {
+                    return "RectTransform fully within null or destroyed container";
+                }
+
+                // Both explicitly narrowed axes (Horizontally().Vertically()) are treated the same as
+                // unnarrowed: only a SINGLE narrowed axis gets called out in the description.
+                var axisWord = _axes == RectAxes.Horizontal ? "horizontally "
+                    : _axes == RectAxes.Vertical ? "vertically "
+                    : string.Empty;
+                var containerRect = ScreenRectHelper.GetScreenRect(_container);
+                return
+                    $"RectTransform {axisWord}fully within {ConstraintMessageFormatter.Quote(_container)} {ConstraintMessageFormatter.Format(containerRect)}";
+            }
+        }
 
         /// <inheritdoc/>
         public override ConstraintResult ApplyTo(object actual)
         {
-            return default;
+            if (_container == null)
+            {
+                return new ReportingConstraintResult(this, new ConstraintReport("container is null or destroyed"),
+                    false);
+            }
+
+            if (actual == null)
+            {
+                return new ReportingConstraintResult(this, null, false);
+            }
+
+            if (!RectTransformResolver.TryResolve(actual, out var rectTransform, out var failureReason))
+            {
+                return new ReportingConstraintResult(this, new ConstraintReport(failureReason), false);
+            }
+
+            var elementRect = ScreenRectHelper.GetScreenRect(rectTransform);
+            var containerRect = ScreenRectHelper.GetScreenRect(_container);
+            var effectiveAxes = _axes == RectAxes.None ? RectAxes.Both : _axes;
+            var overshoot = RectGeometry.GetOvershoot(elementRect, containerRect, effectiveAxes, _tolerance);
+            var elementText =
+                $"{ConstraintMessageFormatter.Quote(rectTransform)} {ConstraintMessageFormatter.Format(elementRect)}";
+            var message = overshoot == null ? elementText : $"{elementText} {overshoot}";
+
+            return new ReportingConstraintResult(this, new ConstraintReport(message), overshoot == null);
         }
     }
 }

--- a/Runtime/Constraints/FullyWithinConstraint.cs.meta
+++ b/Runtime/Constraints/FullyWithinConstraint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 030d9a3f84ca34e1d98eebd9a6488ff9

--- a/Runtime/Constraints/Is.cs
+++ b/Runtime/Constraints/Is.cs
@@ -1,5 +1,7 @@
-﻿// Copyright (c) 2023 Koji Hasegawa.
+﻿// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
+
+using UnityEngine;
 
 namespace TestHelper.Constraints
 {
@@ -11,5 +13,26 @@ namespace TestHelper.Constraints
         /// Create constraint to destroyed GameObject.
         /// </summary>
         public static DestroyedConstraint Destroyed => new DestroyedConstraint();
+
+        /// <summary>
+        /// Create constraint to <see cref="RectTransform"/> within the screen.
+        /// </summary>
+        public static WithinScreenConstraint WithinScreen => default;
+
+        /// <summary>
+        /// Create constraint to <see cref="RectTransform"/> fully within <paramref name="container"/>.
+        /// </summary>
+        /// <param name="container">Container to check containment against.</param>
+        public static FullyWithinConstraint FullyWithin(RectTransform container) => default;
+
+        /// <summary>
+        /// Create constraint to a collection of <see cref="RectTransform"/> where any pair overlaps.
+        /// </summary>
+        public static OverlappingConstraint Overlapping => default;
+
+        /// <summary>
+        /// Create constraint to text overflowing its own <see cref="RectTransform"/>.
+        /// </summary>
+        public static TextOverflowingConstraint TextOverflowing => default;
     }
 }

--- a/Runtime/Constraints/Is.cs
+++ b/Runtime/Constraints/Is.cs
@@ -23,7 +23,8 @@ namespace TestHelper.Constraints
         /// Create constraint to <see cref="RectTransform"/> fully within <paramref name="container"/>.
         /// </summary>
         /// <param name="container">Container to check containment against.</param>
-        public static FullyWithinConstraint FullyWithin(RectTransform container) => new FullyWithinConstraint(container);
+        public static FullyWithinConstraint FullyWithin(RectTransform container) =>
+            new FullyWithinConstraint(container);
 
         /// <summary>
         /// Create constraint to a collection of <see cref="RectTransform"/> where any pair overlaps.

--- a/Runtime/Constraints/Is.cs
+++ b/Runtime/Constraints/Is.cs
@@ -17,22 +17,22 @@ namespace TestHelper.Constraints
         /// <summary>
         /// Create constraint to <see cref="RectTransform"/> within the screen.
         /// </summary>
-        public static WithinScreenConstraint WithinScreen => default;
+        public static WithinScreenConstraint WithinScreen => new WithinScreenConstraint();
 
         /// <summary>
         /// Create constraint to <see cref="RectTransform"/> fully within <paramref name="container"/>.
         /// </summary>
         /// <param name="container">Container to check containment against.</param>
-        public static FullyWithinConstraint FullyWithin(RectTransform container) => default;
+        public static FullyWithinConstraint FullyWithin(RectTransform container) => new FullyWithinConstraint(container);
 
         /// <summary>
         /// Create constraint to a collection of <see cref="RectTransform"/> where any pair overlaps.
         /// </summary>
-        public static OverlappingConstraint Overlapping => default;
+        public static OverlappingConstraint Overlapping => new OverlappingConstraint();
 
         /// <summary>
         /// Create constraint to text overflowing its own <see cref="RectTransform"/>.
         /// </summary>
-        public static TextOverflowingConstraint TextOverflowing => default;
+        public static TextOverflowingConstraint TextOverflowing => new TextOverflowingConstraint();
     }
 }

--- a/Runtime/Constraints/OverlappingConstraint.cs
+++ b/Runtime/Constraints/OverlappingConstraint.cs
@@ -1,8 +1,11 @@
 // Copyright (c) 2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using System;
 using System.Collections;
+using System.Collections.Generic;
 using NUnit.Framework.Constraints;
+using UnityEngine;
 
 namespace TestHelper.Constraints
 {
@@ -12,7 +15,9 @@ namespace TestHelper.Constraints
     /// </summary>
     public class OverlappingConstraint : Constraint
     {
-        private float _tolerance;
+        private const float DefaultTolerance = 0.5f;
+        private readonly List<IEnumerable> _ignoredGroups = new List<IEnumerable>();
+        private float _tolerance = DefaultTolerance;
 
         public OverlappingConstraint(params object[] args) : base(args)
         {
@@ -25,10 +30,16 @@ namespace TestHelper.Constraints
         /// </summary>
         /// <param name="ignoredGroup">Group of elements whose internal pairs are excluded.</param>
         /// <returns>this</returns>
-        /// <exception cref="System.ArgumentNullException"><paramref name="ignoredGroup"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="ignoredGroup"/> is null.</exception>
         public OverlappingConstraint Ignoring(IEnumerable ignoredGroup)
         {
-            return default;
+            if (ignoredGroup == null)
+            {
+                throw new ArgumentNullException(nameof(ignoredGroup));
+            }
+
+            _ignoredGroups.Add(ignoredGroup);
+            return this;
         }
 
         /// <summary>
@@ -38,16 +49,111 @@ namespace TestHelper.Constraints
         /// <returns>this</returns>
         public OverlappingConstraint Within(float tolerance)
         {
-            return default;
+            _tolerance = Mathf.Max(0f, tolerance);
+            return this;
         }
 
         /// <inheritdoc/>
-        public override string Description => default;
+        public override string Description => "any pair of RectTransforms overlapping";
 
         /// <inheritdoc/>
         public override ConstraintResult ApplyTo(object actual)
         {
-            return default;
+            if (actual == null)
+            {
+                return new ReportingConstraintResult(this, null, false);
+            }
+
+            // Checked before the general IEnumerable branch: RectTransform (a Transform) enumerates its
+            // children, so a single element passed directly would otherwise be misread as a collection.
+            if (actual is RectTransform || actual is GameObject || actual is Component)
+            {
+                RectTransformResolver.TryResolve(actual, out var singleRectTransform, out var singleFailureReason);
+                var message = singleRectTransform != null
+                    ? $"{ConstraintMessageFormatter.Quote(singleRectTransform)} is a single RectTransform, not a collection"
+                    : singleFailureReason;
+                return new ReportingConstraintResult(this, new ConstraintReport(message), false);
+            }
+
+            // string implements IEnumerable<char>; special-cased so it doesn't get misread as a collection
+            // of per-character "elements".
+            if (!(actual is IEnumerable) || actual is string)
+            {
+                var message = $"{ConstraintMessageFormatter.DescribeActual(actual)} is not a collection of RectTransforms";
+                return new ReportingConstraintResult(this, new ConstraintReport(message), false);
+            }
+
+            var elements = new List<RectTransform>();
+            var index = 0;
+            foreach (var item in (IEnumerable)actual)
+            {
+                if (!RectTransformResolver.TryResolve(item, out var rectTransform, out var failureReason))
+                {
+                    var message = $"element at index {index}: {failureReason}";
+                    return new ReportingConstraintResult(this, new ConstraintReport(message), false);
+                }
+
+                elements.Add(rectTransform);
+                index++;
+            }
+
+            var ignoredSets = new List<HashSet<RectTransform>>();
+            foreach (var rawGroup in _ignoredGroups)
+            {
+                var set = new HashSet<RectTransform>();
+                var groupIndex = 0;
+                foreach (var item in rawGroup)
+                {
+                    if (!RectTransformResolver.TryResolve(item, out var rectTransform, out var failureReason))
+                    {
+                        var message = $"ignored group member at index {groupIndex}: {failureReason}";
+                        return new ReportingConstraintResult(this, new ConstraintReport(message), false);
+                    }
+
+                    set.Add(rectTransform);
+                    groupIndex++;
+                }
+
+                ignoredSets.Add(set);
+            }
+
+            var overlappingPairs = new List<KeyValuePair<RectTransform, RectTransform>>();
+            for (var i = 0; i < elements.Count; i++)
+            {
+                for (var j = i + 1; j < elements.Count; j++)
+                {
+                    var a = elements[i];
+                    var b = elements[j];
+                    if (ignoredSets.Exists(set => set.Contains(a) && set.Contains(b)))
+                    {
+                        continue;
+                    }
+
+                    var rectA = ScreenRectHelper.GetScreenRect(a);
+                    var rectB = ScreenRectHelper.GetScreenRect(b);
+                    if (RectGeometry.Overlaps(rectA, rectB, _tolerance))
+                    {
+                        overlappingPairs.Add(new KeyValuePair<RectTransform, RectTransform>(a, b));
+                    }
+                }
+            }
+
+            if (overlappingPairs.Count > 0)
+            {
+                var first = overlappingPairs[0];
+                var pairMessage =
+                    $"{ConstraintMessageFormatter.Quote(first.Key)} {ConstraintMessageFormatter.Format(ScreenRectHelper.GetScreenRect(first.Key))}" +
+                    $" overlaps {ConstraintMessageFormatter.Quote(first.Value)} {ConstraintMessageFormatter.Format(ScreenRectHelper.GetScreenRect(first.Value))}";
+                if (overlappingPairs.Count > 1)
+                {
+                    pairMessage += $" (and {overlappingPairs.Count - 1} more overlapping pairs)";
+                }
+
+                return new ReportingConstraintResult(this, new ConstraintReport(pairMessage), true);
+            }
+
+            var noOverlapMessage = $"no overlapping pair among {elements.Count} RectTransforms";
+            return new ReportingConstraintResult(this, new ConstraintReport(noOverlapMessage), false);
         }
     }
 }

--- a/Runtime/Constraints/OverlappingConstraint.cs
+++ b/Runtime/Constraints/OverlappingConstraint.cs
@@ -66,7 +66,7 @@ namespace TestHelper.Constraints
 
             // Checked before the general IEnumerable branch: RectTransform (a Transform) enumerates its
             // children, so a single element passed directly would otherwise be misread as a collection.
-            if (actual is RectTransform || actual is GameObject || actual is Component)
+            if (RectTransformResolver.IsResolvableSingle(actual))
             {
                 RectTransformResolver.TryResolve(actual, out var singleRectTransform, out var singleFailureReason);
                 var message = singleRectTransform != null
@@ -79,45 +79,36 @@ namespace TestHelper.Constraints
             // of per-character "elements".
             if (!(actual is IEnumerable) || actual is string)
             {
-                var message = $"{ConstraintMessageFormatter.DescribeActual(actual)} is not a collection of RectTransforms";
+                var message =
+                    $"{ConstraintMessageFormatter.DescribeActual(actual)} is not a collection of RectTransforms";
                 return new ReportingConstraintResult(this, new ConstraintReport(message), false);
             }
 
-            var elements = new List<RectTransform>();
-            var index = 0;
-            foreach (var item in (IEnumerable)actual)
+            if (!TryResolveAll((IEnumerable)actual, "element", out var elements, out var elementsFailure))
             {
-                if (!RectTransformResolver.TryResolve(item, out var rectTransform, out var failureReason))
-                {
-                    var message = $"element at index {index}: {failureReason}";
-                    return new ReportingConstraintResult(this, new ConstraintReport(message), false);
-                }
-
-                elements.Add(rectTransform);
-                index++;
+                return elementsFailure;
             }
 
             var ignoredSets = new List<HashSet<RectTransform>>();
             foreach (var rawGroup in _ignoredGroups)
             {
-                var set = new HashSet<RectTransform>();
-                var groupIndex = 0;
-                foreach (var item in rawGroup)
+                if (!TryResolveAll(rawGroup, "ignored group member", out var groupMembers, out var groupFailure))
                 {
-                    if (!RectTransformResolver.TryResolve(item, out var rectTransform, out var failureReason))
-                    {
-                        var message = $"ignored group member at index {groupIndex}: {failureReason}";
-                        return new ReportingConstraintResult(this, new ConstraintReport(message), false);
-                    }
-
-                    set.Add(rectTransform);
-                    groupIndex++;
+                    return groupFailure;
                 }
 
-                ignoredSets.Add(set);
+                ignoredSets.Add(new HashSet<RectTransform>(groupMembers));
             }
 
-            var overlappingPairs = new List<KeyValuePair<RectTransform, RectTransform>>();
+            // Computed once per element (not once per pair) so an element isn't re-projected to screen
+            // space for every other element it's paired against.
+            var rects = new Rect[elements.Count];
+            for (var i = 0; i < elements.Count; i++)
+            {
+                rects[i] = ScreenRectHelper.GetScreenRect(elements[i]);
+            }
+
+            var overlappingPairs = new List<OverlappingPair>();
             for (var i = 0; i < elements.Count; i++)
             {
                 for (var j = i + 1; j < elements.Count; j++)
@@ -129,11 +120,9 @@ namespace TestHelper.Constraints
                         continue;
                     }
 
-                    var rectA = ScreenRectHelper.GetScreenRect(a);
-                    var rectB = ScreenRectHelper.GetScreenRect(b);
-                    if (RectGeometry.Overlaps(rectA, rectB, _tolerance))
+                    if (RectGeometry.Overlaps(rects[i], rects[j], _tolerance))
                     {
-                        overlappingPairs.Add(new KeyValuePair<RectTransform, RectTransform>(a, b));
+                        overlappingPairs.Add(new OverlappingPair(a, b, rects[i], rects[j]));
                     }
                 }
             }
@@ -142,8 +131,8 @@ namespace TestHelper.Constraints
             {
                 var first = overlappingPairs[0];
                 var pairMessage =
-                    $"{ConstraintMessageFormatter.Quote(first.Key)} {ConstraintMessageFormatter.Format(ScreenRectHelper.GetScreenRect(first.Key))}" +
-                    $" overlaps {ConstraintMessageFormatter.Quote(first.Value)} {ConstraintMessageFormatter.Format(ScreenRectHelper.GetScreenRect(first.Value))}";
+                    $"{ConstraintMessageFormatter.Quote(first.A)} {ConstraintMessageFormatter.Format(first.RectA)}" +
+                    $" overlaps {ConstraintMessageFormatter.Quote(first.B)} {ConstraintMessageFormatter.Format(first.RectB)}";
                 if (overlappingPairs.Count > 1)
                 {
                     pairMessage += $" (and {overlappingPairs.Count - 1} more overlapping pairs)";
@@ -154,6 +143,50 @@ namespace TestHelper.Constraints
 
             var noOverlapMessage = $"no overlapping pair among {elements.Count} RectTransforms";
             return new ReportingConstraintResult(this, new ConstraintReport(noOverlapMessage), false);
+        }
+
+        /// <summary>
+        /// Resolves every item in <paramref name="source"/> to a <see cref="RectTransform"/>. On the first
+        /// unresolvable item, returns false with <paramref name="failure"/> set to a ready failure result
+        /// whose message is prefixed with <paramref name="label"/> and the item's index (shared by both the
+        /// checked-elements loop and each ignored-group loop, which differ only in that prefix).
+        /// </summary>
+        private bool TryResolveAll(IEnumerable source, string label, out List<RectTransform> resolved,
+            out ConstraintResult failure)
+        {
+            resolved = new List<RectTransform>();
+            var index = 0;
+            foreach (var item in source)
+            {
+                if (!RectTransformResolver.TryResolve(item, out var rectTransform, out var failureReason))
+                {
+                    var message = $"{label} at index {index}: {failureReason}";
+                    failure = new ReportingConstraintResult(this, new ConstraintReport(message), false);
+                    return false;
+                }
+
+                resolved.Add(rectTransform);
+                index++;
+            }
+
+            failure = null;
+            return true;
+        }
+
+        private readonly struct OverlappingPair
+        {
+            internal readonly RectTransform A;
+            internal readonly RectTransform B;
+            internal readonly Rect RectA;
+            internal readonly Rect RectB;
+
+            internal OverlappingPair(RectTransform a, RectTransform b, Rect rectA, Rect rectB)
+            {
+                A = a;
+                B = b;
+                RectA = rectA;
+                RectB = rectB;
+            }
         }
     }
 }

--- a/Runtime/Constraints/OverlappingConstraint.cs
+++ b/Runtime/Constraints/OverlappingConstraint.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;

--- a/Runtime/Constraints/OverlappingConstraint.cs
+++ b/Runtime/Constraints/OverlappingConstraint.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Collections;
+using NUnit.Framework.Constraints;
+
+namespace TestHelper.Constraints
+{
+    /// <summary>
+    /// An NUnit test constraint class to a collection of <see cref="UnityEngine.RectTransform"/> where any
+    /// pair overlaps.
+    /// </summary>
+    public class OverlappingConstraint : Constraint
+    {
+        private float _tolerance;
+
+        public OverlappingConstraint(params object[] args) : base(args)
+        {
+        }
+
+        /// <summary>
+        /// Exclude pairs whose both members belong to <paramref name="ignoredGroup"/> from the check.
+        /// Members are still checked against elements outside the group. Can be called more than once to
+        /// register multiple groups.
+        /// </summary>
+        /// <param name="ignoredGroup">Group of elements whose internal pairs are excluded.</param>
+        /// <returns>this</returns>
+        /// <exception cref="System.ArgumentNullException"><paramref name="ignoredGroup"/> is null.</exception>
+        public OverlappingConstraint Ignoring(IEnumerable ignoredGroup)
+        {
+            return default;
+        }
+
+        /// <summary>
+        /// Set the tolerance in pixels. Negative values are clamped to 0. Default is 0.5f.
+        /// </summary>
+        /// <param name="tolerance">Tolerance in pixels.</param>
+        /// <returns>this</returns>
+        public OverlappingConstraint Within(float tolerance)
+        {
+            return default;
+        }
+
+        /// <inheritdoc/>
+        public override string Description => default;
+
+        /// <inheritdoc/>
+        public override ConstraintResult ApplyTo(object actual)
+        {
+            return default;
+        }
+    }
+}

--- a/Runtime/Constraints/OverlappingConstraint.cs
+++ b/Runtime/Constraints/OverlappingConstraint.cs
@@ -57,46 +57,43 @@ namespace TestHelper.Constraints
         public override string Description => "any pair of RectTransforms overlapping";
 
         /// <inheritdoc/>
+        /// <exception cref="ArgumentNullException"><paramref name="actual"/>, or an element within it (or
+        /// within an <see cref="Ignoring"/> group), is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="actual"/> is not a single resolvable element
+        /// or a collection of RectTransforms, or an element within it (or within an <see cref="Ignoring"/>
+        /// group) cannot be resolved to a <see cref="RectTransform"/>.</exception>
         public override ConstraintResult ApplyTo(object actual)
         {
             if (actual == null)
             {
-                return new ReportingConstraintResult(this, null, false);
+                throw new ArgumentNullException(nameof(actual));
             }
 
             // Checked before the general IEnumerable branch: RectTransform (a Transform) enumerates its
             // children, so a single element passed directly would otherwise be misread as a collection.
             if (RectTransformResolver.IsResolvableSingle(actual))
             {
-                RectTransformResolver.TryResolve(actual, out var singleRectTransform, out var singleFailureReason);
-                var message = singleRectTransform != null
-                    ? $"{ConstraintMessageFormatter.Quote(singleRectTransform)} is a single RectTransform, not a collection"
-                    : singleFailureReason;
-                return new ReportingConstraintResult(this, new ConstraintReport(message), false);
+                var singleRectTransform = RectTransformResolver.ResolveOrThrow(actual, nameof(actual));
+                throw new ArgumentException(
+                    $"{ConstraintMessageFormatter.Quote(singleRectTransform)} is a single RectTransform, not a collection",
+                    nameof(actual));
             }
 
             // string implements IEnumerable<char>; special-cased so it doesn't get misread as a collection
             // of per-character "elements".
             if (!(actual is IEnumerable) || actual is string)
             {
-                var message =
-                    $"{ConstraintMessageFormatter.DescribeActual(actual)} is not a collection of RectTransforms";
-                return new ReportingConstraintResult(this, new ConstraintReport(message), false);
+                throw new ArgumentException(
+                    $"{ConstraintMessageFormatter.DescribeActual(actual)} is not a collection of RectTransforms",
+                    nameof(actual));
             }
 
-            if (!TryResolveAll((IEnumerable)actual, "element", out var elements, out var elementsFailure))
-            {
-                return elementsFailure;
-            }
+            var elements = ResolveAll((IEnumerable)actual, "element");
 
             var ignoredSets = new List<HashSet<RectTransform>>();
             foreach (var rawGroup in _ignoredGroups)
             {
-                if (!TryResolveAll(rawGroup, "ignored group member", out var groupMembers, out var groupFailure))
-                {
-                    return groupFailure;
-                }
-
+                var groupMembers = ResolveAll(rawGroup, "ignored group member");
                 ignoredSets.Add(new HashSet<RectTransform>(groupMembers));
             }
 
@@ -146,31 +143,25 @@ namespace TestHelper.Constraints
         }
 
         /// <summary>
-        /// Resolves every item in <paramref name="source"/> to a <see cref="RectTransform"/>. On the first
-        /// unresolvable item, returns false with <paramref name="failure"/> set to a ready failure result
-        /// whose message is prefixed with <paramref name="label"/> and the item's index (shared by both the
-        /// checked-elements loop and each ignored-group loop, which differ only in that prefix).
+        /// Resolves every item in <paramref name="source"/> to a <see cref="RectTransform"/>, throwing on the
+        /// first unresolvable item. The reported parameter name is prefixed with <paramref name="label"/> and
+        /// the item's index (shared by both the checked-elements loop and each ignored-group loop, which
+        /// differ only in that prefix).
         /// </summary>
-        private bool TryResolveAll(IEnumerable source, string label, out List<RectTransform> resolved,
-            out ConstraintResult failure)
+        /// <exception cref="ArgumentNullException">An item in <paramref name="source"/> is null.</exception>
+        /// <exception cref="ArgumentException">An item in <paramref name="source"/> cannot be resolved to a
+        /// <see cref="RectTransform"/>.</exception>
+        private static List<RectTransform> ResolveAll(IEnumerable source, string label)
         {
-            resolved = new List<RectTransform>();
+            var resolved = new List<RectTransform>();
             var index = 0;
             foreach (var item in source)
             {
-                if (!RectTransformResolver.TryResolve(item, out var rectTransform, out var failureReason))
-                {
-                    var message = $"{label} at index {index}: {failureReason}";
-                    failure = new ReportingConstraintResult(this, new ConstraintReport(message), false);
-                    return false;
-                }
-
-                resolved.Add(rectTransform);
+                resolved.Add(RectTransformResolver.ResolveOrThrow(item, $"{label} at index {index}"));
                 index++;
             }
 
-            failure = null;
-            return true;
+            return resolved;
         }
 
         private readonly struct OverlappingPair

--- a/Runtime/Constraints/OverlappingConstraint.cs.meta
+++ b/Runtime/Constraints/OverlappingConstraint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0ad6833b1a6a74e2abf48c3596eae37a

--- a/Runtime/Constraints/RectAxes.cs
+++ b/Runtime/Constraints/RectAxes.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;

--- a/Runtime/Constraints/RectAxes.cs
+++ b/Runtime/Constraints/RectAxes.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+
+namespace TestHelper.Constraints
+{
+    /// <summary>
+    /// Axes considered when checking whether a <see cref="UnityEngine.RectTransform"/> is fully within another.
+    /// </summary>
+    [Flags]
+    internal enum RectAxes
+    {
+        /// <summary>Not narrowed. Treated the same as <see cref="Both"/>.</summary>
+        None = 0,
+
+        /// <summary>Check the horizontal axis only.</summary>
+        Horizontal = 1,
+
+        /// <summary>Check the vertical axis only.</summary>
+        Vertical = 2,
+
+        /// <summary>Check both axes.</summary>
+        Both = Horizontal | Vertical,
+    }
+}

--- a/Runtime/Constraints/RectAxes.cs.meta
+++ b/Runtime/Constraints/RectAxes.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d6a952dc9bd954e13baf817a21fb03fd

--- a/Runtime/Constraints/RectGeometry.cs
+++ b/Runtime/Constraints/RectGeometry.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Collections.Generic;

--- a/Runtime/Constraints/RectGeometry.cs
+++ b/Runtime/Constraints/RectGeometry.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace TestHelper.Constraints
@@ -10,19 +11,72 @@ namespace TestHelper.Constraints
     /// </summary>
     internal static class RectGeometry
     {
+        /// <summary>
+        /// Returns null when <paramref name="inner"/> is contained in <paramref name="outer"/> on the given
+        /// <paramref name="axes"/> within <paramref name="tolerance"/>; otherwise a description of every
+        /// exceeded edge, e.g. "exceeds the left edge by 12.0px and the top edge by 7.0px".
+        /// </summary>
         internal static string GetOvershoot(Rect inner, Rect outer, RectAxes axes, float tolerance)
         {
-            return default;
+            // RectAxes.None means "not narrowed" and is treated the same as Both.
+            var checkHorizontal = axes == RectAxes.None || (axes & RectAxes.Horizontal) != 0;
+            var checkVertical = axes == RectAxes.None || (axes & RectAxes.Vertical) != 0;
+
+            var clauses = new List<string>();
+
+            if (checkHorizontal)
+            {
+                var left = outer.xMin - inner.xMin;
+                if (left > tolerance)
+                {
+                    clauses.Add($"the left edge by {ConstraintMessageFormatter.Format(left)}px");
+                }
+
+                var right = inner.xMax - outer.xMax;
+                if (right > tolerance)
+                {
+                    clauses.Add($"the right edge by {ConstraintMessageFormatter.Format(right)}px");
+                }
+            }
+
+            if (checkVertical)
+            {
+                // Screen space is Y-up, so the "top" edge is the larger-Y (yMax) side.
+                var top = inner.yMax - outer.yMax;
+                if (top > tolerance)
+                {
+                    clauses.Add($"the top edge by {ConstraintMessageFormatter.Format(top)}px");
+                }
+
+                var bottom = outer.yMin - inner.yMin;
+                if (bottom > tolerance)
+                {
+                    clauses.Add($"the bottom edge by {ConstraintMessageFormatter.Format(bottom)}px");
+                }
+            }
+
+            return clauses.Count == 0 ? null : "exceeds " + string.Join(" and ", clauses);
         }
 
+        /// <summary>
+        /// Overlap extent per axis: min(aMax,bMax) - max(aMin,bMin). Zero or negative means touching/separated.
+        /// </summary>
         internal static Vector2 GetOverlapExtent(Rect a, Rect b)
         {
-            return default;
+            var x = Mathf.Min(a.xMax, b.xMax) - Mathf.Max(a.xMin, b.xMin);
+            var y = Mathf.Min(a.yMax, b.yMax) - Mathf.Max(a.yMin, b.yMin);
+            return new Vector2(x, y);
         }
 
+        /// <summary>
+        /// True when the overlap extent exceeds <paramref name="tolerance"/> on both axes. Does not use
+        /// <see cref="Rect.Overlaps(Rect)"/>, which has no epsilon and would false-fail on sub-pixel error
+        /// for adjacent, zero-gap layout cells.
+        /// </summary>
         internal static bool Overlaps(Rect a, Rect b, float tolerance)
         {
-            return default;
+            var extent = GetOverlapExtent(a, b);
+            return extent.x > tolerance && extent.y > tolerance;
         }
     }
 }

--- a/Runtime/Constraints/RectGeometry.cs
+++ b/Runtime/Constraints/RectGeometry.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using UnityEngine;
+
+namespace TestHelper.Constraints
+{
+    /// <summary>
+    /// Geometry predicates shared by the layout constraints: containment overshoot and overlap extent.
+    /// </summary>
+    internal static class RectGeometry
+    {
+        internal static string GetOvershoot(Rect inner, Rect outer, RectAxes axes, float tolerance)
+        {
+            return default;
+        }
+
+        internal static Vector2 GetOverlapExtent(Rect a, Rect b)
+        {
+            return default;
+        }
+
+        internal static bool Overlaps(Rect a, Rect b, float tolerance)
+        {
+            return default;
+        }
+    }
+}

--- a/Runtime/Constraints/RectGeometry.cs.meta
+++ b/Runtime/Constraints/RectGeometry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 43947d2bacaed414e84b7d30ce8fefc3

--- a/Runtime/Constraints/RectTransformResolver.cs
+++ b/Runtime/Constraints/RectTransformResolver.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using NUnit.Framework.Constraints;
 using UnityEngine;
 
 namespace TestHelper.Constraints
@@ -8,10 +9,43 @@ namespace TestHelper.Constraints
     /// <summary>
     /// Resolves an <c>actual</c> value passed to a layout constraint into a <see cref="RectTransform"/>.
     /// Accepts <see cref="RectTransform"/>, <see cref="GameObject"/>, and <see cref="Component"/>. Never
-    /// throws; a resolution failure is reported through <paramref name="failureReason"/> instead.
+    /// throws; a resolution failure is reported through an output failure-reason string instead.
     /// </summary>
     internal static class RectTransformResolver
     {
+        /// <summary>
+        /// True when <paramref name="actual"/> is a type <see cref="TryResolve"/> can resolve directly to a
+        /// single <see cref="RectTransform"/> (i.e. <see cref="RectTransform"/>, <see cref="GameObject"/>, or
+        /// <see cref="Component"/>), ignoring the null/destroyed cases. Used to distinguish "a single element
+        /// was passed" from "a collection was passed" before enumerating.
+        /// </summary>
+        internal static bool IsResolvableSingle(object actual)
+        {
+            return actual is RectTransform || actual is GameObject || actual is Component;
+        }
+
+        /// <summary>
+        /// Resolves <paramref name="actual"/> for a constraint's <c>ApplyTo</c>, handling the null-actual and
+        /// resolution-failure cases uniformly. Returns null on success (with <paramref name="rectTransform"/>
+        /// set); otherwise the ready failure <see cref="ConstraintResult"/> to return from <c>ApplyTo</c>.
+        /// </summary>
+        internal static ConstraintResult TryResolveOrFail(object actual, IConstraint constraint,
+            out RectTransform rectTransform)
+        {
+            if (actual == null)
+            {
+                rectTransform = null;
+                return new ReportingConstraintResult(constraint, null, false);
+            }
+
+            if (!TryResolve(actual, out rectTransform, out var failureReason))
+            {
+                return new ReportingConstraintResult(constraint, new ConstraintReport(failureReason), false);
+            }
+
+            return null;
+        }
+
         internal static bool TryResolve(object actual, out RectTransform rectTransform, out string failureReason)
         {
             rectTransform = null;

--- a/Runtime/Constraints/RectTransformResolver.cs
+++ b/Runtime/Constraints/RectTransformResolver.cs
@@ -1,15 +1,14 @@
 // Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
-using NUnit.Framework.Constraints;
+using System;
 using UnityEngine;
 
 namespace TestHelper.Constraints
 {
     /// <summary>
     /// Resolves an <c>actual</c> value passed to a layout constraint into a <see cref="RectTransform"/>.
-    /// Accepts <see cref="RectTransform"/>, <see cref="GameObject"/>, and <see cref="Component"/>. Never
-    /// throws; a resolution failure is reported through an output failure-reason string instead.
+    /// Accepts <see cref="RectTransform"/>, <see cref="GameObject"/>, and <see cref="Component"/>.
     /// </summary>
     internal static class RectTransformResolver
     {
@@ -17,7 +16,7 @@ namespace TestHelper.Constraints
         /// True when <paramref name="actual"/> is a type <see cref="TryResolve"/> can resolve directly to a
         /// single <see cref="RectTransform"/> (i.e. <see cref="RectTransform"/>, <see cref="GameObject"/>, or
         /// <see cref="Component"/>), ignoring the null/destroyed cases. Used to distinguish "a single element
-        /// was passed" from "a collection was passed" before enumerating.
+        /// was passed" from "a collection was passed" before enumerating. Never throws.
         /// </summary>
         internal static bool IsResolvableSingle(object actual)
         {
@@ -25,27 +24,36 @@ namespace TestHelper.Constraints
         }
 
         /// <summary>
-        /// Resolves <paramref name="actual"/> for a constraint's <c>ApplyTo</c>, handling the null-actual and
-        /// resolution-failure cases uniformly. Returns null on success (with <paramref name="rectTransform"/>
-        /// set); otherwise the ready failure <see cref="ConstraintResult"/> to return from <c>ApplyTo</c>.
+        /// Resolves <paramref name="actual"/> to a <see cref="RectTransform"/> for a constraint's
+        /// <c>ApplyTo</c>. A resolution failure cannot be reported as an ordinary non-match: the constraint
+        /// has nothing to evaluate, so silently returning "not matched" would make a negated constraint
+        /// (e.g. <c>Is.Not.WithinScreen()</c>) vacuously pass on a null or unusable <paramref name="actual"/>.
         /// </summary>
-        internal static ConstraintResult TryResolveOrFail(object actual, IConstraint constraint,
-            out RectTransform rectTransform)
+        /// <param name="actual">Value to resolve.</param>
+        /// <param name="paramName">Name reported on failure; does not need to be a real parameter of the
+        /// caller (e.g. <c>"element at index 2"</c> for a collection member).</param>
+        /// <exception cref="ArgumentNullException"><paramref name="actual"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="actual"/> is destroyed, is not a
+        /// <see cref="RectTransform"/>, <see cref="GameObject"/>, or <see cref="Component"/>, or its
+        /// GameObject has no <see cref="RectTransform"/> component.</exception>
+        internal static RectTransform ResolveOrThrow(object actual, string paramName)
         {
+            if (TryResolve(actual, out var rectTransform, out var failureReason))
+            {
+                return rectTransform;
+            }
+
             if (actual == null)
             {
-                rectTransform = null;
-                return new ReportingConstraintResult(constraint, null, false);
+                throw new ArgumentNullException(paramName);
             }
 
-            if (!TryResolve(actual, out rectTransform, out var failureReason))
-            {
-                return new ReportingConstraintResult(constraint, new ConstraintReport(failureReason), false);
-            }
-
-            return null;
+            throw new ArgumentException(failureReason, paramName);
         }
 
+        /// <summary>
+        /// Never throws; a resolution failure is reported through <paramref name="failureReason"/> instead.
+        /// </summary>
         internal static bool TryResolve(object actual, out RectTransform rectTransform, out string failureReason)
         {
             rectTransform = null;
@@ -60,7 +68,7 @@ namespace TestHelper.Constraints
             // Checked before any type-specific branch: a destroyed RectTransform/GameObject/Component all
             // report identically here, and this guard runs before GetComponent, which would otherwise throw
             // MissingReferenceException on a destroyed object.
-            if (actual is Object unityObject && !unityObject)
+            if (actual is UnityEngine.Object unityObject && !unityObject)
             {
                 failureReason = "destroyed UnityEngine.Object";
                 return false;

--- a/Runtime/Constraints/RectTransformResolver.cs
+++ b/Runtime/Constraints/RectTransformResolver.cs
@@ -7,15 +7,62 @@ namespace TestHelper.Constraints
 {
     /// <summary>
     /// Resolves an <c>actual</c> value passed to a layout constraint into a <see cref="RectTransform"/>.
-    /// Accepts <see cref="RectTransform"/>, <see cref="GameObject"/>, and <see cref="Component"/>.
+    /// Accepts <see cref="RectTransform"/>, <see cref="GameObject"/>, and <see cref="Component"/>. Never
+    /// throws; a resolution failure is reported through <paramref name="failureReason"/> instead.
     /// </summary>
     internal static class RectTransformResolver
     {
         internal static bool TryResolve(object actual, out RectTransform rectTransform, out string failureReason)
         {
-            rectTransform = default;
-            failureReason = default;
-            return default;
+            rectTransform = null;
+            failureReason = null;
+
+            if (actual == null)
+            {
+                failureReason = "null";
+                return false;
+            }
+
+            // Checked before any type-specific branch: a destroyed RectTransform/GameObject/Component all
+            // report identically here, and this guard runs before GetComponent, which would otherwise throw
+            // MissingReferenceException on a destroyed object.
+            if (actual is Object unityObject && !unityObject)
+            {
+                failureReason = "destroyed UnityEngine.Object";
+                return false;
+            }
+
+            if (actual is RectTransform rectTransformActual)
+            {
+                rectTransform = rectTransformActual;
+                return true;
+            }
+
+            GameObject gameObject;
+            if (actual is GameObject gameObjectActual)
+            {
+                gameObject = gameObjectActual;
+            }
+            else if (actual is Component componentActual)
+            {
+                gameObject = componentActual.gameObject;
+            }
+            else
+            {
+                failureReason =
+                    $"{ConstraintMessageFormatter.DescribeActual(actual)} is not a RectTransform, GameObject, or Component";
+                return false;
+            }
+
+            var found = gameObject.GetComponent<RectTransform>();
+            if (found == null)
+            {
+                failureReason = $"{ConstraintMessageFormatter.Quote(gameObject)} has no RectTransform component";
+                return false;
+            }
+
+            rectTransform = found;
+            return true;
         }
     }
 }

--- a/Runtime/Constraints/RectTransformResolver.cs
+++ b/Runtime/Constraints/RectTransformResolver.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using NUnit.Framework.Constraints;

--- a/Runtime/Constraints/RectTransformResolver.cs
+++ b/Runtime/Constraints/RectTransformResolver.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using UnityEngine;
+
+namespace TestHelper.Constraints
+{
+    /// <summary>
+    /// Resolves an <c>actual</c> value passed to a layout constraint into a <see cref="RectTransform"/>.
+    /// Accepts <see cref="RectTransform"/>, <see cref="GameObject"/>, and <see cref="Component"/>.
+    /// </summary>
+    internal static class RectTransformResolver
+    {
+        internal static bool TryResolve(object actual, out RectTransform rectTransform, out string failureReason)
+        {
+            rectTransform = default;
+            failureReason = default;
+            return default;
+        }
+    }
+}

--- a/Runtime/Constraints/RectTransformResolver.cs.meta
+++ b/Runtime/Constraints/RectTransformResolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e147ea6d2d485454bb4aac86fb1d894b

--- a/Runtime/Constraints/ReportingConstraintResult.cs
+++ b/Runtime/Constraints/ReportingConstraintResult.cs
@@ -19,6 +19,7 @@ namespace TestHelper.Constraints
 
         public override void WriteActualValueTo(MessageWriter writer)
         {
+            writer.Write(ActualValue == null ? "null" : ActualValue.ToString());
         }
     }
 }

--- a/Runtime/Constraints/ReportingConstraintResult.cs
+++ b/Runtime/Constraints/ReportingConstraintResult.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using NUnit.Framework.Constraints;
+
+namespace TestHelper.Constraints
+{
+    /// <summary>
+    /// A <see cref="ConstraintResult"/> that writes its actual value verbatim, so the diagnostic message
+    /// survives even when negated by <c>Is.Not</c> (NUnit rebuilds a plain <see cref="ConstraintResult"/>
+    /// from <c>ActualValue</c> in that case, discarding any subclass).
+    /// </summary>
+    internal sealed class ReportingConstraintResult : ConstraintResult
+    {
+        internal ReportingConstraintResult(IConstraint constraint, object actualValue, bool isSuccess)
+            : base(constraint, actualValue, isSuccess)
+        {
+        }
+
+        public override void WriteActualValueTo(MessageWriter writer)
+        {
+        }
+    }
+}

--- a/Runtime/Constraints/ReportingConstraintResult.cs
+++ b/Runtime/Constraints/ReportingConstraintResult.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using NUnit.Framework.Constraints;

--- a/Runtime/Constraints/ReportingConstraintResult.cs.meta
+++ b/Runtime/Constraints/ReportingConstraintResult.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2e515cb6ff710498184614df27629a0b

--- a/Runtime/Constraints/ScreenRectHelper.cs
+++ b/Runtime/Constraints/ScreenRectHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using UnityEngine;

--- a/Runtime/Constraints/ScreenRectHelper.cs
+++ b/Runtime/Constraints/ScreenRectHelper.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using UnityEngine;
+
+namespace TestHelper.Constraints
+{
+    /// <summary>
+    /// Computes the axis-aligned screen-space rect of a <see cref="RectTransform"/>, supporting all three
+    /// <see cref="Canvas"/> render modes.
+    /// </summary>
+    internal static class ScreenRectHelper
+    {
+        internal static Rect GetScreenRect(RectTransform rectTransform)
+        {
+            return default;
+        }
+
+        internal static Camera GetScreenSpaceCamera(RectTransform rectTransform)
+        {
+            return default;
+        }
+    }
+}

--- a/Runtime/Constraints/ScreenRectHelper.cs
+++ b/Runtime/Constraints/ScreenRectHelper.cs
@@ -9,16 +9,67 @@ namespace TestHelper.Constraints
     /// Computes the axis-aligned screen-space rect of a <see cref="RectTransform"/>, supporting all three
     /// <see cref="Canvas"/> render modes.
     /// </summary>
+    /// <remarks>
+    /// The rect is the axis-aligned bounding box of the four world corners, so a rotated element is
+    /// over-approximated. Scale is handled correctly. Masking/clipping (<c>RectMask2D</c>),
+    /// <c>Canvas.enabled</c>, <c>CanvasGroup.alpha</c>, and <c>activeInHierarchy</c> are ignored — this is
+    /// geometry only.
+    /// </remarks>
     internal static class ScreenRectHelper
     {
         internal static Rect GetScreenRect(RectTransform rectTransform)
         {
-            return default;
+            var camera = GetScreenSpaceCamera(rectTransform);
+
+            var corners = new Vector3[4];
+            rectTransform.GetWorldCorners(corners);
+
+            var min = new Vector2(float.MaxValue, float.MaxValue);
+            var max = new Vector2(float.MinValue, float.MinValue);
+            for (var i = 0; i < corners.Length; i++)
+            {
+                var screenPoint = RectTransformUtility.WorldToScreenPoint(camera, corners[i]);
+                min = Vector2.Min(min, screenPoint);
+                max = Vector2.Max(max, screenPoint);
+            }
+
+            return Rect.MinMaxRect(min.x, min.y, max.x, max.y);
         }
 
         internal static Camera GetScreenSpaceCamera(RectTransform rectTransform)
         {
-            return default;
+            var canvas = FindCanvasInParent(rectTransform);
+            if (canvas == null)
+            {
+                return null;
+            }
+
+            var rootCanvas = canvas.rootCanvas;
+
+            // A non-null camera under Overlay would yield wrong values; RectTransformUtility.WorldToScreenPoint
+            // treats a null camera as "world position == screen position", which is exactly the Overlay
+            // convention (and also the convention used when there is no Canvas ancestor at all).
+            return rootCanvas.renderMode == RenderMode.ScreenSpaceOverlay ? null : rootCanvas.worldCamera;
+        }
+
+        private static Canvas FindCanvasInParent(RectTransform rectTransform)
+        {
+            // A manual walk instead of GetComponentInParent<Canvas>(), because the includeInactive overload
+            // does not exist in Unity 2019.4 and the no-arg form is not reliable for inactive ancestors — a
+            // common test scenario (a Canvas temporarily disabled to check its visibility state).
+            var current = rectTransform.transform;
+            while (current != null)
+            {
+                var canvas = current.GetComponent<Canvas>();
+                if (canvas != null)
+                {
+                    return canvas;
+                }
+
+                current = current.parent;
+            }
+
+            return null;
         }
     }
 }

--- a/Runtime/Constraints/ScreenRectHelper.cs.meta
+++ b/Runtime/Constraints/ScreenRectHelper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ea650ae787e39423a8e6bd2b27cfce6b

--- a/Runtime/Constraints/TextOverflowDetection.cs
+++ b/Runtime/Constraints/TextOverflowDetection.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using UnityEngine;

--- a/Runtime/Constraints/TextOverflowDetection.cs
+++ b/Runtime/Constraints/TextOverflowDetection.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using UnityEngine;
+
+namespace TestHelper.Constraints
+{
+    /// <summary>
+    /// Detection result produced by a text-overflow probe (uGUI or TextMeshPro) and scored by
+    /// <see cref="TextOverflowingConstraint"/>.
+    /// </summary>
+    internal class TextOverflowDetection
+    {
+        internal string ComponentTypeName;
+        internal Vector2 PreferredSize;
+        internal Vector2 RectSize;
+        internal bool WidthChecked;
+        internal bool HeightChecked;
+        internal string SkipReason;
+        internal bool CharactersTruncated;
+        internal string TruncationDetail;
+        internal bool NotLaidOut;
+        internal bool SizeExceeded;
+        internal Vector2 Excess;
+
+        internal bool IsOverflowing => default;
+    }
+}

--- a/Runtime/Constraints/TextOverflowDetection.cs
+++ b/Runtime/Constraints/TextOverflowDetection.cs
@@ -23,6 +23,6 @@ namespace TestHelper.Constraints
         internal bool SizeExceeded;
         internal Vector2 Excess;
 
-        internal bool IsOverflowing => default;
+        internal bool IsOverflowing => SizeExceeded || CharactersTruncated || NotLaidOut;
     }
 }

--- a/Runtime/Constraints/TextOverflowDetection.cs
+++ b/Runtime/Constraints/TextOverflowDetection.cs
@@ -11,7 +11,6 @@ namespace TestHelper.Constraints
     /// </summary>
     internal class TextOverflowDetection
     {
-        internal string ComponentTypeName;
         internal Vector2 PreferredSize;
         internal Vector2 RectSize;
         internal bool WidthChecked;

--- a/Runtime/Constraints/TextOverflowDetection.cs.meta
+++ b/Runtime/Constraints/TextOverflowDetection.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ec0c835031cfc4904aa0408fcfb6047a

--- a/Runtime/Constraints/TextOverflowingConstraint.cs
+++ b/Runtime/Constraints/TextOverflowingConstraint.cs
@@ -64,13 +64,7 @@ namespace TestHelper.Constraints
 
         private static TextOverflowDetection Detect(RectTransform rectTransform)
         {
-            TextOverflowDetection detection = null;
-#if ENABLE_UGUI
-            if (detection == null)
-            {
-                UguiTextOverflowProbe.TryDetect(rectTransform, out detection);
-            }
-#endif
+            UguiTextOverflowProbe.TryDetect(rectTransform, out var detection);
 #if ENABLE_TMP
             if (detection == null)
             {

--- a/Runtime/Constraints/TextOverflowingConstraint.cs
+++ b/Runtime/Constraints/TextOverflowingConstraint.cs
@@ -1,17 +1,21 @@
 // Copyright (c) 2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using System.Collections.Generic;
 using NUnit.Framework.Constraints;
+using UnityEngine;
 
 namespace TestHelper.Constraints
 {
     /// <summary>
     /// An NUnit test constraint class to text overflowing its own <see cref="UnityEngine.RectTransform"/>.
-    /// Supports uGUI <see cref="UnityEngine.UI.Text"/> and TextMeshPro <see cref="TMPro.TMP_Text"/>.
+    /// Supports uGUI <see cref="UnityEngine.UI.Text"/> and TextMeshPro <see cref="TMPro.TMP_Text"/> (uGUI is
+    /// tried first; whichever is found on the target's own GameObject is used).
     /// </summary>
     public class TextOverflowingConstraint : Constraint
     {
-        private float _tolerance;
+        private const float DefaultTolerance = 0.5f;
+        private float _tolerance = DefaultTolerance;
 
         public TextOverflowingConstraint(params object[] args) : base(args)
         {
@@ -24,16 +28,123 @@ namespace TestHelper.Constraints
         /// <returns>this</returns>
         public TextOverflowingConstraint Within(float tolerance)
         {
-            return default;
+            _tolerance = Mathf.Max(0f, tolerance);
+            return this;
         }
 
         /// <inheritdoc/>
-        public override string Description => default;
+        public override string Description => "text overflowing its RectTransform";
 
         /// <inheritdoc/>
         public override ConstraintResult ApplyTo(object actual)
         {
-            return default;
+            if (actual == null)
+            {
+                return new ReportingConstraintResult(this, null, false);
+            }
+
+            if (!RectTransformResolver.TryResolve(actual, out var rectTransform, out var failureReason))
+            {
+                return new ReportingConstraintResult(this, new ConstraintReport(failureReason), false);
+            }
+
+            var detection = Detect(rectTransform);
+            if (detection == null)
+            {
+                var message = $"{ConstraintMessageFormatter.Quote(rectTransform)} has no Text or TMP_Text component";
+                return new ReportingConstraintResult(this, new ConstraintReport(message), false);
+            }
+
+            EvaluateSize(detection);
+
+            var elementName = ConstraintMessageFormatter.Quote(rectTransform);
+            var reportMessage = detection.IsOverflowing
+                ? BuildOverflowingMessage(elementName, detection)
+                : BuildNotOverflowingMessage(elementName, detection);
+
+            return new ReportingConstraintResult(this, new ConstraintReport(reportMessage), detection.IsOverflowing);
+        }
+
+        private static TextOverflowDetection Detect(RectTransform rectTransform)
+        {
+            TextOverflowDetection detection = null;
+#if ENABLE_UGUI
+            if (detection == null)
+            {
+                UguiTextOverflowProbe.TryDetect(rectTransform, out detection);
+            }
+#endif
+#if ENABLE_TMP
+            if (detection == null)
+            {
+                TmpTextOverflowProbe.TryDetect(rectTransform, out detection);
+            }
+#endif
+            return detection;
+        }
+
+        private void EvaluateSize(TextOverflowDetection detection)
+        {
+            if (!detection.WidthChecked && !detection.HeightChecked)
+            {
+                return;
+            }
+
+            var excessX = detection.WidthChecked
+                ? Mathf.Max(0f, detection.PreferredSize.x - detection.RectSize.x)
+                : 0f;
+            var excessY = detection.HeightChecked
+                ? Mathf.Max(0f, detection.PreferredSize.y - detection.RectSize.y)
+                : 0f;
+            var exceedsX = detection.WidthChecked && excessX > _tolerance;
+            var exceedsY = detection.HeightChecked && excessY > _tolerance;
+
+            detection.SizeExceeded = exceedsX || exceedsY;
+            detection.Excess = new Vector2(excessX, excessY);
+        }
+
+        private static string BuildOverflowingMessage(string elementName, TextOverflowDetection detection)
+        {
+            var clauses = new List<string>();
+            if (detection.SizeExceeded)
+            {
+                clauses.Add(
+                    $"preferred size {ConstraintMessageFormatter.Format(detection.PreferredSize)} exceeds rect {ConstraintMessageFormatter.Format(detection.RectSize)} by {ConstraintMessageFormatter.Format(detection.Excess)}");
+            }
+
+            if (detection.CharactersTruncated)
+            {
+                clauses.Add(detection.TruncationDetail);
+            }
+
+            if (detection.NotLaidOut)
+            {
+                clauses.Add("has not been laid out; call Canvas.ForceUpdateCanvases() before asserting");
+            }
+
+            return $"{elementName} {string.Join("; ", clauses)}";
+        }
+
+        private static string BuildNotOverflowingMessage(string elementName, TextOverflowDetection detection)
+        {
+            var notes = new List<string>();
+            if (detection.WidthChecked || detection.HeightChecked)
+            {
+                notes.Add(
+                    $"preferred size {ConstraintMessageFormatter.Format(detection.PreferredSize)} within rect {ConstraintMessageFormatter.Format(detection.RectSize)}");
+            }
+
+            if (!string.IsNullOrEmpty(detection.SkipReason))
+            {
+                notes.Add($"({detection.SkipReason})");
+            }
+
+            if (notes.Count == 0)
+            {
+                notes.Add("fits its rect");
+            }
+
+            return $"{elementName} {string.Join(" ", notes)}";
         }
     }
 }

--- a/Runtime/Constraints/TextOverflowingConstraint.cs
+++ b/Runtime/Constraints/TextOverflowingConstraint.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Collections.Generic;

--- a/Runtime/Constraints/TextOverflowingConstraint.cs
+++ b/Runtime/Constraints/TextOverflowingConstraint.cs
@@ -38,14 +38,10 @@ namespace TestHelper.Constraints
         /// <inheritdoc/>
         public override ConstraintResult ApplyTo(object actual)
         {
-            if (actual == null)
+            var failure = RectTransformResolver.TryResolveOrFail(actual, this, out var rectTransform);
+            if (failure != null)
             {
-                return new ReportingConstraintResult(this, null, false);
-            }
-
-            if (!RectTransformResolver.TryResolve(actual, out var rectTransform, out var failureReason))
-            {
-                return new ReportingConstraintResult(this, new ConstraintReport(failureReason), false);
+                return failure;
             }
 
             var detection = Detect(rectTransform);

--- a/Runtime/Constraints/TextOverflowingConstraint.cs
+++ b/Runtime/Constraints/TextOverflowingConstraint.cs
@@ -36,13 +36,12 @@ namespace TestHelper.Constraints
         public override string Description => "text overflowing its RectTransform";
 
         /// <inheritdoc/>
+        /// <exception cref="System.ArgumentNullException"><paramref name="actual"/> is null.</exception>
+        /// <exception cref="System.ArgumentException"><paramref name="actual"/> cannot be resolved to a
+        /// <see cref="RectTransform"/>.</exception>
         public override ConstraintResult ApplyTo(object actual)
         {
-            var failure = RectTransformResolver.TryResolveOrFail(actual, this, out var rectTransform);
-            if (failure != null)
-            {
-                return failure;
-            }
+            var rectTransform = RectTransformResolver.ResolveOrThrow(actual, nameof(actual));
 
             var detection = Detect(rectTransform);
             if (detection == null)

--- a/Runtime/Constraints/TextOverflowingConstraint.cs
+++ b/Runtime/Constraints/TextOverflowingConstraint.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using NUnit.Framework.Constraints;
+
+namespace TestHelper.Constraints
+{
+    /// <summary>
+    /// An NUnit test constraint class to text overflowing its own <see cref="UnityEngine.RectTransform"/>.
+    /// Supports uGUI <see cref="UnityEngine.UI.Text"/> and TextMeshPro <see cref="TMPro.TMP_Text"/>.
+    /// </summary>
+    public class TextOverflowingConstraint : Constraint
+    {
+        private float _tolerance;
+
+        public TextOverflowingConstraint(params object[] args) : base(args)
+        {
+        }
+
+        /// <summary>
+        /// Set the tolerance in pixels. Negative values are clamped to 0. Default is 0.5f.
+        /// </summary>
+        /// <param name="tolerance">Tolerance in pixels.</param>
+        /// <returns>this</returns>
+        public TextOverflowingConstraint Within(float tolerance)
+        {
+            return default;
+        }
+
+        /// <inheritdoc/>
+        public override string Description => default;
+
+        /// <inheritdoc/>
+        public override ConstraintResult ApplyTo(object actual)
+        {
+            return default;
+        }
+    }
+}

--- a/Runtime/Constraints/TextOverflowingConstraint.cs
+++ b/Runtime/Constraints/TextOverflowingConstraint.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using NUnit.Framework.Constraints;
 using UnityEngine;
@@ -36,9 +37,9 @@ namespace TestHelper.Constraints
         public override string Description => "text overflowing its RectTransform";
 
         /// <inheritdoc/>
-        /// <exception cref="System.ArgumentNullException"><paramref name="actual"/> is null.</exception>
-        /// <exception cref="System.ArgumentException"><paramref name="actual"/> cannot be resolved to a
-        /// <see cref="RectTransform"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="actual"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="actual"/> cannot be resolved to a
+        /// <see cref="RectTransform"/>, or its GameObject has no Text or TMP_Text component.</exception>
         public override ConstraintResult ApplyTo(object actual)
         {
             var rectTransform = RectTransformResolver.ResolveOrThrow(actual, nameof(actual));
@@ -46,8 +47,9 @@ namespace TestHelper.Constraints
             var detection = Detect(rectTransform);
             if (detection == null)
             {
-                var message = $"{ConstraintMessageFormatter.Quote(rectTransform)} has no Text or TMP_Text component";
-                return new ReportingConstraintResult(this, new ConstraintReport(message), false);
+                throw new ArgumentException(
+                    $"{ConstraintMessageFormatter.Quote(rectTransform)} has no Text or TMP_Text component",
+                    nameof(actual));
             }
 
             EvaluateSize(detection);

--- a/Runtime/Constraints/TextOverflowingConstraint.cs.meta
+++ b/Runtime/Constraints/TextOverflowingConstraint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8076c046fa1774ec3a582f6046e94224

--- a/Runtime/Constraints/TmpTextOverflowProbe.cs
+++ b/Runtime/Constraints/TmpTextOverflowProbe.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 #if ENABLE_TMP

--- a/Runtime/Constraints/TmpTextOverflowProbe.cs
+++ b/Runtime/Constraints/TmpTextOverflowProbe.cs
@@ -2,19 +2,63 @@
 // This software is released under the MIT License.
 
 #if ENABLE_TMP
+using TMPro;
 using UnityEngine;
 
 namespace TestHelper.Constraints
 {
     /// <summary>
-    /// Detects text overflow on a TextMeshPro <see cref="TMPro.TMP_Text"/> component.
+    /// Detects text overflow on a TextMeshPro <see cref="TMP_Text"/> component.
     /// </summary>
     internal static class TmpTextOverflowProbe
     {
         internal static bool TryDetect(RectTransform rectTransform, out TextOverflowDetection detection)
         {
-            detection = default;
-            return default;
+            var text = rectTransform.GetComponent<TMP_Text>();
+            if (text == null)
+            {
+                detection = null;
+                return false;
+            }
+
+            detection = new TextOverflowDetection { ComponentTypeName = "TMP_Text" };
+
+            if (text.text.Length == 0)
+            {
+                // Nothing to overflow.
+                return true;
+            }
+
+            // Under TextOverflowModes.Overflow, firstOverflowCharacterIndex is still populated to indicate
+            // where text WOULD be cut, but no characters are actually hidden — only Truncate really drops
+            // them, so only Truncate is treated as an overflow signal here.
+            detection.CharactersTruncated =
+                text.overflowMode == TextOverflowModes.Truncate && text.firstOverflowCharacterIndex >= 0;
+            if (detection.CharactersTruncated)
+            {
+                var total = text.textInfo != null ? text.textInfo.characterCount : text.text.Length;
+                detection.TruncationDetail =
+                    $"characters from index {text.firstOverflowCharacterIndex} of {total} are not rendered (overflowMode: {text.overflowMode})";
+            }
+
+            if (text.enableAutoSizing)
+            {
+                // Auto Sizing shrinks the font to the rect, so comparing preferred height against the rect
+                // would be meaningless.
+                detection.SkipReason = "auto size enabled";
+                return true;
+            }
+
+            detection.PreferredSize = new Vector2(text.preferredWidth, text.preferredHeight);
+            detection.RectSize = rectTransform.rect.size;
+            detection.HeightChecked = true;
+
+            // TMP's preferred width is always measured without wrapping, and its wrapping mode cannot be
+            // read across the supported Unity range without an obsolete API, so the width is never checked.
+            detection.WidthChecked = false;
+            detection.SkipReason = "TMP preferred width is measured without wrapping";
+
+            return true;
         }
     }
 }

--- a/Runtime/Constraints/TmpTextOverflowProbe.cs
+++ b/Runtime/Constraints/TmpTextOverflowProbe.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+#if ENABLE_TMP
+using UnityEngine;
+
+namespace TestHelper.Constraints
+{
+    /// <summary>
+    /// Detects text overflow on a TextMeshPro <see cref="TMPro.TMP_Text"/> component.
+    /// </summary>
+    internal static class TmpTextOverflowProbe
+    {
+        internal static bool TryDetect(RectTransform rectTransform, out TextOverflowDetection detection)
+        {
+            detection = default;
+            return default;
+        }
+    }
+}
+#endif

--- a/Runtime/Constraints/TmpTextOverflowProbe.cs
+++ b/Runtime/Constraints/TmpTextOverflowProbe.cs
@@ -21,7 +21,7 @@ namespace TestHelper.Constraints
                 return false;
             }
 
-            detection = new TextOverflowDetection { ComponentTypeName = "TMP_Text" };
+            detection = new TextOverflowDetection();
 
             if (text.text.Length == 0)
             {

--- a/Runtime/Constraints/TmpTextOverflowProbe.cs.meta
+++ b/Runtime/Constraints/TmpTextOverflowProbe.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fa288861dad3f40c3a927147ebc615e3

--- a/Runtime/Constraints/UguiTextOverflowProbe.cs
+++ b/Runtime/Constraints/UguiTextOverflowProbe.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+#if ENABLE_UGUI
+using UnityEngine;
+
+namespace TestHelper.Constraints
+{
+    /// <summary>
+    /// Detects text overflow on a uGUI <see cref="UnityEngine.UI.Text"/> component.
+    /// </summary>
+    internal static class UguiTextOverflowProbe
+    {
+        internal static bool TryDetect(RectTransform rectTransform, out TextOverflowDetection detection)
+        {
+            detection = default;
+            return default;
+        }
+    }
+}
+#endif

--- a/Runtime/Constraints/UguiTextOverflowProbe.cs
+++ b/Runtime/Constraints/UguiTextOverflowProbe.cs
@@ -21,7 +21,7 @@ namespace TestHelper.Constraints
                 return false;
             }
 
-            detection = new TextOverflowDetection { ComponentTypeName = "Text" };
+            detection = new TextOverflowDetection();
 
             if (text.text.Length == 0)
             {
@@ -43,7 +43,7 @@ namespace TestHelper.Constraints
             // Truncation only removes characters under VerticalWrapMode.Truncate; under Overflow all
             // characters exist and merely spill, which only the size comparison below can detect.
             detection.CharactersTruncated = text.verticalOverflow == VerticalWrapMode.Truncate &&
-                                             generator.characterCountVisible < text.text.Length;
+                                            generator.characterCountVisible < text.text.Length;
             if (detection.CharactersTruncated)
             {
                 detection.TruncationDetail =

--- a/Runtime/Constraints/UguiTextOverflowProbe.cs
+++ b/Runtime/Constraints/UguiTextOverflowProbe.cs
@@ -3,18 +3,74 @@
 
 #if ENABLE_UGUI
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace TestHelper.Constraints
 {
     /// <summary>
-    /// Detects text overflow on a uGUI <see cref="UnityEngine.UI.Text"/> component.
+    /// Detects text overflow on a uGUI <see cref="Text"/> component.
     /// </summary>
     internal static class UguiTextOverflowProbe
     {
         internal static bool TryDetect(RectTransform rectTransform, out TextOverflowDetection detection)
         {
-            detection = default;
-            return default;
+            var text = rectTransform.GetComponent<Text>();
+            if (text == null)
+            {
+                detection = null;
+                return false;
+            }
+
+            detection = new TextOverflowDetection { ComponentTypeName = "Text" };
+
+            if (text.text.Length == 0)
+            {
+                // Nothing to overflow.
+                return true;
+            }
+
+            // Read characterCount BEFORE preferredWidth/preferredHeight: those getters can populate the
+            // text generator as a side effect, which would mask the "never laid out" state checked below.
+            // Skipped under Truncate: a rect too small for even one line can legitimately generate zero
+            // characters, which is a truncation result (handled below), not an unlaid-out one.
+            var generator = text.cachedTextGenerator;
+            if (text.verticalOverflow != VerticalWrapMode.Truncate && generator.characterCount == 0)
+            {
+                detection.NotLaidOut = true;
+                return true;
+            }
+
+            // Truncation only removes characters under VerticalWrapMode.Truncate; under Overflow all
+            // characters exist and merely spill, which only the size comparison below can detect.
+            detection.CharactersTruncated = text.verticalOverflow == VerticalWrapMode.Truncate &&
+                                             generator.characterCountVisible < text.text.Length;
+            if (detection.CharactersTruncated)
+            {
+                detection.TruncationDetail =
+                    $"only {generator.characterCountVisible} of {text.text.Length} characters are rendered";
+            }
+
+            if (text.resizeTextForBestFit)
+            {
+                // Best Fit shrinks the font to the rect, so comparing preferred size against the rect
+                // would be meaningless; only the truncation check above still applies.
+                detection.SkipReason = "best fit enabled";
+                return true;
+            }
+
+            detection.PreferredSize = new Vector2(text.preferredWidth, text.preferredHeight);
+            detection.RectSize = rectTransform.rect.size;
+            detection.HeightChecked = true;
+
+            // Text.preferredWidth reports the unwrapped width even when the text wraps correctly, so
+            // comparing it against the rect width would false-fail correctly-wrapping text.
+            detection.WidthChecked = text.horizontalOverflow == HorizontalWrapMode.Overflow;
+            if (!detection.WidthChecked)
+            {
+                detection.SkipReason = "width check skipped (wrap mode)";
+            }
+
+            return true;
         }
     }
 }

--- a/Runtime/Constraints/UguiTextOverflowProbe.cs
+++ b/Runtime/Constraints/UguiTextOverflowProbe.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 #if ENABLE_UGUI

--- a/Runtime/Constraints/UguiTextOverflowProbe.cs
+++ b/Runtime/Constraints/UguiTextOverflowProbe.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
-#if ENABLE_UGUI
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -74,4 +73,3 @@ namespace TestHelper.Constraints
         }
     }
 }
-#endif

--- a/Runtime/Constraints/UguiTextOverflowProbe.cs.meta
+++ b/Runtime/Constraints/UguiTextOverflowProbe.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d0eedaeb8b3c74f7aafa108be133278f

--- a/Runtime/Constraints/WithinScreenConstraint.cs
+++ b/Runtime/Constraints/WithinScreenConstraint.cs
@@ -2,6 +2,7 @@
 // This software is released under the MIT License.
 
 using NUnit.Framework.Constraints;
+using UnityEngine;
 
 namespace TestHelper.Constraints
 {
@@ -10,7 +11,8 @@ namespace TestHelper.Constraints
     /// </summary>
     public class WithinScreenConstraint : Constraint
     {
-        private float _tolerance;
+        private const float DefaultTolerance = 0.5f;
+        private float _tolerance = DefaultTolerance;
 
         public WithinScreenConstraint(params object[] args) : base(args)
         {
@@ -23,16 +25,36 @@ namespace TestHelper.Constraints
         /// <returns>this</returns>
         public WithinScreenConstraint Within(float tolerance)
         {
-            return default;
+            _tolerance = Mathf.Max(0f, tolerance);
+            return this;
         }
 
         /// <inheritdoc/>
-        public override string Description => default;
+        public override string Description =>
+            $"RectTransform within screen {ConstraintMessageFormatter.FormatIntegral(ScreenBounds)}";
+
+        private static Rect ScreenBounds => new Rect(0f, 0f, Screen.width, Screen.height);
 
         /// <inheritdoc/>
         public override ConstraintResult ApplyTo(object actual)
         {
-            return default;
+            if (actual == null)
+            {
+                return new ReportingConstraintResult(this, null, false);
+            }
+
+            if (!RectTransformResolver.TryResolve(actual, out var rectTransform, out var failureReason))
+            {
+                return new ReportingConstraintResult(this, new ConstraintReport(failureReason), false);
+            }
+
+            var screenRect = ScreenRectHelper.GetScreenRect(rectTransform);
+            var overshoot = RectGeometry.GetOvershoot(screenRect, ScreenBounds, RectAxes.Both, _tolerance);
+            var elementText =
+                $"{ConstraintMessageFormatter.Quote(rectTransform)} {ConstraintMessageFormatter.Format(screenRect)}";
+            var message = overshoot == null ? elementText : $"{elementText} {overshoot}";
+
+            return new ReportingConstraintResult(this, new ConstraintReport(message), overshoot == null);
         }
     }
 }

--- a/Runtime/Constraints/WithinScreenConstraint.cs
+++ b/Runtime/Constraints/WithinScreenConstraint.cs
@@ -36,13 +36,12 @@ namespace TestHelper.Constraints
         private static Rect ScreenBounds => new Rect(0f, 0f, Screen.width, Screen.height);
 
         /// <inheritdoc/>
+        /// <exception cref="System.ArgumentNullException"><paramref name="actual"/> is null.</exception>
+        /// <exception cref="System.ArgumentException"><paramref name="actual"/> cannot be resolved to a
+        /// <see cref="RectTransform"/>.</exception>
         public override ConstraintResult ApplyTo(object actual)
         {
-            var failure = RectTransformResolver.TryResolveOrFail(actual, this, out var rectTransform);
-            if (failure != null)
-            {
-                return failure;
-            }
+            var rectTransform = RectTransformResolver.ResolveOrThrow(actual, nameof(actual));
 
             var screenRect = ScreenRectHelper.GetScreenRect(rectTransform);
             var overshoot = RectGeometry.GetOvershoot(screenRect, ScreenBounds, RectAxes.Both, _tolerance);

--- a/Runtime/Constraints/WithinScreenConstraint.cs
+++ b/Runtime/Constraints/WithinScreenConstraint.cs
@@ -38,14 +38,10 @@ namespace TestHelper.Constraints
         /// <inheritdoc/>
         public override ConstraintResult ApplyTo(object actual)
         {
-            if (actual == null)
+            var failure = RectTransformResolver.TryResolveOrFail(actual, this, out var rectTransform);
+            if (failure != null)
             {
-                return new ReportingConstraintResult(this, null, false);
-            }
-
-            if (!RectTransformResolver.TryResolve(actual, out var rectTransform, out var failureReason))
-            {
-                return new ReportingConstraintResult(this, new ConstraintReport(failureReason), false);
+                return failure;
             }
 
             var screenRect = ScreenRectHelper.GetScreenRect(rectTransform);

--- a/Runtime/Constraints/WithinScreenConstraint.cs
+++ b/Runtime/Constraints/WithinScreenConstraint.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using NUnit.Framework.Constraints;

--- a/Runtime/Constraints/WithinScreenConstraint.cs
+++ b/Runtime/Constraints/WithinScreenConstraint.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using NUnit.Framework.Constraints;
+
+namespace TestHelper.Constraints
+{
+    /// <summary>
+    /// An NUnit test constraint class to a <see cref="UnityEngine.RectTransform"/> within the screen.
+    /// </summary>
+    public class WithinScreenConstraint : Constraint
+    {
+        private float _tolerance;
+
+        public WithinScreenConstraint(params object[] args) : base(args)
+        {
+        }
+
+        /// <summary>
+        /// Set the tolerance in pixels. Negative values are clamped to 0. Default is 0.5f.
+        /// </summary>
+        /// <param name="tolerance">Tolerance in pixels.</param>
+        /// <returns>this</returns>
+        public WithinScreenConstraint Within(float tolerance)
+        {
+            return default;
+        }
+
+        /// <inheritdoc/>
+        public override string Description => default;
+
+        /// <inheritdoc/>
+        public override ConstraintResult ApplyTo(object actual)
+        {
+            return default;
+        }
+    }
+}

--- a/Runtime/Constraints/WithinScreenConstraint.cs.meta
+++ b/Runtime/Constraints/WithinScreenConstraint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5b82c2ff98f404e9295449256691a2ea

--- a/Runtime/TestHelper.asmdef
+++ b/Runtime/TestHelper.asmdef
@@ -40,11 +40,6 @@
             "define": "ENABLE_FLIP_BINDING"
         },
         {
-            "name": "com.unity.ugui",
-            "expression": "",
-            "define": "ENABLE_UGUI"
-        },
-        {
             "name": "com.unity.textmeshpro",
             "expression": "",
             "define": "ENABLE_TMP"

--- a/Runtime/TestHelper.asmdef
+++ b/Runtime/TestHelper.asmdef
@@ -6,7 +6,9 @@
         "UnityEditor.TestRunner",
         "TestHelper.RuntimeInternals",
         "InstantReplay",
-        "UniEnc"
+        "UniEnc",
+        "UnityEngine.UI",
+        "Unity.TextMeshPro"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -14,7 +16,8 @@
     "overrideReferences": true,
     "precompiledReferences": [
         "nunit.framework.dll",
-        "FlipBinding.CSharp.dll"
+        "FlipBinding.CSharp.dll",
+        "UnityEngine.UI.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [
@@ -35,6 +38,21 @@
             "name": "org.nuget.flipbinding.csharp",
             "expression": "1.0.0",
             "define": "ENABLE_FLIP_BINDING"
+        },
+        {
+            "name": "com.unity.ugui",
+            "expression": "",
+            "define": "ENABLE_UGUI"
+        },
+        {
+            "name": "com.unity.textmeshpro",
+            "expression": "",
+            "define": "ENABLE_TMP"
+        },
+        {
+            "name": "com.unity.ugui",
+            "expression": "2.0.0",
+            "define": "ENABLE_TMP"
         }
     ],
     "noEngineReferences": false

--- a/Tests/Runtime/Constraints/FullyWithinConstraintTest.cs
+++ b/Tests/Runtime/Constraints/FullyWithinConstraintTest.cs
@@ -1,0 +1,324 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using NUnit.Framework;
+using TestHelper.Attributes;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TestHelper.Constraints
+{
+    [SuppressMessage("ReSharper", "AccessToStaticMemberViaDerivedType")]
+    public class FullyWithinConstraintTest
+    {
+        public enum ActualKind
+        {
+            RectTransform,
+            GameObject,
+            Component,
+        }
+
+        public enum ContainerState
+        {
+            Null,
+            Destroyed,
+        }
+
+        private static readonly Vector2 ContainerPosition = new Vector2(10f, 10f);
+        private static readonly Vector2 ContainerSize = new Vector2(200f, 150f);
+
+        private static Rect ContainerScreenRect => new Rect(ContainerPosition, ContainerSize);
+
+        private static RectTransform CreateContainer()
+        {
+            var canvasGameObject = new GameObject("Canvas", typeof(Canvas));
+            canvasGameObject.GetComponent<Canvas>().renderMode = RenderMode.ScreenSpaceOverlay;
+
+            var gameObject = new GameObject("Viewport", typeof(RectTransform));
+            var rectTransform = (RectTransform)gameObject.transform;
+            rectTransform.SetParent(canvasGameObject.transform, worldPositionStays: false);
+            rectTransform.anchorMin = Vector2.zero;
+            rectTransform.anchorMax = Vector2.zero;
+            rectTransform.pivot = Vector2.zero;
+            rectTransform.anchoredPosition = ContainerPosition;
+            rectTransform.sizeDelta = ContainerSize;
+            return rectTransform;
+        }
+
+        private static RectTransform CreateElement(string name, RectTransform container, Vector2 localPosition,
+            Vector2 size)
+        {
+            var gameObject = new GameObject(name, typeof(RectTransform));
+            var rectTransform = (RectTransform)gameObject.transform;
+            rectTransform.SetParent(container, worldPositionStays: false);
+            rectTransform.anchorMin = Vector2.zero;
+            rectTransform.anchorMax = Vector2.zero;
+            rectTransform.pivot = Vector2.zero;
+            rectTransform.anchoredPosition = localPosition;
+            rectTransform.sizeDelta = size;
+            return rectTransform;
+        }
+
+        private static Rect ElementScreenRect(Vector2 localPosition, Vector2 size) =>
+            new Rect(ContainerPosition + localPosition, size);
+
+        private static object AsActual(RectTransform rectTransform, ActualKind kind)
+        {
+            switch (kind)
+            {
+                case ActualKind.GameObject:
+                    return rectTransform.gameObject;
+                case ActualKind.Component:
+                    return rectTransform.gameObject.AddComponent<Image>();
+                default:
+                    return rectTransform;
+            }
+        }
+
+        private static RectTransform ContainerFor(ContainerState state)
+        {
+            if (state == ContainerState.Null)
+            {
+                return null;
+            }
+
+            var container = CreateContainer();
+            GameObject.DestroyImmediate(container.gameObject);
+            return container;
+        }
+
+        private static string FormatFloat(float value) => value.ToString("F1", CultureInfo.InvariantCulture);
+
+        private static string FormatRect(Rect rect) =>
+            $"({FormatFloat(rect.x)}, {FormatFloat(rect.y)}, {FormatFloat(rect.width)}, {FormatFloat(rect.height)})";
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsFullyWithin_ElementInsideContainer_Success()
+        {
+            var container = CreateContainer();
+            var actual = CreateElement("Element", container, new Vector2(20f, 20f), new Vector2(100f, 80f));
+
+            Assert.That(actual, Is.FullyWithin(container));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsFullyWithin_AcceptedActualTypes_Success([Values] ActualKind kind)
+        {
+            var container = CreateContainer();
+            var rectTransform = CreateElement("Element", container, new Vector2(20f, 20f), new Vector2(100f, 80f));
+            var actual = AsActual(rectTransform, kind);
+
+            Assert.That(actual, Is.FullyWithin(container));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsFullyWithin_ElementExceedsContainerRightEdge_Failure()
+        {
+            const float Overshoot = 30f;
+            var container = CreateContainer();
+            var localPosition = new Vector2(ContainerSize.x - 50f + Overshoot, 20f);
+            var size = new Vector2(50f, 60f);
+            var element = CreateElement("CardView", container, localPosition, size);
+
+            Assert.That(() =>
+            {
+                Assert.That(element, Is.FullyWithin(container));
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: RectTransform fully within \"Viewport\" {FormatRect(ContainerScreenRect)}{Environment.NewLine}" +
+                $"  But was:  \"CardView\" {FormatRect(ElementScreenRect(localPosition, size))} exceeds the right edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsFullyWithin_Horizontally_ElementExceedsVerticalBoundsOnly_Success()
+        {
+            var container = CreateContainer();
+            var actual = CreateElement("Element", container, new Vector2(20f, -100f), new Vector2(100f, 500f));
+
+            Assert.That(actual, Is.FullyWithin(container).Horizontally());
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsFullyWithin_Horizontally_ElementExceedsHorizontalBounds_Failure()
+        {
+            const float Overshoot = 30f;
+            var container = CreateContainer();
+            var localPosition = new Vector2(ContainerSize.x - 50f + Overshoot, 20f);
+            var size = new Vector2(50f, 60f);
+            var element = CreateElement("CardView", container, localPosition, size);
+
+            Assert.That(() =>
+            {
+                Assert.That(element, Is.FullyWithin(container).Horizontally());
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: RectTransform horizontally fully within \"Viewport\" {FormatRect(ContainerScreenRect)}{Environment.NewLine}" +
+                $"  But was:  \"CardView\" {FormatRect(ElementScreenRect(localPosition, size))} exceeds the right edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsFullyWithin_Vertically_ElementExceedsHorizontalBoundsOnly_Success()
+        {
+            var container = CreateContainer();
+            var actual = CreateElement("Element", container, new Vector2(-100f, 20f), new Vector2(500f, 80f));
+
+            Assert.That(actual, Is.FullyWithin(container).Vertically());
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsFullyWithin_Vertically_ElementExceedsVerticalBounds_Failure()
+        {
+            const float Overshoot = 15f;
+            var container = CreateContainer();
+            var localPosition = new Vector2(20f, ContainerSize.y - 60f + Overshoot);
+            var size = new Vector2(50f, 60f);
+            var element = CreateElement("CardView", container, localPosition, size);
+
+            Assert.That(() =>
+            {
+                Assert.That(element, Is.FullyWithin(container).Vertically());
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: RectTransform vertically fully within \"Viewport\" {FormatRect(ContainerScreenRect)}{Environment.NewLine}" +
+                $"  But was:  \"CardView\" {FormatRect(ElementScreenRect(localPosition, size))} exceeds the top edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsFullyWithin_HorizontallyAndVertically_ElementExceedsVerticalBounds_Failure()
+        {
+            const float Overshoot = 15f;
+            var container = CreateContainer();
+            var localPosition = new Vector2(20f, ContainerSize.y - 60f + Overshoot);
+            var size = new Vector2(50f, 60f);
+            var element = CreateElement("CardView", container, localPosition, size);
+
+            Assert.That(() =>
+            {
+                Assert.That(element, Is.FullyWithin(container).Horizontally().Vertically());
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: RectTransform fully within \"Viewport\" {FormatRect(ContainerScreenRect)}{Environment.NewLine}" +
+                $"  But was:  \"CardView\" {FormatRect(ElementScreenRect(localPosition, size))} exceeds the top edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+        }
+
+        [TestCase(0.0f)]
+        [TestCase(0.5f)]
+        [CreateScene]
+        public void IsFullyWithin_OvershootWithinDefaultTolerance_Success(float overshoot)
+        {
+            var container = CreateContainer();
+            var actual = CreateElement("Element", container, new Vector2(ContainerSize.x - 50f + overshoot, 20f),
+                new Vector2(50f, 60f));
+
+            Assert.That(actual, Is.FullyWithin(container));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsFullyWithin_OvershootWithinSpecifiedTolerance_Success()
+        {
+            const float Overshoot = 1.5f;
+            var container = CreateContainer();
+            var actual = CreateElement("Element", container, new Vector2(ContainerSize.x - 50f + Overshoot, 20f),
+                new Vector2(50f, 60f));
+
+            Assert.That(actual, Is.FullyWithin(container).Within(2f));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsFullyWithin_NullOrDestroyedContainer_Failure([Values] ContainerState state)
+        {
+            var container = ContainerFor(state);
+            var element = CreateElement("Element", CreateContainer(), Vector2.zero, Vector2.zero);
+
+            Assert.That(() =>
+            {
+                Assert.That(element, Is.FullyWithin(container));
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: RectTransform fully within null or destroyed container{Environment.NewLine}" +
+                $"  But was:  container is null or destroyed{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        public void IsFullyWithin_Null_Failure()
+        {
+            var container = CreateContainer();
+
+            Assert.That(() =>
+            {
+                Assert.That(null, Is.FullyWithin(container));
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: RectTransform fully within \"Viewport\" {FormatRect(ContainerScreenRect)}{Environment.NewLine}" +
+                $"  But was:  null{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotFullyWithin_ElementExceedsContainer_Success()
+        {
+            const float Overshoot = 30f;
+            var container = CreateContainer();
+            var actual = CreateElement("Element", container, new Vector2(ContainerSize.x - 50f + Overshoot, 20f),
+                new Vector2(50f, 60f));
+
+            Assert.That(actual, Is.Not.FullyWithin(container)); // Note: Use it in method style when with operators
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotFullyWithin_ElementInsideContainer_Failure()
+        {
+            var container = CreateContainer();
+            var localPosition = new Vector2(20f, 20f);
+            var size = new Vector2(100f, 80f);
+            var element = CreateElement("Element", container, localPosition, size);
+
+            Assert.That(() =>
+            {
+                Assert.That(element, Is.Not.FullyWithin(container)); // Note: Use it in method style when with operators
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: not RectTransform fully within \"Viewport\" {FormatRect(ContainerScreenRect)}{Environment.NewLine}" +
+                $"  But was:  <\"Element\" {FormatRect(ElementScreenRect(localPosition, size))}>{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotFullyWithin_ChainedAxisAndToleranceModifiers_Failure()
+        {
+            var container = CreateContainer();
+            var localPosition = new Vector2(20f, -100f); // vertically out of bounds, horizontally fine
+            var size = new Vector2(100f, 500f);
+            var element = CreateElement("Element", container, localPosition, size);
+
+            Assert.That(() =>
+            {
+                Assert.That(element, Is.Not.FullyWithin(container).Horizontally().Within(2f));
+                // Note: Use it in method style when with operators
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: not RectTransform horizontally fully within \"Viewport\" {FormatRect(ContainerScreenRect)}{Environment.NewLine}" +
+                $"  But was:  <\"Element\" {FormatRect(ElementScreenRect(localPosition, size))}>{Environment.NewLine}"));
+        }
+    }
+}

--- a/Tests/Runtime/Constraints/FullyWithinConstraintTest.cs
+++ b/Tests/Runtime/Constraints/FullyWithinConstraintTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;

--- a/Tests/Runtime/Constraints/FullyWithinConstraintTest.cs
+++ b/Tests/Runtime/Constraints/FullyWithinConstraintTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using NUnit.Framework;
 using TestHelper.Attributes;
 using UnityEngine;
@@ -69,6 +68,8 @@ namespace TestHelper.Constraints
         {
             switch (kind)
             {
+                case ActualKind.RectTransform:
+                    return rectTransform;
                 case ActualKind.GameObject:
                     return rectTransform.gameObject;
                 case ActualKind.Component:
@@ -89,11 +90,6 @@ namespace TestHelper.Constraints
             GameObject.DestroyImmediate(container.gameObject);
             return container;
         }
-
-        private static string FormatFloat(float value) => value.ToString("F1", CultureInfo.InvariantCulture);
-
-        private static string FormatRect(Rect rect) =>
-            $"({FormatFloat(rect.x)}, {FormatFloat(rect.y)}, {FormatFloat(rect.width)}, {FormatFloat(rect.height)})";
 
         [Test]
         [CreateScene]
@@ -133,8 +129,8 @@ namespace TestHelper.Constraints
             {
                 Assert.That(element, Is.FullyWithin(container));
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: RectTransform fully within \"Viewport\" {FormatRect(ContainerScreenRect)}{Environment.NewLine}" +
-                $"  But was:  \"CardView\" {FormatRect(ElementScreenRect(localPosition, size))} exceeds the right edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+                $"  Expected: RectTransform fully within \"Viewport\" {ConstraintMessageFormatter.Format(ContainerScreenRect)}{Environment.NewLine}" +
+                $"  But was:  \"CardView\" {ConstraintMessageFormatter.Format(ElementScreenRect(localPosition, size))} exceeds the right edge by {ConstraintMessageFormatter.Format(Overshoot)}px{Environment.NewLine}"));
         }
 
         [Test]
@@ -163,8 +159,8 @@ namespace TestHelper.Constraints
             {
                 Assert.That(element, Is.FullyWithin(container).Horizontally());
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: RectTransform horizontally fully within \"Viewport\" {FormatRect(ContainerScreenRect)}{Environment.NewLine}" +
-                $"  But was:  \"CardView\" {FormatRect(ElementScreenRect(localPosition, size))} exceeds the right edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+                $"  Expected: RectTransform horizontally fully within \"Viewport\" {ConstraintMessageFormatter.Format(ContainerScreenRect)}{Environment.NewLine}" +
+                $"  But was:  \"CardView\" {ConstraintMessageFormatter.Format(ElementScreenRect(localPosition, size))} exceeds the right edge by {ConstraintMessageFormatter.Format(Overshoot)}px{Environment.NewLine}"));
         }
 
         [Test]
@@ -193,8 +189,8 @@ namespace TestHelper.Constraints
             {
                 Assert.That(element, Is.FullyWithin(container).Vertically());
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: RectTransform vertically fully within \"Viewport\" {FormatRect(ContainerScreenRect)}{Environment.NewLine}" +
-                $"  But was:  \"CardView\" {FormatRect(ElementScreenRect(localPosition, size))} exceeds the top edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+                $"  Expected: RectTransform vertically fully within \"Viewport\" {ConstraintMessageFormatter.Format(ContainerScreenRect)}{Environment.NewLine}" +
+                $"  But was:  \"CardView\" {ConstraintMessageFormatter.Format(ElementScreenRect(localPosition, size))} exceeds the top edge by {ConstraintMessageFormatter.Format(Overshoot)}px{Environment.NewLine}"));
         }
 
         [Test]
@@ -212,8 +208,8 @@ namespace TestHelper.Constraints
             {
                 Assert.That(element, Is.FullyWithin(container).Horizontally().Vertically());
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: RectTransform fully within \"Viewport\" {FormatRect(ContainerScreenRect)}{Environment.NewLine}" +
-                $"  But was:  \"CardView\" {FormatRect(ElementScreenRect(localPosition, size))} exceeds the top edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+                $"  Expected: RectTransform fully within \"Viewport\" {ConstraintMessageFormatter.Format(ContainerScreenRect)}{Environment.NewLine}" +
+                $"  But was:  \"CardView\" {ConstraintMessageFormatter.Format(ElementScreenRect(localPosition, size))} exceeds the top edge by {ConstraintMessageFormatter.Format(Overshoot)}px{Environment.NewLine}"));
         }
 
         [TestCase(0.0f)]
@@ -267,7 +263,7 @@ namespace TestHelper.Constraints
             {
                 Assert.That(null, Is.FullyWithin(container));
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: RectTransform fully within \"Viewport\" {FormatRect(ContainerScreenRect)}{Environment.NewLine}" +
+                $"  Expected: RectTransform fully within \"Viewport\" {ConstraintMessageFormatter.Format(ContainerScreenRect)}{Environment.NewLine}" +
                 $"  But was:  null{Environment.NewLine}"));
         }
 
@@ -298,8 +294,8 @@ namespace TestHelper.Constraints
             {
                 Assert.That(element, Is.Not.FullyWithin(container)); // Note: Use it in method style when with operators
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: not RectTransform fully within \"Viewport\" {FormatRect(ContainerScreenRect)}{Environment.NewLine}" +
-                $"  But was:  <\"Element\" {FormatRect(ElementScreenRect(localPosition, size))}>{Environment.NewLine}"));
+                $"  Expected: not RectTransform fully within \"Viewport\" {ConstraintMessageFormatter.Format(ContainerScreenRect)}{Environment.NewLine}" +
+                $"  But was:  <\"Element\" {ConstraintMessageFormatter.Format(ElementScreenRect(localPosition, size))}>{Environment.NewLine}"));
         }
 
         [Test]
@@ -317,8 +313,8 @@ namespace TestHelper.Constraints
                 Assert.That(element, Is.Not.FullyWithin(container).Horizontally().Within(2f));
                 // Note: Use it in method style when with operators
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: not RectTransform horizontally fully within \"Viewport\" {FormatRect(ContainerScreenRect)}{Environment.NewLine}" +
-                $"  But was:  <\"Element\" {FormatRect(ElementScreenRect(localPosition, size))}>{Environment.NewLine}"));
+                $"  Expected: not RectTransform horizontally fully within \"Viewport\" {ConstraintMessageFormatter.Format(ContainerScreenRect)}{Environment.NewLine}" +
+                $"  But was:  <\"Element\" {ConstraintMessageFormatter.Format(ElementScreenRect(localPosition, size))}>{Environment.NewLine}"));
         }
     }
 }

--- a/Tests/Runtime/Constraints/FullyWithinConstraintTest.cs
+++ b/Tests/Runtime/Constraints/FullyWithinConstraintTest.cs
@@ -240,7 +240,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        public void IsFullyWithin_NullOrDestroyedContainer_Failure([Values] ContainerState state)
+        public void IsFullyWithin_NullOrDestroyedContainer_ThrowsArgumentNullException([Values] ContainerState state)
         {
             var container = ContainerFor(state);
             var element = CreateElement("Element", CreateContainer(), Vector2.zero, Vector2.zero);
@@ -248,23 +248,69 @@ namespace TestHelper.Constraints
             Assert.That(() =>
             {
                 Assert.That(element, Is.FullyWithin(container));
-            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: RectTransform fully within null or destroyed container{Environment.NewLine}" +
-                $"  But was:  container is null or destroyed{Environment.NewLine}"));
+            }, Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("container"));
         }
 
         [Test]
         [CreateScene]
-        public void IsFullyWithin_Null_Failure()
+        public void IsFullyWithin_Null_ThrowsArgumentNullException()
         {
             var container = CreateContainer();
 
             Assert.That(() =>
             {
                 Assert.That(null, Is.FullyWithin(container));
-            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: RectTransform fully within \"Viewport\" {ConstraintMessageFormatter.Format(ContainerScreenRect)}{Environment.NewLine}" +
-                $"  But was:  null{Environment.NewLine}"));
+            }, Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("actual"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsFullyWithin_DestroyedGameObject_ThrowsArgumentException()
+        {
+            var container = CreateContainer();
+            var element = CreateElement("Element", container, Vector2.zero, Vector2.zero);
+            GameObject.DestroyImmediate(element.gameObject);
+
+            Assert.That(() =>
+            {
+                Assert.That(element, Is.FullyWithin(container));
+            }, Throws.TypeOf<ArgumentException>()
+                .With.Property("ParamName").EqualTo("actual")
+                .And.Message.Contains("destroyed UnityEngine.Object"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsFullyWithin_UnsupportedActualType_ThrowsArgumentException()
+        {
+            var container = CreateContainer();
+
+            Assert.That(() =>
+            {
+                // Not a swapped actual/expected: this constant IS the actual value under test, deliberately an
+                // unsupported type, to exercise the "not a RectTransform, GameObject, or Component" failure path.
+                Assert.That("not a RectTransform", Is.FullyWithin(container));
+            }, Throws.TypeOf<ArgumentException>()
+                .With.Property("ParamName").EqualTo("actual")
+                .And.Message.Contains("is not a RectTransform, GameObject, or Component"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsFullyWithin_GameObjectWithoutRectTransform_ThrowsArgumentException()
+        {
+            var container = CreateContainer();
+            var gameObject = new GameObject("PlainObject");
+
+            Assert.That(() =>
+            {
+                Assert.That(gameObject, Is.FullyWithin(container));
+            }, Throws.TypeOf<ArgumentException>()
+                .With.Property("ParamName").EqualTo("actual")
+                .And.Message.Contains("has no RectTransform component"));
         }
 
         [Test]
@@ -296,6 +342,32 @@ namespace TestHelper.Constraints
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: not RectTransform fully within \"Viewport\" {ConstraintMessageFormatter.Format(ContainerScreenRect)}{Environment.NewLine}" +
                 $"  But was:  <\"Element\" {ConstraintMessageFormatter.Format(ElementScreenRect(localPosition, size))}>{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotFullyWithin_NullActual_ThrowsArgumentNullException()
+        {
+            var container = CreateContainer();
+
+            Assert.That(() =>
+            {
+                Assert.That(null, Is.Not.FullyWithin(container)); // Note: Use it in method style when with operators
+            }, Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("actual"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotFullyWithin_NullContainer_ThrowsArgumentNullException()
+        {
+            var element = CreateElement("Element", CreateContainer(), Vector2.zero, Vector2.zero);
+
+            Assert.That(() =>
+            {
+                Assert.That(element, Is.Not.FullyWithin(null)); // Note: Use it in method style when with operators
+            }, Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("container"));
         }
 
         [Test]

--- a/Tests/Runtime/Constraints/FullyWithinConstraintTest.cs.meta
+++ b/Tests/Runtime/Constraints/FullyWithinConstraintTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 605d65fa6c404447b9eb6558559e14b5

--- a/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
@@ -1,0 +1,431 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using NUnit.Framework;
+using TestHelper.Attributes;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TestHelper.Constraints
+{
+    [SuppressMessage("ReSharper", "AccessToStaticMemberViaDerivedType")]
+    public class OverlappingConstraintTest
+    {
+        public enum ActualKind
+        {
+            RectTransform,
+            GameObject,
+            Component,
+        }
+
+        private static Canvas CreateCanvas()
+        {
+            var canvasGameObject = new GameObject("Canvas", typeof(Canvas));
+            canvasGameObject.GetComponent<Canvas>().renderMode = RenderMode.ScreenSpaceOverlay;
+            return canvasGameObject.GetComponent<Canvas>();
+        }
+
+        private static RectTransform CreateElement(Transform parent, string name, Vector2 anchoredPosition,
+            Vector2 sizeDelta)
+        {
+            var gameObject = new GameObject(name, typeof(RectTransform));
+            var rectTransform = (RectTransform)gameObject.transform;
+            rectTransform.SetParent(parent, worldPositionStays: false);
+            rectTransform.anchorMin = Vector2.zero;
+            rectTransform.anchorMax = Vector2.zero;
+            rectTransform.pivot = Vector2.zero;
+            rectTransform.anchoredPosition = anchoredPosition;
+            rectTransform.sizeDelta = sizeDelta;
+            return rectTransform;
+        }
+
+        private static RectTransform[] CreateElements(Transform parent, int count)
+        {
+            if (count == 0)
+            {
+                return Array.Empty<RectTransform>();
+            }
+
+            return new[] { CreateElement(parent, "TestCard (0)", Vector2.zero, new Vector2(50f, 50f)) };
+        }
+
+        private static object AsActual(RectTransform rectTransform, ActualKind kind)
+        {
+            switch (kind)
+            {
+                case ActualKind.GameObject:
+                    return rectTransform.gameObject;
+                case ActualKind.Component:
+                    return rectTransform.gameObject.AddComponent<Image>();
+                default:
+                    return rectTransform;
+            }
+        }
+
+        private static string FormatFloat(float value) => value.ToString("F1", CultureInfo.InvariantCulture);
+
+        private static string FormatRect(Rect rect) =>
+            $"({FormatFloat(rect.x)}, {FormatFloat(rect.y)}, {FormatFloat(rect.width)}, {FormatFloat(rect.height)})";
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotOverlapping_NoPairOverlaps_Success()
+        {
+            var canvas = CreateCanvas();
+            var actual = new[]
+            {
+                CreateElement(canvas.transform, "TestCard (0)", new Vector2(0f, 0f), new Vector2(50f, 50f)),
+                CreateElement(canvas.transform, "TestCard (1)", new Vector2(60f, 0f), new Vector2(50f, 50f)),
+                CreateElement(canvas.transform, "TestCard (2)", new Vector2(120f, 0f), new Vector2(50f, 50f)),
+            };
+
+            Assert.That(actual, Is.Not.Overlapping()); // Note: Use it in method style when with operators
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotOverlapping_AcceptedActualElementTypes_Success([Values] ActualKind kind)
+        {
+            var canvas = CreateCanvas();
+            var element0 = CreateElement(canvas.transform, "TestCard (0)", new Vector2(0f, 0f), new Vector2(50f, 50f));
+            var element1 = CreateElement(canvas.transform, "TestCard (1)", new Vector2(60f, 0f), new Vector2(50f, 50f));
+            var actual = new[] { AsActual(element0, kind), AsActual(element1, kind) };
+
+            Assert.That(actual, Is.Not.Overlapping()); // Note: Use it in method style when with operators
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotOverlapping_TwoElementsOverlap_Failure()
+        {
+            var canvas = CreateCanvas();
+            var element0 = CreateElement(canvas.transform, "TestCard (3)", new Vector2(120f, 40f),
+                new Vector2(100f, 100f));
+            var element1 = CreateElement(canvas.transform, "TestCard (4)", new Vector2(200f, 40f),
+                new Vector2(100f, 100f));
+            var actual = new[] { element0, element1 };
+
+            Assert.That(() =>
+            {
+                Assert.That(actual, Is.Not.Overlapping()); // Note: Use it in method style when with operators
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: not any pair of RectTransforms overlapping{Environment.NewLine}" +
+                $"  But was:  <\"TestCard (3)\" {FormatRect(new Rect(120f, 40f, 100f, 100f))} overlaps \"TestCard (4)\" {FormatRect(new Rect(200f, 40f, 100f, 100f))}>{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotOverlapping_ThreePairsOverlap_Failure()
+        {
+            var canvas = CreateCanvas();
+            var element0 = CreateElement(canvas.transform, "TestCard (0)", new Vector2(0f, 0f),
+                new Vector2(100f, 100f));
+            var element1 = CreateElement(canvas.transform, "TestCard (1)", new Vector2(20f, 20f),
+                new Vector2(100f, 100f));
+            var element2 = CreateElement(canvas.transform, "TestCard (2)", new Vector2(40f, 40f),
+                new Vector2(100f, 100f));
+            var actual = new[] { element0, element1, element2 };
+
+            Assert.That(() =>
+            {
+                Assert.That(actual, Is.Not.Overlapping()); // Note: Use it in method style when with operators
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: not any pair of RectTransforms overlapping{Environment.NewLine}" +
+                $"  But was:  <\"TestCard (0)\" {FormatRect(new Rect(0f, 0f, 100f, 100f))} overlaps \"TestCard (1)\" {FormatRect(new Rect(20f, 20f, 100f, 100f))} (and 2 more overlapping pairs)>{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsOverlapping_AnyPairOverlaps_Success()
+        {
+            var canvas = CreateCanvas();
+            var actual = new[]
+            {
+                CreateElement(canvas.transform, "TestCard (0)", new Vector2(0f, 0f), new Vector2(100f, 100f)),
+                CreateElement(canvas.transform, "TestCard (1)", new Vector2(20f, 20f), new Vector2(100f, 100f)),
+            };
+
+            Assert.That(actual, Is.Overlapping);
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsOverlapping_NoPairOverlaps_Failure()
+        {
+            var canvas = CreateCanvas();
+            var actual = new[]
+            {
+                CreateElement(canvas.transform, "TestCard (0)", new Vector2(0f, 0f), new Vector2(50f, 50f)),
+                CreateElement(canvas.transform, "TestCard (1)", new Vector2(60f, 0f), new Vector2(50f, 50f)),
+            };
+
+            Assert.That(() =>
+            {
+                Assert.That(actual, Is.Overlapping);
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: any pair of RectTransforms overlapping{Environment.NewLine}" +
+                $"  But was:  no overlapping pair among {actual.Length} RectTransforms{Environment.NewLine}"));
+        }
+
+        [TestCase(0.0f)]
+        [TestCase(0.5f)]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotOverlapping_OverlapExtentWithinDefaultTolerance_Success(float overlapExtent)
+        {
+            var canvas = CreateCanvas();
+            var actual = new[]
+            {
+                CreateElement(canvas.transform, "TestCard (0)", new Vector2(0f, 0f), new Vector2(100f, 100f)),
+                CreateElement(canvas.transform, "TestCard (1)", new Vector2(100f - overlapExtent, 0f),
+                    new Vector2(100f, 100f)),
+            };
+
+            Assert.That(actual, Is.Not.Overlapping()); // Note: Use it in method style when with operators
+        }
+
+        [Test]
+        [CreateScene]
+        public void IsNotOverlapping_OverlapExtentExceedsDefaultTolerance_Failure()
+        {
+            const float OverlapExtent = 5f;
+            var canvas = CreateCanvas();
+            var element0 = CreateElement(canvas.transform, "TestCard (0)", new Vector2(0f, 0f),
+                new Vector2(100f, 100f));
+            var element1 = CreateElement(canvas.transform, "TestCard (1)", new Vector2(100f - OverlapExtent, 0f),
+                new Vector2(100f, 100f));
+            var actual = new[] { element0, element1 };
+
+            Assert.That(() =>
+            {
+                Assert.That(actual, Is.Not.Overlapping()); // Note: Use it in method style when with operators
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: not any pair of RectTransforms overlapping{Environment.NewLine}" +
+                $"  But was:  <\"TestCard (0)\" {FormatRect(new Rect(0f, 0f, 100f, 100f))} overlaps \"TestCard (1)\" {FormatRect(new Rect(100f - OverlapExtent, 0f, 100f, 100f))}>{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotOverlapping_OverlapExtentWithinSpecifiedTolerance_Success()
+        {
+            const float OverlapExtent = 1.5f;
+            var canvas = CreateCanvas();
+            var actual = new[]
+            {
+                CreateElement(canvas.transform, "TestCard (0)", new Vector2(0f, 0f), new Vector2(100f, 100f)),
+                CreateElement(canvas.transform, "TestCard (1)", new Vector2(100f - OverlapExtent, 0f),
+                    new Vector2(100f, 100f)),
+            };
+
+            Assert.That(actual, Is.Not.Overlapping().Within(2f));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotOverlapping_OverlapOnSingleAxisOnly_Success()
+        {
+            var canvas = CreateCanvas();
+            var actual = new[]
+            {
+                CreateElement(canvas.transform, "TestCard (0)", new Vector2(0f, 0f), new Vector2(100f, 50f)),
+                CreateElement(canvas.transform, "TestCard (1)", new Vector2(50f, 100f), new Vector2(100f, 50f)),
+            };
+
+            Assert.That(actual, Is.Not.Overlapping()); // Note: Use it in method style when with operators
+        }
+
+        [TestCase(0)]
+        [TestCase(1)]
+        [CreateScene]
+        public void IsNotOverlapping_FewerThanTwoMembers_Success(int memberCount)
+        {
+            var canvas = CreateCanvas();
+            var actual = CreateElements(canvas.transform, memberCount);
+
+            Assert.That(actual, Is.Not.Overlapping()); // Note: Use it in method style when with operators
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotOverlapping_IgnoringGroupContainingBothOverlappingMembers_Success()
+        {
+            var canvas = CreateCanvas();
+            var element0 = CreateElement(canvas.transform, "TestCard (0)", new Vector2(0f, 0f),
+                new Vector2(100f, 100f));
+            var element1 = CreateElement(canvas.transform, "TestCard (1)", new Vector2(20f, 20f),
+                new Vector2(100f, 100f));
+            var actual = new[] { element0, element1 };
+            var ignoredGroup = new[] { element0, element1 };
+
+            Assert.That(actual, Is.Not.Overlapping().Ignoring(ignoredGroup));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotOverlapping_IgnoringGroupContainingOneOverlappingMember_Failure()
+        {
+            var canvas = CreateCanvas();
+            var element0 = CreateElement(canvas.transform, "TestCard (0)", new Vector2(0f, 0f),
+                new Vector2(100f, 100f));
+            var element1 = CreateElement(canvas.transform, "TestCard (1)", new Vector2(20f, 20f),
+                new Vector2(100f, 100f));
+            var actual = new[] { element0, element1 };
+            var ignoredGroup = new[] { element0 };
+
+            Assert.That(() =>
+            {
+                Assert.That(actual, Is.Not.Overlapping().Ignoring(ignoredGroup));
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: not any pair of RectTransforms overlapping{Environment.NewLine}" +
+                $"  But was:  <\"TestCard (0)\" {FormatRect(new Rect(0f, 0f, 100f, 100f))} overlaps \"TestCard (1)\" {FormatRect(new Rect(20f, 20f, 100f, 100f))}>{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotOverlapping_MultipleIgnoredGroups_Success()
+        {
+            var canvas = CreateCanvas();
+            var element0 = CreateElement(canvas.transform, "TestCard (0)", new Vector2(0f, 0f),
+                new Vector2(100f, 100f));
+            var element1 = CreateElement(canvas.transform, "TestCard (1)", new Vector2(20f, 20f),
+                new Vector2(100f, 100f));
+            var element2 = CreateElement(canvas.transform, "TestCard (2)", new Vector2(300f, 0f),
+                new Vector2(100f, 100f));
+            var element3 = CreateElement(canvas.transform, "TestCard (3)", new Vector2(320f, 20f),
+                new Vector2(100f, 100f));
+            var actual = new[] { element0, element1, element2, element3 };
+            var groupA = new[] { element0, element1 };
+            var groupB = new[] { element2, element3 };
+
+            Assert.That(actual, Is.Not.Overlapping().Ignoring(groupA).Ignoring(groupB));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotOverlapping_ChainedIgnoringAndWithinModifiers_Success()
+        {
+            var canvas = CreateCanvas();
+            var element0 = CreateElement(canvas.transform, "TestCard (0)", new Vector2(0f, 0f),
+                new Vector2(100f, 100f));
+            var element1 = CreateElement(canvas.transform, "TestCard (1)", new Vector2(20f, 20f),
+                new Vector2(100f, 100f));
+            var element2 = CreateElement(canvas.transform, "TestCard (2)", new Vector2(300f, 0f),
+                new Vector2(100f, 100f));
+            var element3 = CreateElement(canvas.transform, "TestCard (3)", new Vector2(398.5f, 0f),
+                new Vector2(100f, 100f));
+            var actual = new[] { element0, element1, element2, element3 };
+            var ignoredGroup = new[] { element0, element1 };
+
+            Assert.That(actual, Is.Not.Overlapping().Ignoring(ignoredGroup).Within(2f));
+        }
+
+        [Test]
+        [Category("Acceptance")]
+        public void Ignoring_Null_ThrowsArgumentNullException()
+        {
+            Assert.That(() =>
+            {
+                Is.Overlapping.Ignoring(null);
+            }, Throws.TypeOf<ArgumentNullException>());
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotOverlapping_IgnoredGroupContainsNull_Failure()
+        {
+            var canvas = CreateCanvas();
+            var element0 = CreateElement(canvas.transform, "TestCard (0)", new Vector2(0f, 0f),
+                new Vector2(50f, 50f));
+            var element1 = CreateElement(canvas.transform, "TestCard (1)", new Vector2(60f, 0f),
+                new Vector2(50f, 50f));
+            var actual = new[] { element0, element1 };
+            var ignoredGroup = new RectTransform[] { element0, null };
+
+            Assert.That(() =>
+            {
+                Assert.That(actual, Is.Overlapping.Ignoring(ignoredGroup));
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: any pair of RectTransforms overlapping{Environment.NewLine}" +
+                $"  But was:  ignored group member at index 1: null{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotOverlapping_SingleElementActual_Failure([Values] ActualKind kind)
+        {
+            var canvas = CreateCanvas();
+            var rectTransform = CreateElement(canvas.transform, "Element", Vector2.zero, new Vector2(50f, 50f));
+            var actual = AsActual(rectTransform, kind);
+
+            Assert.That(() =>
+            {
+                Assert.That(actual, Is.Overlapping);
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: any pair of RectTransforms overlapping{Environment.NewLine}" +
+                $"  But was:  \"Element\" is a single RectTransform, not a collection{Environment.NewLine}"));
+        }
+
+        [Test]
+        [Category("Acceptance")]
+        public void IsNotOverlapping_NonCollectionActual_Failure()
+        {
+            Assert.That(() =>
+            {
+                Assert.That("not a collection", Is.Overlapping);
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: any pair of RectTransforms overlapping{Environment.NewLine}" +
+                $"  But was:  <System.String> is not a collection of RectTransforms{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotOverlapping_CollectionContainsElementWithoutRectTransform_Failure()
+        {
+            var canvas = CreateCanvas();
+            var element0 = CreateElement(canvas.transform, "TestCard (0)", Vector2.zero, new Vector2(50f, 50f));
+            var plainObject = new GameObject("PlainObject");
+            var actual = new object[] { element0, plainObject };
+
+            Assert.That(() =>
+            {
+                Assert.That(actual, Is.Overlapping);
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: any pair of RectTransforms overlapping{Environment.NewLine}" +
+                $"  But was:  element at index 1: \"PlainObject\" has no RectTransform component{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        public void IsNotOverlapping_CollectionContainsNullElement_Failure()
+        {
+            var canvas = CreateCanvas();
+            var element0 = CreateElement(canvas.transform, "TestCard (0)", Vector2.zero, new Vector2(50f, 50f));
+            var actual = new RectTransform[] { element0, null };
+
+            Assert.That(() =>
+            {
+                Assert.That(actual, Is.Overlapping);
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: any pair of RectTransforms overlapping{Environment.NewLine}" +
+                $"  But was:  element at index 1: null{Environment.NewLine}"));
+        }
+    }
+}

--- a/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using NUnit.Framework;
 using TestHelper.Attributes;
 using UnityEngine;
@@ -56,6 +55,8 @@ namespace TestHelper.Constraints
         {
             switch (kind)
             {
+                case ActualKind.RectTransform:
+                    return rectTransform;
                 case ActualKind.GameObject:
                     return rectTransform.gameObject;
                 case ActualKind.Component:
@@ -64,11 +65,6 @@ namespace TestHelper.Constraints
                     return rectTransform;
             }
         }
-
-        private static string FormatFloat(float value) => value.ToString("F1", CultureInfo.InvariantCulture);
-
-        private static string FormatRect(Rect rect) =>
-            $"({FormatFloat(rect.x)}, {FormatFloat(rect.y)}, {FormatFloat(rect.width)}, {FormatFloat(rect.height)})";
 
         [Test]
         [CreateScene]
@@ -116,7 +112,7 @@ namespace TestHelper.Constraints
                 Assert.That(actual, Is.Not.Overlapping()); // Note: Use it in method style when with operators
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: not any pair of RectTransforms overlapping{Environment.NewLine}" +
-                $"  But was:  <\"TestCard (3)\" {FormatRect(new Rect(120f, 40f, 100f, 100f))} overlaps \"TestCard (4)\" {FormatRect(new Rect(200f, 40f, 100f, 100f))}>{Environment.NewLine}"));
+                $"  But was:  <\"TestCard (3)\" {ConstraintMessageFormatter.Format(new Rect(120f, 40f, 100f, 100f))} overlaps \"TestCard (4)\" {ConstraintMessageFormatter.Format(new Rect(200f, 40f, 100f, 100f))}>{Environment.NewLine}"));
         }
 
         [Test]
@@ -138,7 +134,7 @@ namespace TestHelper.Constraints
                 Assert.That(actual, Is.Not.Overlapping()); // Note: Use it in method style when with operators
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: not any pair of RectTransforms overlapping{Environment.NewLine}" +
-                $"  But was:  <\"TestCard (0)\" {FormatRect(new Rect(0f, 0f, 100f, 100f))} overlaps \"TestCard (1)\" {FormatRect(new Rect(20f, 20f, 100f, 100f))} (and 2 more overlapping pairs)>{Environment.NewLine}"));
+                $"  But was:  <\"TestCard (0)\" {ConstraintMessageFormatter.Format(new Rect(0f, 0f, 100f, 100f))} overlaps \"TestCard (1)\" {ConstraintMessageFormatter.Format(new Rect(20f, 20f, 100f, 100f))} (and 2 more overlapping pairs)>{Environment.NewLine}"));
         }
 
         [Test]
@@ -210,7 +206,7 @@ namespace TestHelper.Constraints
                 Assert.That(actual, Is.Not.Overlapping()); // Note: Use it in method style when with operators
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: not any pair of RectTransforms overlapping{Environment.NewLine}" +
-                $"  But was:  <\"TestCard (0)\" {FormatRect(new Rect(0f, 0f, 100f, 100f))} overlaps \"TestCard (1)\" {FormatRect(new Rect(100f - OverlapExtent, 0f, 100f, 100f))}>{Environment.NewLine}"));
+                $"  But was:  <\"TestCard (0)\" {ConstraintMessageFormatter.Format(new Rect(0f, 0f, 100f, 100f))} overlaps \"TestCard (1)\" {ConstraintMessageFormatter.Format(new Rect(100f - OverlapExtent, 0f, 100f, 100f))}>{Environment.NewLine}"));
         }
 
         [Test]
@@ -290,7 +286,7 @@ namespace TestHelper.Constraints
                 Assert.That(actual, Is.Not.Overlapping().Ignoring(ignoredGroup));
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: not any pair of RectTransforms overlapping{Environment.NewLine}" +
-                $"  But was:  <\"TestCard (0)\" {FormatRect(new Rect(0f, 0f, 100f, 100f))} overlaps \"TestCard (1)\" {FormatRect(new Rect(20f, 20f, 100f, 100f))}>{Environment.NewLine}"));
+                $"  But was:  <\"TestCard (0)\" {ConstraintMessageFormatter.Format(new Rect(0f, 0f, 100f, 100f))} overlaps \"TestCard (1)\" {ConstraintMessageFormatter.Format(new Rect(20f, 20f, 100f, 100f))}>{Environment.NewLine}"));
         }
 
         [Test]
@@ -347,7 +343,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        public void IsNotOverlapping_IgnoredGroupContainsNull_Failure()
+        public void IsOverlapping_IgnoredGroupContainsNull_Failure()
         {
             var canvas = CreateCanvas();
             var element0 = CreateElement(canvas.transform, "TestCard (0)", new Vector2(0f, 0f),
@@ -355,7 +351,7 @@ namespace TestHelper.Constraints
             var element1 = CreateElement(canvas.transform, "TestCard (1)", new Vector2(60f, 0f),
                 new Vector2(50f, 50f));
             var actual = new[] { element0, element1 };
-            var ignoredGroup = new RectTransform[] { element0, null };
+            var ignoredGroup = new[] { element0, null };
 
             Assert.That(() =>
             {
@@ -368,7 +364,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        public void IsNotOverlapping_SingleElementActual_Failure([Values] ActualKind kind)
+        public void IsOverlapping_SingleElementActual_Failure([Values] ActualKind kind)
         {
             var canvas = CreateCanvas();
             var rectTransform = CreateElement(canvas.transform, "Element", Vector2.zero, new Vector2(50f, 50f));
@@ -384,7 +380,10 @@ namespace TestHelper.Constraints
 
         [Test]
         [Category("Acceptance")]
-        public void IsNotOverlapping_NonCollectionActual_Failure()
+        // Not a swapped actual/expected: this constant IS the actual value under test, deliberately a
+        // non-collection, to exercise the "not a collection of RectTransforms" failure path.
+        [SuppressMessage("Assertion", "NUnit2007:The actual value should not be a constant")]
+        public void IsOverlapping_NonCollectionActual_Failure()
         {
             Assert.That(() =>
             {
@@ -397,7 +396,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        public void IsNotOverlapping_CollectionContainsElementWithoutRectTransform_Failure()
+        public void IsOverlapping_CollectionContainsElementWithoutRectTransform_Failure()
         {
             var canvas = CreateCanvas();
             var element0 = CreateElement(canvas.transform, "TestCard (0)", Vector2.zero, new Vector2(50f, 50f));
@@ -414,11 +413,11 @@ namespace TestHelper.Constraints
 
         [Test]
         [CreateScene]
-        public void IsNotOverlapping_CollectionContainsNullElement_Failure()
+        public void IsOverlapping_CollectionContainsNullElement_Failure()
         {
             var canvas = CreateCanvas();
             var element0 = CreateElement(canvas.transform, "TestCard (0)", Vector2.zero, new Vector2(50f, 50f));
-            var actual = new RectTransform[] { element0, null };
+            var actual = new[] { element0, null };
 
             Assert.That(() =>
             {

--- a/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;

--- a/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
@@ -380,13 +380,12 @@ namespace TestHelper.Constraints
 
         [Test]
         [Category("Acceptance")]
-        // Not a swapped actual/expected: this constant IS the actual value under test, deliberately a
-        // non-collection, to exercise the "not a collection of RectTransforms" failure path.
-        [SuppressMessage("Assertion", "NUnit2007:The actual value should not be a constant")]
         public void IsOverlapping_NonCollectionActual_Failure()
         {
             Assert.That(() =>
             {
+                // Not a swapped actual/expected: this constant IS the actual value under test, deliberately a
+                // non-collection, to exercise the "not a collection of RectTransforms" failure path.
                 Assert.That("not a collection", Is.Overlapping);
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: any pair of RectTransforms overlapping{Environment.NewLine}" +

--- a/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
@@ -343,7 +343,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        public void IsOverlapping_IgnoredGroupContainsNull_Failure()
+        public void IsOverlapping_IgnoredGroupContainsNull_ThrowsArgumentNullException()
         {
             var canvas = CreateCanvas();
             var element0 = CreateElement(canvas.transform, "TestCard (0)", new Vector2(0f, 0f),
@@ -356,15 +356,14 @@ namespace TestHelper.Constraints
             Assert.That(() =>
             {
                 Assert.That(actual, Is.Overlapping.Ignoring(ignoredGroup));
-            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: any pair of RectTransforms overlapping{Environment.NewLine}" +
-                $"  But was:  ignored group member at index 1: null{Environment.NewLine}"));
+            }, Throws.TypeOf<ArgumentNullException>().With.Property("ParamName")
+                .EqualTo("ignored group member at index 1"));
         }
 
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        public void IsOverlapping_SingleElementActual_Failure([Values] ActualKind kind)
+        public void IsOverlapping_SingleElementActual_ThrowsArgumentException([Values] ActualKind kind)
         {
             var canvas = CreateCanvas();
             var rectTransform = CreateElement(canvas.transform, "Element", Vector2.zero, new Vector2(50f, 50f));
@@ -373,29 +372,29 @@ namespace TestHelper.Constraints
             Assert.That(() =>
             {
                 Assert.That(actual, Is.Overlapping);
-            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: any pair of RectTransforms overlapping{Environment.NewLine}" +
-                $"  But was:  \"Element\" is a single RectTransform, not a collection{Environment.NewLine}"));
+            }, Throws.TypeOf<ArgumentException>()
+                .With.Property("ParamName").EqualTo("actual")
+                .And.Message.Contains("is a single RectTransform, not a collection"));
         }
 
         [Test]
         [Category("Acceptance")]
-        public void IsOverlapping_NonCollectionActual_Failure()
+        public void IsOverlapping_NonCollectionActual_ThrowsArgumentException()
         {
             Assert.That(() =>
             {
                 // Not a swapped actual/expected: this constant IS the actual value under test, deliberately a
                 // non-collection, to exercise the "not a collection of RectTransforms" failure path.
                 Assert.That("not a collection", Is.Overlapping);
-            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: any pair of RectTransforms overlapping{Environment.NewLine}" +
-                $"  But was:  <System.String> is not a collection of RectTransforms{Environment.NewLine}"));
+            }, Throws.TypeOf<ArgumentException>()
+                .With.Property("ParamName").EqualTo("actual")
+                .And.Message.Contains("is not a collection of RectTransforms"));
         }
 
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        public void IsOverlapping_CollectionContainsElementWithoutRectTransform_Failure()
+        public void IsOverlapping_CollectionContainsElementWithoutRectTransform_ThrowsArgumentException()
         {
             var canvas = CreateCanvas();
             var element0 = CreateElement(canvas.transform, "TestCard (0)", Vector2.zero, new Vector2(50f, 50f));
@@ -405,14 +404,14 @@ namespace TestHelper.Constraints
             Assert.That(() =>
             {
                 Assert.That(actual, Is.Overlapping);
-            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: any pair of RectTransforms overlapping{Environment.NewLine}" +
-                $"  But was:  element at index 1: \"PlainObject\" has no RectTransform component{Environment.NewLine}"));
+            }, Throws.TypeOf<ArgumentException>()
+                .With.Property("ParamName").EqualTo("element at index 1")
+                .And.Message.Contains("has no RectTransform component"));
         }
 
         [Test]
         [CreateScene]
-        public void IsOverlapping_CollectionContainsNullElement_Failure()
+        public void IsOverlapping_CollectionContainsNullElement_ThrowsArgumentNullException()
         {
             var canvas = CreateCanvas();
             var element0 = CreateElement(canvas.transform, "TestCard (0)", Vector2.zero, new Vector2(50f, 50f));
@@ -421,9 +420,27 @@ namespace TestHelper.Constraints
             Assert.That(() =>
             {
                 Assert.That(actual, Is.Overlapping);
-            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: any pair of RectTransforms overlapping{Environment.NewLine}" +
-                $"  But was:  element at index 1: null{Environment.NewLine}"));
+            }, Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("element at index 1"));
+        }
+
+        [Test]
+        [Category("Acceptance")]
+        public void IsOverlapping_Null_ThrowsArgumentNullException()
+        {
+            Assert.That(() =>
+            {
+                Assert.That(null, Is.Overlapping);
+            }, Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("actual"));
+        }
+
+        [Test]
+        [Category("Acceptance")]
+        public void IsNotOverlapping_Null_ThrowsArgumentNullException()
+        {
+            Assert.That(() =>
+            {
+                Assert.That(null, Is.Not.Overlapping()); // Note: Use it in method style when with operators
+            }, Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("actual"));
         }
     }
 }

--- a/Tests/Runtime/Constraints/OverlappingConstraintTest.cs.meta
+++ b/Tests/Runtime/Constraints/OverlappingConstraintTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 54f8fac507b434a95975f501700ecd37

--- a/Tests/Runtime/Constraints/RectGeometryTest.cs
+++ b/Tests/Runtime/Constraints/RectGeometryTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using NUnit.Framework;

--- a/Tests/Runtime/Constraints/RectGeometryTest.cs
+++ b/Tests/Runtime/Constraints/RectGeometryTest.cs
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using NUnit.Framework;
+using UnityEngine;
+
+namespace TestHelper.Constraints
+{
+    public class RectGeometryTest
+    {
+        [Test]
+        public void GetOvershoot_InnerInsideOuter_ReturnsNull()
+        {
+            var outer = new Rect(0f, 0f, 100f, 100f);
+            var inner = new Rect(10f, 10f, 50f, 50f);
+
+            var actual = RectGeometry.GetOvershoot(inner, outer, RectAxes.Both, 0.5f);
+
+            Assert.That(actual, Is.Null);
+        }
+
+        [TestCase(0.0f)]
+        [TestCase(0.5f)]
+        public void GetOvershoot_OvershootWithinTolerance_ReturnsNull(float overshoot)
+        {
+            var outer = new Rect(0f, 0f, 100f, 100f);
+            var inner = new Rect(60f, 10f, 40f + overshoot, 50f); // right edge overshoots by `overshoot`
+
+            var actual = RectGeometry.GetOvershoot(inner, outer, RectAxes.Both, 0.5f);
+
+            Assert.That(actual, Is.Null);
+        }
+
+        [Test]
+        public void GetOvershoot_ExceedsLeftEdge_ReturnsLeftEdgeOvershootMessage()
+        {
+            var outer = new Rect(0f, 0f, 100f, 100f);
+            var inner = new Rect(-12f, 10f, 50f, 50f); // left edge overshoots by 12.0px
+
+            var actual = RectGeometry.GetOvershoot(inner, outer, RectAxes.Both, 0.5f);
+
+            Assert.That(actual, Is.EqualTo("exceeds the left edge by 12.0px"));
+        }
+
+        [Test]
+        public void GetOvershoot_ExceedsRightEdge_ReturnsRightEdgeOvershootMessage()
+        {
+            var outer = new Rect(0f, 0f, 100f, 100f);
+            var inner = new Rect(50f, 10f, 65f, 50f); // right edge overshoots by 15.0px
+
+            var actual = RectGeometry.GetOvershoot(inner, outer, RectAxes.Both, 0.5f);
+
+            Assert.That(actual, Is.EqualTo("exceeds the right edge by 15.0px"));
+        }
+
+        [Test]
+        public void GetOvershoot_ExceedsTopEdge_ReturnsTopEdgeOvershootMessage()
+        {
+            var outer = new Rect(0f, 0f, 100f, 100f);
+            var inner = new Rect(10f, 40f, 50f, 67f); // top edge overshoots by 7.0px
+
+            var actual = RectGeometry.GetOvershoot(inner, outer, RectAxes.Both, 0.5f);
+
+            Assert.That(actual, Is.EqualTo("exceeds the top edge by 7.0px"));
+        }
+
+        [Test]
+        public void GetOvershoot_ExceedsBottomEdge_ReturnsBottomEdgeOvershootMessage()
+        {
+            var outer = new Rect(0f, 0f, 100f, 100f);
+            var inner = new Rect(10f, -9f, 50f, 50f); // bottom edge overshoots by 9.0px
+
+            var actual = RectGeometry.GetOvershoot(inner, outer, RectAxes.Both, 0.5f);
+
+            Assert.That(actual, Is.EqualTo("exceeds the bottom edge by 9.0px"));
+        }
+
+        [Test]
+        public void GetOvershoot_ExceedsMultipleEdges_ReturnsMessageForAllExceededEdges()
+        {
+            var outer = new Rect(0f, 0f, 100f, 100f);
+            var inner = new Rect(-12f, 40f, 50f, 67f); // left edge by 12.0px, top edge by 7.0px
+
+            var actual = RectGeometry.GetOvershoot(inner, outer, RectAxes.Both, 0.5f);
+
+            Assert.That(actual, Is.EqualTo("exceeds the left edge by 12.0px and the top edge by 7.0px"));
+        }
+
+        [Test]
+        public void GetOvershoot_HorizontalAxisOnly_ExceedsVerticalBoundsOnly_ReturnsNull()
+        {
+            var outer = new Rect(0f, 0f, 100f, 100f);
+            var inner = new Rect(10f, -50f, 50f, 300f); // exceeds top and bottom edges, horizontally inside
+
+            var actual = RectGeometry.GetOvershoot(inner, outer, RectAxes.Horizontal, 0.5f);
+
+            Assert.That(actual, Is.Null);
+        }
+
+        [Test]
+        public void GetOvershoot_VerticalAxisOnly_ExceedsHorizontalBoundsOnly_ReturnsNull()
+        {
+            var outer = new Rect(0f, 0f, 100f, 100f);
+            var inner = new Rect(-50f, 10f, 300f, 50f); // exceeds left and right edges, vertically inside
+
+            var actual = RectGeometry.GetOvershoot(inner, outer, RectAxes.Vertical, 0.5f);
+
+            Assert.That(actual, Is.Null);
+        }
+
+        [Test]
+        public void GetOverlapExtent_OverlappingRects_ReturnsPositiveExtentOnBothAxes()
+        {
+            var a = new Rect(0f, 0f, 100f, 100f);
+            var b = new Rect(50f, 50f, 100f, 100f); // overlapping region is 50x50
+
+            var actual = RectGeometry.GetOverlapExtent(a, b);
+
+            Assert.That(actual, Is.EqualTo(new Vector2(50f, 50f)));
+        }
+
+        [Test]
+        public void GetOverlapExtent_TouchingRects_ReturnsZeroExtentOnTouchingAxis()
+        {
+            var a = new Rect(0f, 0f, 100f, 100f);
+            var b = new Rect(100f, 0f, 100f, 100f); // touching at x = 100, fully overlapping on y
+
+            var actual = RectGeometry.GetOverlapExtent(a, b);
+
+            Assert.That(actual.x, Is.EqualTo(0f));
+        }
+
+        [Test]
+        public void GetOverlapExtent_SeparatedRects_ReturnsNegativeExtentOnSeparatedAxis()
+        {
+            var a = new Rect(0f, 0f, 50f, 50f);
+            var b = new Rect(80f, 0f, 50f, 50f); // 30px gap on x, fully overlapping on y
+
+            var actual = RectGeometry.GetOverlapExtent(a, b);
+
+            Assert.That(actual.x, Is.EqualTo(-30f));
+        }
+
+        [Test]
+        public void Overlaps_ExtentExceedsToleranceOnBothAxes_ReturnsTrue()
+        {
+            var a = new Rect(0f, 0f, 100f, 100f);
+            var b = new Rect(90f, 90f, 100f, 100f); // overlap extent (10, 10)
+
+            var actual = RectGeometry.Overlaps(a, b, 0.5f);
+
+            Assert.That(actual, Is.True);
+        }
+
+        [TestCase(0.0f)]
+        [TestCase(0.5f)]
+        public void Overlaps_ExtentWithinToleranceOnHorizontalAxis_ReturnsFalse(float extent)
+        {
+            var a = new Rect(0f, 0f, 100f, 100f);
+            var b = new Rect(100f - extent, 0f, 100f, 100f); // x overlap = `extent`, y fully overlapping
+
+            var actual = RectGeometry.Overlaps(a, b, 0.5f);
+
+            Assert.That(actual, Is.False);
+        }
+
+        [TestCase(0.0f)]
+        [TestCase(0.5f)]
+        public void Overlaps_ExtentWithinToleranceOnVerticalAxis_ReturnsFalse(float extent)
+        {
+            var a = new Rect(0f, 0f, 100f, 100f);
+            var b = new Rect(0f, 100f - extent, 100f, 100f); // y overlap = `extent`, x fully overlapping
+
+            var actual = RectGeometry.Overlaps(a, b, 0.5f);
+
+            Assert.That(actual, Is.False);
+        }
+
+        [Test]
+        public void Overlaps_SeparatedRects_ReturnsFalse()
+        {
+            var a = new Rect(0f, 0f, 50f, 50f);
+            var b = new Rect(100f, 100f, 50f, 50f); // clearly separated on both axes
+
+            var actual = RectGeometry.Overlaps(a, b, 0.5f);
+
+            Assert.That(actual, Is.False);
+        }
+    }
+}

--- a/Tests/Runtime/Constraints/RectGeometryTest.cs.meta
+++ b/Tests/Runtime/Constraints/RectGeometryTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: feccbe9507ac04a4d89c0b507bd94578

--- a/Tests/Runtime/Constraints/ScreenRectHelperTest.cs
+++ b/Tests/Runtime/Constraints/ScreenRectHelperTest.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.Attributes;
 using UnityEngine;
@@ -93,7 +94,7 @@ namespace TestHelper.Constraints
         {
             var canvas = CreateOverlayCanvas();
             var element = CreateElement(canvas.transform, new Vector2(10f, 20f), new Vector2(100f, 50f));
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             var actual = ScreenRectHelper.GetScreenRect(element);
 
@@ -108,7 +109,7 @@ namespace TestHelper.Constraints
             var camera = CreatePerspectiveCamera();
             var canvas = CreateScreenSpaceCameraCanvas(camera);
             var element = CreateElement(canvas.transform, new Vector2(10f, 20f), new Vector2(100f, 50f));
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             var actual = ScreenRectHelper.GetScreenRect(element);
 
@@ -123,7 +124,7 @@ namespace TestHelper.Constraints
             var camera = CreateOrthographicCamera();
             var canvas = CreateWorldSpaceCanvas(camera);
             var element = CreateElement(canvas.transform, new Vector2(10f, 20f), new Vector2(100f, 50f));
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             var actual = ScreenRectHelper.GetScreenRect(element);
 
@@ -176,7 +177,7 @@ namespace TestHelper.Constraints
             nestedRectTransform.offsetMax = Vector2.zero;
             var element = CreateElement(nestedCanvasGameObject.transform, new Vector2(10f, 20f),
                 new Vector2(100f, 50f));
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             var actual = ScreenRectHelper.GetScreenRect(element);
 

--- a/Tests/Runtime/Constraints/ScreenRectHelperTest.cs
+++ b/Tests/Runtime/Constraints/ScreenRectHelperTest.cs
@@ -1,0 +1,268 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using TestHelper.Attributes;
+using UnityEngine;
+
+namespace TestHelper.Constraints
+{
+    [SuppressMessage("ReSharper", "AccessToStaticMemberViaDerivedType")]
+    public class ScreenRectHelperTest
+    {
+        private static RectTransform CreateElement(Transform parent, Vector2 anchoredPosition, Vector2 sizeDelta)
+        {
+            var gameObject = new GameObject("Element", typeof(RectTransform));
+            var rectTransform = (RectTransform)gameObject.transform;
+            rectTransform.SetParent(parent, worldPositionStays: false);
+            rectTransform.anchorMin = Vector2.zero;
+            rectTransform.anchorMax = Vector2.zero;
+            rectTransform.pivot = Vector2.zero;
+            rectTransform.anchoredPosition = anchoredPosition;
+            rectTransform.sizeDelta = sizeDelta;
+            return rectTransform;
+        }
+
+        private static Canvas CreateOverlayCanvas()
+        {
+            var gameObject = new GameObject("Canvas", typeof(Canvas));
+            var canvas = gameObject.GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            return canvas;
+        }
+
+        private static Camera CreatePerspectiveCamera()
+        {
+            var gameObject = new GameObject("Camera", typeof(Camera));
+            return gameObject.GetComponent<Camera>();
+        }
+
+        private static Camera CreateOrthographicCamera()
+        {
+            var camera = CreatePerspectiveCamera();
+            camera.orthographic = true;
+            camera.orthographicSize = Screen.height / 2f;
+            camera.transform.position = new Vector3(0f, 0f, -10f);
+            return camera;
+        }
+
+        private static Canvas CreateScreenSpaceCameraCanvas(Camera camera)
+        {
+            var gameObject = new GameObject("Canvas", typeof(Canvas));
+            var canvas = gameObject.GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceCamera;
+            canvas.worldCamera = camera;
+            canvas.planeDistance = 10f;
+            return canvas;
+        }
+
+        private static Canvas CreateWorldSpaceCanvas(Camera camera)
+        {
+            var gameObject = new GameObject("Canvas", typeof(Canvas));
+            var canvas = gameObject.GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.WorldSpace;
+            canvas.worldCamera = camera;
+
+            var rectTransform = (RectTransform)canvas.transform;
+            rectTransform.pivot = Vector2.zero;
+            rectTransform.sizeDelta = new Vector2(Screen.width, Screen.height);
+            rectTransform.position = new Vector3(-Screen.width / 2f, -Screen.height / 2f, 0f);
+            return canvas;
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task GetScreenRect_ScreenSpaceOverlayCanvas_ReturnsScreenSpaceRect()
+        {
+            var canvas = CreateOverlayCanvas();
+            var element = CreateElement(canvas.transform, new Vector2(10f, 20f), new Vector2(100f, 50f));
+            await Awaitable.NextFrameAsync();
+
+            var actual = ScreenRectHelper.GetScreenRect(element);
+
+            Assert.That(actual, Is.EqualTo(new Rect(10f, 20f, 100f, 50f)));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task GetScreenRect_ScreenSpaceCameraCanvas_ReturnsScreenSpaceRect()
+        {
+            var camera = CreatePerspectiveCamera();
+            var canvas = CreateScreenSpaceCameraCanvas(camera);
+            var element = CreateElement(canvas.transform, new Vector2(10f, 20f), new Vector2(100f, 50f));
+            await Awaitable.NextFrameAsync();
+
+            var actual = ScreenRectHelper.GetScreenRect(element);
+
+            Assert.That(actual, Is.EqualTo(new Rect(10f, 20f, 100f, 50f)));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task GetScreenRect_WorldSpaceCanvas_ReturnsScreenSpaceRect()
+        {
+            var camera = CreateOrthographicCamera();
+            var canvas = CreateWorldSpaceCanvas(camera);
+            var element = CreateElement(canvas.transform, new Vector2(10f, 20f), new Vector2(100f, 50f));
+            await Awaitable.NextFrameAsync();
+
+            var actual = ScreenRectHelper.GetScreenRect(element);
+
+            Assert.That(actual, Is.EqualTo(new Rect(10f, 20f, 100f, 50f)));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void GetScreenRect_NoCanvasAncestor_ReturnsRectFromWorldCoordinates()
+        {
+            var element = CreateElement(null, new Vector2(10f, 20f), new Vector2(100f, 50f));
+
+            var actual = ScreenRectHelper.GetScreenRect(element);
+
+            Assert.That(actual, Is.EqualTo(new Rect(10f, 20f, 100f, 50f)));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void GetScreenRect_InactiveCanvasAncestor_ReturnsScreenSpaceRect()
+        {
+            var canvas = CreateOverlayCanvas();
+            var element = CreateElement(canvas.transform, new Vector2(10f, 20f), new Vector2(100f, 50f));
+            canvas.gameObject.SetActive(false);
+
+            var actual = ScreenRectHelper.GetScreenRect(element);
+
+            Assert.That(actual, Is.EqualTo(new Rect(10f, 20f, 100f, 50f)));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task GetScreenRect_NestedCanvasUnderScreenSpaceCameraRootCanvas_ReturnsScreenSpaceRect()
+        {
+            var camera = CreatePerspectiveCamera();
+            var rootCanvas = CreateScreenSpaceCameraCanvas(camera);
+            var nestedCanvasGameObject = new GameObject("NestedCanvas", typeof(Canvas));
+            nestedCanvasGameObject.transform.SetParent(rootCanvas.transform, worldPositionStays: false);
+            var element = CreateElement(nestedCanvasGameObject.transform, new Vector2(10f, 20f), new Vector2(100f, 50f));
+            await Awaitable.NextFrameAsync();
+
+            var actual = ScreenRectHelper.GetScreenRect(element);
+
+            Assert.That(actual, Is.EqualTo(new Rect(10f, 20f, 100f, 50f)));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void GetScreenRect_ScaledElement_ReturnsScaledRect()
+        {
+            var canvas = CreateOverlayCanvas();
+            var element = CreateElement(canvas.transform, new Vector2(10f, 20f), new Vector2(50f, 50f));
+            element.localScale = new Vector3(2f, 2f, 1f);
+
+            var actual = ScreenRectHelper.GetScreenRect(element);
+
+            Assert.That(actual, Is.EqualTo(new Rect(10f, 20f, 100f, 100f)));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void GetScreenRect_RotatedElement_ReturnsAxisAlignedBoundingBox()
+        {
+            var canvas = CreateOverlayCanvas();
+            var gameObject = new GameObject("Element", typeof(RectTransform));
+            var element = (RectTransform)gameObject.transform;
+            element.SetParent(canvas.transform, worldPositionStays: false);
+            element.anchorMin = new Vector2(0.5f, 0.5f);
+            element.anchorMax = new Vector2(0.5f, 0.5f);
+            element.pivot = new Vector2(0.5f, 0.5f);
+            element.anchoredPosition = Vector2.zero;
+            element.sizeDelta = new Vector2(100f, 100f);
+            element.localRotation = Quaternion.Euler(0f, 0f, 45f);
+            var expectedBoundingBoxSide = 100f * Mathf.Sqrt(2f); // 45-degree rotated square's AABB side
+
+            var actual = ScreenRectHelper.GetScreenRect(element);
+
+            Assert.That(actual.width, Is.EqualTo(expectedBoundingBoxSide).Within(0.01f), "width");
+            Assert.That(actual.height, Is.EqualTo(expectedBoundingBoxSide).Within(0.01f), "height");
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void GetScreenSpaceCamera_ScreenSpaceOverlayCanvas_ReturnsNull()
+        {
+            var canvas = CreateOverlayCanvas();
+            var element = CreateElement(canvas.transform, Vector2.zero, Vector2.zero);
+
+            var actual = ScreenRectHelper.GetScreenSpaceCamera(element);
+
+            Assert.That(actual, Is.Null);
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void GetScreenSpaceCamera_NoCanvasAncestor_ReturnsNull()
+        {
+            var element = CreateElement(null, Vector2.zero, Vector2.zero);
+
+            var actual = ScreenRectHelper.GetScreenSpaceCamera(element);
+
+            Assert.That(actual, Is.Null);
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void GetScreenSpaceCamera_ScreenSpaceCameraCanvas_ReturnsCanvasWorldCamera()
+        {
+            var camera = CreatePerspectiveCamera();
+            var canvas = CreateScreenSpaceCameraCanvas(camera);
+            var element = CreateElement(canvas.transform, Vector2.zero, Vector2.zero);
+
+            var actual = ScreenRectHelper.GetScreenSpaceCamera(element);
+
+            Assert.That(actual, Is.SameAs(camera));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void GetScreenSpaceCamera_WorldSpaceCanvas_ReturnsCanvasWorldCamera()
+        {
+            var camera = CreateOrthographicCamera();
+            var canvas = CreateWorldSpaceCanvas(camera);
+            var element = CreateElement(canvas.transform, Vector2.zero, Vector2.zero);
+
+            var actual = ScreenRectHelper.GetScreenSpaceCamera(element);
+
+            Assert.That(actual, Is.SameAs(camera));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void GetScreenSpaceCamera_NestedCanvas_ReturnsRootCanvasWorldCamera()
+        {
+            var camera = CreatePerspectiveCamera();
+            var rootCanvas = CreateScreenSpaceCameraCanvas(camera);
+            var nestedCanvasGameObject = new GameObject("NestedCanvas", typeof(Canvas));
+            nestedCanvasGameObject.transform.SetParent(rootCanvas.transform, worldPositionStays: false);
+            var element = CreateElement(nestedCanvasGameObject.transform, Vector2.zero, Vector2.zero);
+
+            var actual = ScreenRectHelper.GetScreenSpaceCamera(element);
+
+            Assert.That(actual, Is.SameAs(camera));
+        }
+    }
+}

--- a/Tests/Runtime/Constraints/ScreenRectHelperTest.cs
+++ b/Tests/Runtime/Constraints/ScreenRectHelperTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Diagnostics.CodeAnalysis;

--- a/Tests/Runtime/Constraints/ScreenRectHelperTest.cs
+++ b/Tests/Runtime/Constraints/ScreenRectHelperTest.cs
@@ -89,6 +89,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task GetScreenRect_ScreenSpaceOverlayCanvas_ReturnsScreenSpaceRect()
         {
             var canvas = CreateOverlayCanvas();
@@ -103,6 +104,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task GetScreenRect_ScreenSpaceCameraCanvas_ReturnsScreenSpaceRect()
         {
             var camera = CreatePerspectiveCamera();
@@ -118,6 +120,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task GetScreenRect_WorldSpaceCanvas_ReturnsScreenSpaceRect()
         {
             var camera = CreateOrthographicCamera();
@@ -159,6 +162,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task GetScreenRect_NestedCanvasUnderScreenSpaceCameraRootCanvas_ReturnsScreenSpaceRect()
         {
             var camera = CreatePerspectiveCamera();
@@ -174,7 +178,8 @@ namespace TestHelper.Constraints
             nestedRectTransform.anchorMax = Vector2.one;
             nestedRectTransform.offsetMin = Vector2.zero;
             nestedRectTransform.offsetMax = Vector2.zero;
-            var element = CreateElement(nestedCanvasGameObject.transform, new Vector2(10f, 20f), new Vector2(100f, 50f));
+            var element = CreateElement(nestedCanvasGameObject.transform, new Vector2(10f, 20f),
+                new Vector2(100f, 50f));
             await Awaitable.NextFrameAsync();
 
             var actual = ScreenRectHelper.GetScreenRect(element);

--- a/Tests/Runtime/Constraints/ScreenRectHelperTest.cs
+++ b/Tests/Runtime/Constraints/ScreenRectHelperTest.cs
@@ -33,6 +33,20 @@ namespace TestHelper.Constraints
             return canvas;
         }
 
+        // Real Camera projection (used by Screen Space - Camera / World Space) round-trips world<->screen
+        // through a projection matrix, which introduces sub-pixel floating-point noise (~1e-5) even for
+        // "round number" inputs — an inherent property of the math, not a defect. Screen Space - Overlay
+        // and the no-Canvas-ancestor path bypass the camera entirely and stay exact (see the other tests
+        // in this fixture using Is.EqualTo without tolerance).
+        private static void AssertApproximatelyEqual(Rect actual, Rect expected)
+        {
+            const float Tolerance = 0.001f;
+            Assert.That(actual.x, Is.EqualTo(expected.x).Within(Tolerance), "x");
+            Assert.That(actual.y, Is.EqualTo(expected.y).Within(Tolerance), "y");
+            Assert.That(actual.width, Is.EqualTo(expected.width).Within(Tolerance), "width");
+            Assert.That(actual.height, Is.EqualTo(expected.height).Within(Tolerance), "height");
+        }
+
         private static Camera CreatePerspectiveCamera()
         {
             var gameObject = new GameObject("Camera", typeof(Camera));
@@ -98,7 +112,7 @@ namespace TestHelper.Constraints
 
             var actual = ScreenRectHelper.GetScreenRect(element);
 
-            Assert.That(actual, Is.EqualTo(new Rect(10f, 20f, 100f, 50f)));
+            AssertApproximatelyEqual(actual, new Rect(10f, 20f, 100f, 50f));
         }
 
         [Test]
@@ -113,7 +127,7 @@ namespace TestHelper.Constraints
 
             var actual = ScreenRectHelper.GetScreenRect(element);
 
-            Assert.That(actual, Is.EqualTo(new Rect(10f, 20f, 100f, 50f)));
+            AssertApproximatelyEqual(actual, new Rect(10f, 20f, 100f, 50f));
         }
 
         [Test]
@@ -151,12 +165,21 @@ namespace TestHelper.Constraints
             var rootCanvas = CreateScreenSpaceCameraCanvas(camera);
             var nestedCanvasGameObject = new GameObject("NestedCanvas", typeof(Canvas));
             nestedCanvasGameObject.transform.SetParent(rootCanvas.transform, worldPositionStays: false);
+            // A freshly added RectTransform defaults to a point anchor with a fixed 100x100 size, not a
+            // stretch to fill its parent; stretch it explicitly so this nested canvas is a transparent
+            // passthrough over its parent's full rect — otherwise it introduces its own (irrelevant to
+            // this test) offset unrelated to the screen-space-camera conversion under test.
+            var nestedRectTransform = (RectTransform)nestedCanvasGameObject.transform;
+            nestedRectTransform.anchorMin = Vector2.zero;
+            nestedRectTransform.anchorMax = Vector2.one;
+            nestedRectTransform.offsetMin = Vector2.zero;
+            nestedRectTransform.offsetMax = Vector2.zero;
             var element = CreateElement(nestedCanvasGameObject.transform, new Vector2(10f, 20f), new Vector2(100f, 50f));
             await Awaitable.NextFrameAsync();
 
             var actual = ScreenRectHelper.GetScreenRect(element);
 
-            Assert.That(actual, Is.EqualTo(new Rect(10f, 20f, 100f, 50f)));
+            AssertApproximatelyEqual(actual, new Rect(10f, 20f, 100f, 50f));
         }
 
         [Test]

--- a/Tests/Runtime/Constraints/ScreenRectHelperTest.cs
+++ b/Tests/Runtime/Constraints/ScreenRectHelperTest.cs
@@ -89,7 +89,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task GetScreenRect_ScreenSpaceOverlayCanvas_ReturnsScreenSpaceRect()
         {
             var canvas = CreateOverlayCanvas();
@@ -104,7 +103,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task GetScreenRect_ScreenSpaceCameraCanvas_ReturnsScreenSpaceRect()
         {
             var camera = CreatePerspectiveCamera();
@@ -120,7 +118,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task GetScreenRect_WorldSpaceCanvas_ReturnsScreenSpaceRect()
         {
             var camera = CreateOrthographicCamera();
@@ -162,7 +159,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task GetScreenRect_NestedCanvasUnderScreenSpaceCameraRootCanvas_ReturnsScreenSpaceRect()
         {
             var camera = CreatePerspectiveCamera();

--- a/Tests/Runtime/Constraints/ScreenRectHelperTest.cs.meta
+++ b/Tests/Runtime/Constraints/ScreenRectHelperTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 243e9bbe88f1745c28121986c4f83249

--- a/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
@@ -96,7 +96,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiTextFitsRect_Success()
         {
             var canvas = CreateCanvas();
@@ -111,7 +110,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_AcceptedActualTypes_Success([Values] ActualKind kind)
         {
             var canvas = CreateCanvas();
@@ -127,7 +125,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsTextOverflowing_UguiTextFitsRect_Failure()
         {
             var canvas = CreateCanvas();
@@ -148,7 +145,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiPreferredSizeExceedsRect_Failure()
         {
             var canvas = CreateCanvas();
@@ -171,7 +167,6 @@ namespace TestHelper.Constraints
         [TestCase(0.5f)]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiExcessWithinDefaultTolerance_Success(float excess)
         {
             var canvas = CreateCanvas();
@@ -191,7 +186,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiExcessWithinSpecifiedTolerance_Success()
         {
             const float Excess = 1.5f;
@@ -212,7 +206,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiBestFitEnabledAndPreferredSizeExceedsRect_Success()
         {
             var canvas = CreateCanvas();
@@ -228,7 +221,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsTextOverflowing_UguiBestFitEnabled_Failure()
         {
             var canvas = CreateCanvas();
@@ -249,7 +241,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiWrapAndUnwrappedPreferredWidthExceedsRectWidth_Success()
         {
             var canvas = CreateCanvas();
@@ -265,7 +256,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsTextOverflowing_UguiWrapAndTextFitsRect_Failure()
         {
             var canvas = CreateCanvas();
@@ -287,7 +277,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiWrapAndPreferredHeightExceedsRectHeight_Failure()
         {
             var canvas = CreateCanvas();
@@ -308,7 +297,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiHorizontalOverflowAndPreferredWidthExceedsRectWidth_Failure()
         {
             var canvas = CreateCanvas();
@@ -329,7 +317,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiTruncateAndCharactersTruncated_Failure()
         {
             var canvas = CreateCanvas();
@@ -351,7 +338,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiVerticalOverflowAndTextSpillsBeyondRect_Failure()
         {
             var canvas = CreateCanvas();
@@ -392,7 +378,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiEmptyText_Success()
         {
             var canvas = CreateCanvas();
@@ -407,7 +392,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_ScaledTextFitsLocalRect_Success()
         {
             var canvas = CreateCanvas();
@@ -423,7 +407,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_TmpTextFitsRect_Success()
         {
             var canvas = CreateCanvas();
@@ -438,7 +421,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_TmpPreferredHeightExceedsRectHeight_Failure()
         {
             var canvas = CreateCanvas();
@@ -459,7 +441,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_TmpAutoSizingEnabledAndPreferredHeightExceedsRectHeight_Success()
         {
             var canvas = CreateCanvas();
@@ -476,7 +457,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_TmpPreferredWidthExceedsRectWidth_Success()
         {
             var canvas = CreateCanvas();
@@ -492,7 +472,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_TmpCharactersNotRendered_Failure()
         {
             var canvas = CreateCanvas();
@@ -514,7 +493,6 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_BothUguiTextAndTmpTextPresentAndOnlyTmpOverflows_Success()
         {
             // Note: a uGUI Text and a TMP_Text cannot coexist on the same GameObject (both derive from

--- a/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.Attributes;
 #if ENABLE_TMP
@@ -140,7 +141,7 @@ namespace TestHelper.Constraints
             var uguiText = CreateUguiText(canvas.transform, "Label", "Hi", new Vector2(300f, 100f));
             Assume.That(uguiText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
         }
@@ -154,7 +155,7 @@ namespace TestHelper.Constraints
             var uguiText = CreateUguiText(canvas.transform, "Label", "Hi", new Vector2(300f, 100f));
             Assume.That(uguiText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
             var actual = AsActual(uguiText.GetComponent<RectTransform>(), kind);
 
             Assert.That(actual, Is.Not.TextOverflowing());
@@ -169,7 +170,7 @@ namespace TestHelper.Constraints
             var uguiText = CreateUguiText(canvas.transform, "Label", "Hi", new Vector2(300f, 100f));
             Assume.That(uguiText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(() =>
             {
@@ -190,7 +191,7 @@ namespace TestHelper.Constraints
                 new Vector2(5f, 5f));
             Assume.That(uguiText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(() =>
             {
@@ -211,12 +212,12 @@ namespace TestHelper.Constraints
             var uguiText = CreateUguiText(canvas.transform, "Label", "Measure", new Vector2(1000f, 200f));
             Assume.That(uguiText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
             var preferredWidth = uguiText.preferredWidth;
             var rectTransform = uguiText.GetComponent<RectTransform>();
             rectTransform.sizeDelta = new Vector2(preferredWidth - excess, 200f);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(rectTransform, Is.Not.TextOverflowing());
         }
@@ -231,12 +232,12 @@ namespace TestHelper.Constraints
             var uguiText = CreateUguiText(canvas.transform, "Label", "Measure", new Vector2(1000f, 200f));
             Assume.That(uguiText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
             var preferredWidth = uguiText.preferredWidth;
             var rectTransform = uguiText.GetComponent<RectTransform>();
             rectTransform.sizeDelta = new Vector2(preferredWidth - Excess, 200f);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(rectTransform, Is.Not.TextOverflowing().Within(2f));
         }
@@ -251,7 +252,7 @@ namespace TestHelper.Constraints
                 new Vector2(20f, 20f), resizeTextForBestFit: true);
             Assume.That(uguiText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
         }
@@ -266,7 +267,7 @@ namespace TestHelper.Constraints
                 new Vector2(20f, 20f), resizeTextForBestFit: true);
             Assume.That(uguiText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(() =>
             {
@@ -286,7 +287,7 @@ namespace TestHelper.Constraints
                 new Vector2(100f, 300f), HorizontalWrapMode.Wrap);
             Assume.That(uguiText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
         }
@@ -301,7 +302,7 @@ namespace TestHelper.Constraints
                 new Vector2(100f, 300f), HorizontalWrapMode.Wrap);
             Assume.That(uguiText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(() =>
             {
@@ -322,7 +323,7 @@ namespace TestHelper.Constraints
                 new Vector2(100f, 10f), HorizontalWrapMode.Wrap);
             Assume.That(uguiText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(() =>
             {
@@ -342,7 +343,7 @@ namespace TestHelper.Constraints
                 new Vector2(5f, 200f));
             Assume.That(uguiText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(() =>
             {
@@ -363,7 +364,7 @@ namespace TestHelper.Constraints
                 new Vector2(150f, 20f), HorizontalWrapMode.Wrap, VerticalWrapMode.Truncate);
             Assume.That(uguiText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(() =>
             {
@@ -383,7 +384,7 @@ namespace TestHelper.Constraints
                 new Vector2(130f, 55f), HorizontalWrapMode.Wrap, VerticalWrapMode.Truncate);
             Assume.That(uguiText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(() =>
             {
@@ -403,7 +404,7 @@ namespace TestHelper.Constraints
                 new Vector2(300f, 5f));
             Assume.That(uguiText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(() =>
             {
@@ -442,7 +443,7 @@ namespace TestHelper.Constraints
             var uguiText = CreateUguiText(canvas.transform, "Label", string.Empty, new Vector2(5f, 5f));
             Assume.That(uguiText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
         }
@@ -457,7 +458,7 @@ namespace TestHelper.Constraints
             Assume.That(uguiText.font, Is.Not.Null);
             uguiText.GetComponent<RectTransform>().localScale = new Vector3(3f, 3f, 1f);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
         }
@@ -472,7 +473,7 @@ namespace TestHelper.Constraints
             var tmpText = CreateTmpText(canvas.transform, "Label", "Hi", new Vector2(300f, 100f));
             Assume.That(tmpText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
         }
@@ -487,7 +488,7 @@ namespace TestHelper.Constraints
                 "This is a long sentence that will wrap over lines", new Vector2(100f, 10f));
             Assume.That(tmpText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(() =>
             {
@@ -509,7 +510,7 @@ namespace TestHelper.Constraints
                 enableAutoSizing: true);
             Assume.That(tmpText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
         }
@@ -524,7 +525,7 @@ namespace TestHelper.Constraints
                 new Vector2(5f, 100f), enableWordWrapping: false);
             Assume.That(tmpText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
         }
@@ -540,7 +541,7 @@ namespace TestHelper.Constraints
                 overflowMode: TextOverflowModes.Truncate);
             Assume.That(tmpText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(() =>
             {
@@ -559,7 +560,7 @@ namespace TestHelper.Constraints
             var tmpText = CreateTmpText(canvas.transform, "Label", string.Empty, new Vector2(5f, 5f));
             Assume.That(tmpText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
         }
@@ -597,7 +598,7 @@ namespace TestHelper.Constraints
                 new Vector2(5f, 5f), enableWordWrapping: false);
             Assume.That(tmpText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
-            await Awaitable.NextFrameAsync();
+            await UniTask.NextFrame();
 
             Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
         }

--- a/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
@@ -536,7 +536,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        public void IsNotTextOverflowing_NoTextComponent_Failure()
+        public void IsTextOverflowing_NoTextComponent_ThrowsArgumentException()
         {
             var canvas = CreateCanvas();
             var gameObject = new GameObject("PlainObject", typeof(RectTransform));
@@ -545,9 +545,26 @@ namespace TestHelper.Constraints
             Assert.That(() =>
             {
                 Assert.That(gameObject.GetComponent<RectTransform>(), Is.TextOverflowing);
-            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: text overflowing its RectTransform{Environment.NewLine}" +
-                $"  But was:  \"PlainObject\" has no Text or TMP_Text component{Environment.NewLine}"));
+            }, Throws.TypeOf<ArgumentException>()
+                .With.Property("ParamName").EqualTo("actual")
+                .And.Message.Contains("has no Text or TMP_Text component"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotTextOverflowing_NoTextComponent_ThrowsArgumentException()
+        {
+            var canvas = CreateCanvas();
+            var gameObject = new GameObject("PlainObject", typeof(RectTransform));
+            gameObject.transform.SetParent(canvas.transform, worldPositionStays: false);
+
+            Assert.That(() =>
+            {
+                Assert.That(gameObject.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            }, Throws.TypeOf<ArgumentException>()
+                .With.Property("ParamName").EqualTo("actual")
+                .And.Message.Contains("has no Text or TMP_Text component"));
         }
 
         [Test]

--- a/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
@@ -82,6 +82,8 @@ namespace TestHelper.Constraints
         {
             switch (kind)
             {
+                case ActualKind.RectTransform:
+                    return rectTransform;
                 case ActualKind.GameObject:
                     return rectTransform.gameObject;
                 case ActualKind.Component:
@@ -94,6 +96,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiTextFitsRect_Success()
         {
             var canvas = CreateCanvas();
@@ -108,6 +111,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_AcceptedActualTypes_Success([Values] ActualKind kind)
         {
             var canvas = CreateCanvas();
@@ -123,6 +127,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsTextOverflowing_UguiTextFitsRect_Failure()
         {
             var canvas = CreateCanvas();
@@ -143,6 +148,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiPreferredSizeExceedsRect_Failure()
         {
             var canvas = CreateCanvas();
@@ -165,6 +171,7 @@ namespace TestHelper.Constraints
         [TestCase(0.5f)]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiExcessWithinDefaultTolerance_Success(float excess)
         {
             var canvas = CreateCanvas();
@@ -184,6 +191,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiExcessWithinSpecifiedTolerance_Success()
         {
             const float Excess = 1.5f;
@@ -204,6 +212,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiBestFitEnabledAndPreferredSizeExceedsRect_Success()
         {
             var canvas = CreateCanvas();
@@ -219,6 +228,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsTextOverflowing_UguiBestFitEnabled_Failure()
         {
             var canvas = CreateCanvas();
@@ -239,6 +249,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiWrapAndUnwrappedPreferredWidthExceedsRectWidth_Success()
         {
             var canvas = CreateCanvas();
@@ -254,6 +265,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsTextOverflowing_UguiWrapAndTextFitsRect_Failure()
         {
             var canvas = CreateCanvas();
@@ -275,6 +287,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiWrapAndPreferredHeightExceedsRectHeight_Failure()
         {
             var canvas = CreateCanvas();
@@ -295,6 +308,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiHorizontalOverflowAndPreferredWidthExceedsRectWidth_Failure()
         {
             var canvas = CreateCanvas();
@@ -315,6 +329,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiTruncateAndCharactersTruncated_Failure()
         {
             var canvas = CreateCanvas();
@@ -336,6 +351,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiVerticalOverflowAndTextSpillsBeyondRect_Failure()
         {
             var canvas = CreateCanvas();
@@ -376,6 +392,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_UguiEmptyText_Success()
         {
             var canvas = CreateCanvas();
@@ -390,6 +407,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_ScaledTextFitsLocalRect_Success()
         {
             var canvas = CreateCanvas();
@@ -405,6 +423,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_TmpTextFitsRect_Success()
         {
             var canvas = CreateCanvas();
@@ -419,6 +438,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_TmpPreferredHeightExceedsRectHeight_Failure()
         {
             var canvas = CreateCanvas();
@@ -439,6 +459,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_TmpAutoSizingEnabledAndPreferredHeightExceedsRectHeight_Success()
         {
             var canvas = CreateCanvas();
@@ -455,6 +476,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_TmpPreferredWidthExceedsRectWidth_Success()
         {
             var canvas = CreateCanvas();
@@ -470,6 +492,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_TmpCharactersNotRendered_Failure()
         {
             var canvas = CreateCanvas();
@@ -491,6 +514,7 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        [SuppressMessage("ReSharper", "AsyncMethodNamingHighlighting")]
         public async Task IsNotTextOverflowing_BothUguiTextAndTmpTextPresentAndOnlyTmpOverflows_Success()
         {
             // Note: a uGUI Text and a TMP_Text cannot coexist on the same GameObject (both derive from
@@ -503,7 +527,7 @@ namespace TestHelper.Constraints
             Assume.That(uguiText.font, Is.Not.Null);
             var tmpText = CreateTmpText(canvas.transform, "OtherLabel",
                 "A very very very long single line of overflowing text content that exceeds the rect",
-                new Vector2(5f, 5f), TextWrappingModes.NoWrap, false, TextOverflowModes.Overflow);
+                new Vector2(5f, 5f), TextWrappingModes.NoWrap);
             Assume.That(tmpText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
             await Awaitable.NextFrameAsync();

--- a/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;

--- a/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
@@ -338,6 +338,26 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_UguiTruncateAndLineAfterEmbeddedNewlineNotRendered_Failure()
+        {
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", "Overflowing sentence\nSecond line",
+                new Vector2(130f, 55f), HorizontalWrapMode.Wrap, VerticalWrapMode.Truncate);
+            Assume.That(uguiText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(() =>
+            {
+                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            }, Throws.TypeOf<AssertionException>()
+                .With.Message.Contains("\"Label\"")
+                .And.Message.Contains("are rendered"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
         public async Task IsNotTextOverflowing_UguiVerticalOverflowAndTextSpillsBeyondRect_Failure()
         {
             var canvas = CreateCanvas();
@@ -531,14 +551,68 @@ namespace TestHelper.Constraints
         }
 
         [Test]
-        public void IsNotTextOverflowing_Null_Failure()
+        public void IsTextOverflowing_Null_ThrowsArgumentNullException()
         {
             Assert.That(() =>
             {
                 Assert.That(null, Is.TextOverflowing);
-            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: text overflowing its RectTransform{Environment.NewLine}" +
-                $"  But was:  null{Environment.NewLine}"));
+            }, Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("actual"));
+        }
+
+        [Test]
+        public void IsNotTextOverflowing_Null_ThrowsArgumentNullException()
+        {
+            Assert.That(() =>
+            {
+                Assert.That(null, Is.Not.TextOverflowing());
+            }, Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("actual"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsTextOverflowing_DestroyedGameObject_ThrowsArgumentException()
+        {
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", "Hi", new Vector2(300f, 100f));
+            var rectTransform = uguiText.GetComponent<RectTransform>();
+            GameObject.DestroyImmediate(uguiText.gameObject);
+
+            Assert.That(() =>
+            {
+                Assert.That(rectTransform, Is.TextOverflowing);
+            }, Throws.TypeOf<ArgumentException>()
+                .With.Property("ParamName").EqualTo("actual")
+                .And.Message.Contains("destroyed UnityEngine.Object"));
+        }
+
+        [Test]
+        [Category("Acceptance")]
+        public void IsTextOverflowing_UnsupportedActualType_ThrowsArgumentException()
+        {
+            Assert.That(() =>
+            {
+                // Not a swapped actual/expected: this constant IS the actual value under test, deliberately an
+                // unsupported type, to exercise the "not a RectTransform, GameObject, or Component" failure path.
+                Assert.That("not a RectTransform", Is.TextOverflowing);
+            }, Throws.TypeOf<ArgumentException>()
+                .With.Property("ParamName").EqualTo("actual")
+                .And.Message.Contains("is not a RectTransform, GameObject, or Component"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsTextOverflowing_GameObjectWithoutRectTransform_ThrowsArgumentException()
+        {
+            var gameObject = new GameObject("PlainObject");
+
+            Assert.That(() =>
+            {
+                Assert.That(gameObject, Is.TextOverflowing);
+            }, Throws.TypeOf<ArgumentException>()
+                .With.Property("ParamName").EqualTo("actual")
+                .And.Message.Contains("has no RectTransform component"));
         }
     }
 }

--- a/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
@@ -24,6 +24,12 @@ namespace TestHelper.Constraints
             Component,
         }
 
+#if UNITY_2022_2_OR_NEWER
+        private const string BuiltinFontName = "LegacyRuntime.ttf";
+#else
+        private const string BuiltinFontName = "Arial.ttf"; // Arial.ttf was replaced by LegacyRuntime.ttf in Unity 2022.2
+#endif
+
         private static Canvas CreateCanvas()
         {
             var canvasGameObject = new GameObject("Canvas", typeof(Canvas));
@@ -46,7 +52,7 @@ namespace TestHelper.Constraints
             rectTransform.sizeDelta = size;
 
             var uguiText = gameObject.GetComponent<Text>();
-            uguiText.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            uguiText.font = Resources.GetBuiltinResource<Font>(BuiltinFontName);
             uguiText.text = text;
             uguiText.fontSize = 20;
             uguiText.horizontalOverflow = horizontalOverflow;
@@ -58,6 +64,28 @@ namespace TestHelper.Constraints
         }
 
 #if ENABLE_TMP
+        private static TMP_FontAsset s_fallbackTmpFontAsset;
+
+        private static TMP_FontAsset GetTmpFontAsset()
+        {
+            if (TMP_Settings.defaultFontAsset != null)
+            {
+                return TMP_Settings.defaultFontAsset;
+            }
+
+            // TMP_Settings.defaultFontAsset requires the "TMP Essential Resources" to be imported, which
+            // freshly-generated CI projects never do — every TMP test would go Inconclusive there. Fall
+            // back to a runtime-created dynamic font asset instead. Cached in a static because each
+            // CreateFontAsset call builds a new dynamic atlas.
+            if (s_fallbackTmpFontAsset == null)
+            {
+                s_fallbackTmpFontAsset =
+                    TMP_FontAsset.CreateFontAsset(Resources.GetBuiltinResource<Font>(BuiltinFontName));
+            }
+
+            return s_fallbackTmpFontAsset;
+        }
+
         private static TMP_Text CreateTmpText(Transform parent, string name, string text, Vector2 size,
             bool enableWordWrapping = true, bool enableAutoSizing = false,
             TextOverflowModes overflowMode = TextOverflowModes.Overflow)
@@ -72,7 +100,7 @@ namespace TestHelper.Constraints
             rectTransform.sizeDelta = size;
 
             var tmpText = gameObject.GetComponent<TextMeshProUGUI>();
-            tmpText.font = TMP_Settings.defaultFontAsset;
+            tmpText.font = GetTmpFontAsset();
             tmpText.text = text;
             tmpText.fontSize = 20;
             // textWrappingMode/TextWrappingModes isn't available in the TMP version bundled with

--- a/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
@@ -1,0 +1,542 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using TestHelper.Attributes;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TestHelper.Constraints
+{
+    [SuppressMessage("ReSharper", "AccessToStaticMemberViaDerivedType")]
+    public class TextOverflowingConstraintTest
+    {
+        public enum ActualKind
+        {
+            RectTransform,
+            GameObject,
+            Component,
+        }
+
+        private static Canvas CreateCanvas()
+        {
+            var canvasGameObject = new GameObject("Canvas", typeof(Canvas));
+            canvasGameObject.GetComponent<Canvas>().renderMode = RenderMode.ScreenSpaceOverlay;
+            return canvasGameObject.GetComponent<Canvas>();
+        }
+
+        private static Text CreateUguiText(Transform parent, string name, string text, Vector2 size,
+            HorizontalWrapMode horizontalOverflow = HorizontalWrapMode.Overflow,
+            VerticalWrapMode verticalOverflow = VerticalWrapMode.Overflow,
+            bool resizeTextForBestFit = false)
+        {
+            var gameObject = new GameObject(name, typeof(RectTransform), typeof(Text));
+            var rectTransform = (RectTransform)gameObject.transform;
+            rectTransform.SetParent(parent, worldPositionStays: false);
+            rectTransform.anchorMin = Vector2.zero;
+            rectTransform.anchorMax = Vector2.zero;
+            rectTransform.pivot = Vector2.zero;
+            rectTransform.anchoredPosition = Vector2.zero;
+            rectTransform.sizeDelta = size;
+
+            var uguiText = gameObject.GetComponent<Text>();
+            uguiText.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            uguiText.text = text;
+            uguiText.fontSize = 20;
+            uguiText.horizontalOverflow = horizontalOverflow;
+            uguiText.verticalOverflow = verticalOverflow;
+            uguiText.resizeTextForBestFit = resizeTextForBestFit;
+            uguiText.resizeTextMinSize = 10;
+            uguiText.resizeTextMaxSize = 40;
+            return uguiText;
+        }
+
+        private static TMP_Text CreateTmpText(Transform parent, string name, string text, Vector2 size,
+            TextWrappingModes wrappingMode = TextWrappingModes.Normal, bool enableAutoSizing = false,
+            TextOverflowModes overflowMode = TextOverflowModes.Overflow)
+        {
+            var gameObject = new GameObject(name, typeof(RectTransform), typeof(TextMeshProUGUI));
+            var rectTransform = (RectTransform)gameObject.transform;
+            rectTransform.SetParent(parent, worldPositionStays: false);
+            rectTransform.anchorMin = Vector2.zero;
+            rectTransform.anchorMax = Vector2.zero;
+            rectTransform.pivot = Vector2.zero;
+            rectTransform.anchoredPosition = Vector2.zero;
+            rectTransform.sizeDelta = size;
+
+            var tmpText = gameObject.GetComponent<TextMeshProUGUI>();
+            tmpText.font = TMP_Settings.defaultFontAsset;
+            tmpText.text = text;
+            tmpText.fontSize = 20;
+            tmpText.textWrappingMode = wrappingMode;
+            tmpText.enableAutoSizing = enableAutoSizing;
+            tmpText.overflowMode = overflowMode;
+            return tmpText;
+        }
+
+        private static object AsActual(RectTransform rectTransform, ActualKind kind)
+        {
+            switch (kind)
+            {
+                case ActualKind.GameObject:
+                    return rectTransform.gameObject;
+                case ActualKind.Component:
+                    return rectTransform.GetComponent<Text>();
+                default:
+                    return rectTransform;
+            }
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_UguiTextFitsRect_Success()
+        {
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", "Hi", new Vector2(300f, 100f));
+            Assume.That(uguiText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_AcceptedActualTypes_Success([Values] ActualKind kind)
+        {
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", "Hi", new Vector2(300f, 100f));
+            Assume.That(uguiText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+            var actual = AsActual(uguiText.GetComponent<RectTransform>(), kind);
+
+            Assert.That(actual, Is.Not.TextOverflowing());
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsTextOverflowing_UguiTextFitsRect_Failure()
+        {
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", "Hi", new Vector2(300f, 100f));
+            Assume.That(uguiText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(() =>
+            {
+                Assert.That(uguiText.GetComponent<RectTransform>(), Is.TextOverflowing);
+            }, Throws.TypeOf<AssertionException>()
+                .With.Message.Contains("Expected: text overflowing its RectTransform")
+                .And.Message.Contains("\"Label\"")
+                .And.Message.Contains("within rect"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_UguiPreferredSizeExceedsRect_Failure()
+        {
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", "Overflowing text content",
+                new Vector2(5f, 5f));
+            Assume.That(uguiText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(() =>
+            {
+                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            }, Throws.TypeOf<AssertionException>()
+                .With.Message.Contains("Expected: not text overflowing its RectTransform")
+                .And.Message.Contains("\"Label\"")
+                .And.Message.Contains("exceeds rect"));
+        }
+
+        [TestCase(0.0f)]
+        [TestCase(0.5f)]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_UguiExcessWithinDefaultTolerance_Success(float excess)
+        {
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", "Measure", new Vector2(1000f, 200f));
+            Assume.That(uguiText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+            var preferredWidth = uguiText.preferredWidth;
+            var rectTransform = uguiText.GetComponent<RectTransform>();
+            rectTransform.sizeDelta = new Vector2(preferredWidth - excess, 200f);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(rectTransform, Is.Not.TextOverflowing());
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_UguiExcessWithinSpecifiedTolerance_Success()
+        {
+            const float Excess = 1.5f;
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", "Measure", new Vector2(1000f, 200f));
+            Assume.That(uguiText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+            var preferredWidth = uguiText.preferredWidth;
+            var rectTransform = uguiText.GetComponent<RectTransform>();
+            rectTransform.sizeDelta = new Vector2(preferredWidth - Excess, 200f);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(rectTransform, Is.Not.TextOverflowing().Within(2f));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_UguiBestFitEnabledAndPreferredSizeExceedsRect_Success()
+        {
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", "Very long overflowing label text",
+                new Vector2(20f, 20f), resizeTextForBestFit: true);
+            Assume.That(uguiText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsTextOverflowing_UguiBestFitEnabled_Failure()
+        {
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", "Very long overflowing label text",
+                new Vector2(20f, 20f), resizeTextForBestFit: true);
+            Assume.That(uguiText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(() =>
+            {
+                Assert.That(uguiText.GetComponent<RectTransform>(), Is.TextOverflowing);
+            }, Throws.TypeOf<AssertionException>()
+                .With.Message.Contains("\"Label\"")
+                .And.Message.Contains("best fit"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_UguiWrapAndUnwrappedPreferredWidthExceedsRectWidth_Success()
+        {
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", "This is a long sentence that will wrap",
+                new Vector2(100f, 300f), HorizontalWrapMode.Wrap);
+            Assume.That(uguiText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsTextOverflowing_UguiWrapAndTextFitsRect_Failure()
+        {
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", "This is a long sentence that will wrap",
+                new Vector2(100f, 300f), HorizontalWrapMode.Wrap);
+            Assume.That(uguiText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(() =>
+            {
+                Assert.That(uguiText.GetComponent<RectTransform>(), Is.TextOverflowing);
+            }, Throws.TypeOf<AssertionException>()
+                .With.Message.Contains("\"Label\"")
+                .And.Message.Contains("width")
+                .And.Message.Contains("skipped"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_UguiWrapAndPreferredHeightExceedsRectHeight_Failure()
+        {
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", "This is a long sentence that will wrap",
+                new Vector2(100f, 10f), HorizontalWrapMode.Wrap);
+            Assume.That(uguiText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(() =>
+            {
+                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            }, Throws.TypeOf<AssertionException>()
+                .With.Message.Contains("\"Label\"")
+                .And.Message.Contains("exceeds rect"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_UguiHorizontalOverflowAndPreferredWidthExceedsRectWidth_Failure()
+        {
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", "Overflowing text content",
+                new Vector2(5f, 200f));
+            Assume.That(uguiText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(() =>
+            {
+                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            }, Throws.TypeOf<AssertionException>()
+                .With.Message.Contains("\"Label\"")
+                .And.Message.Contains("exceeds rect"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_UguiTruncateAndCharactersTruncated_Failure()
+        {
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label",
+                "This text will not fully fit and gets truncated",
+                new Vector2(150f, 20f), HorizontalWrapMode.Wrap, VerticalWrapMode.Truncate);
+            Assume.That(uguiText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(() =>
+            {
+                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            }, Throws.TypeOf<AssertionException>()
+                .With.Message.Contains("\"Label\"")
+                .And.Message.Contains("are rendered"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_UguiVerticalOverflowAndTextSpillsBeyondRect_Failure()
+        {
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", "Single line text",
+                new Vector2(300f, 5f));
+            Assume.That(uguiText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(() =>
+            {
+                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            }, Throws.TypeOf<AssertionException>()
+                .With.Message.Contains("\"Label\"")
+                .And.Message.Contains("exceeds rect")
+                .And.Message.Not.Contains("are rendered"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotTextOverflowing_UguiTextNotLaidOut_Failure()
+        {
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", "Some text", new Vector2(200f, 50f));
+            Assume.That(uguiText.font, Is.Not.Null);
+            // Note: intentionally skip Canvas.ForceUpdateCanvases()/frame wait so the TextGenerator never populates
+
+            Assert.That(() =>
+            {
+                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            }, Throws.TypeOf<AssertionException>()
+                .With.Message.Contains("\"Label\"")
+                .And.Message.Contains("has not been laid out; call Canvas.ForceUpdateCanvases() before asserting")
+                .And.Message.Not.Contains("are rendered"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_UguiEmptyText_Success()
+        {
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", string.Empty, new Vector2(5f, 5f));
+            Assume.That(uguiText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_ScaledTextFitsLocalRect_Success()
+        {
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", "Hi", new Vector2(300f, 100f));
+            Assume.That(uguiText.font, Is.Not.Null);
+            uguiText.GetComponent<RectTransform>().localScale = new Vector3(3f, 3f, 1f);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_TmpTextFitsRect_Success()
+        {
+            var canvas = CreateCanvas();
+            var tmpText = CreateTmpText(canvas.transform, "Label", "Hi", new Vector2(300f, 100f));
+            Assume.That(tmpText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_TmpPreferredHeightExceedsRectHeight_Failure()
+        {
+            var canvas = CreateCanvas();
+            var tmpText = CreateTmpText(canvas.transform, "Label",
+                "This is a long sentence that will wrap over lines", new Vector2(100f, 10f));
+            Assume.That(tmpText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(() =>
+            {
+                Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            }, Throws.TypeOf<AssertionException>()
+                .With.Message.Contains("\"Label\"")
+                .And.Message.Contains("exceeds rect"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_TmpAutoSizingEnabledAndPreferredHeightExceedsRectHeight_Success()
+        {
+            var canvas = CreateCanvas();
+            var tmpText = CreateTmpText(canvas.transform, "Label",
+                "This is a long sentence that will wrap over lines", new Vector2(100f, 10f),
+                enableAutoSizing: true);
+            Assume.That(tmpText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_TmpPreferredWidthExceedsRectWidth_Success()
+        {
+            var canvas = CreateCanvas();
+            var tmpText = CreateTmpText(canvas.transform, "Label", "A very very very long single line of text",
+                new Vector2(5f, 100f), TextWrappingModes.NoWrap);
+            Assume.That(tmpText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_TmpCharactersNotRendered_Failure()
+        {
+            var canvas = CreateCanvas();
+            var tmpText = CreateTmpText(canvas.transform, "Label",
+                "This text will not fully fit and gets truncated", new Vector2(150f, 20f),
+                TextWrappingModes.Normal, false, TextOverflowModes.Truncate);
+            Assume.That(tmpText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(() =>
+            {
+                Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            }, Throws.TypeOf<AssertionException>()
+                .With.Message.Contains("\"Label\"")
+                .And.Message.Contains("are not rendered (overflowMode: Truncate)"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_BothUguiTextAndTmpTextPresentAndOnlyTmpOverflows_Success()
+        {
+            // Note: a uGUI Text and a TMP_Text cannot coexist on the same GameObject (both derive from
+            // Graphic, and a GameObject allows only one Graphic component), so the TMP element that would
+            // overflow is placed on a sibling GameObject instead. This still exercises the same precedence
+            // guarantee (GetComponent looks at the target's own GameObject only, so a nearby, unrelated,
+            // overflowing TMP element must not affect the uGUI Text's own fitting result).
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", "Hi", new Vector2(300f, 100f));
+            Assume.That(uguiText.font, Is.Not.Null);
+            var tmpText = CreateTmpText(canvas.transform, "OtherLabel",
+                "A very very very long single line of overflowing text content that exceeds the rect",
+                new Vector2(5f, 5f), TextWrappingModes.NoWrap, false, TextOverflowModes.Overflow);
+            Assume.That(tmpText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotTextOverflowing_NoTextComponent_Failure()
+        {
+            var canvas = CreateCanvas();
+            var gameObject = new GameObject("PlainObject", typeof(RectTransform));
+            gameObject.transform.SetParent(canvas.transform, worldPositionStays: false);
+
+            Assert.That(() =>
+            {
+                Assert.That(gameObject.GetComponent<RectTransform>(), Is.TextOverflowing);
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: text overflowing its RectTransform{Environment.NewLine}" +
+                $"  But was:  \"PlainObject\" has no Text or TMP_Text component{Environment.NewLine}"));
+        }
+
+        [Test]
+        public void IsNotTextOverflowing_Null_Failure()
+        {
+            Assert.That(() =>
+            {
+                Assert.That(null, Is.TextOverflowing);
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: text overflowing its RectTransform{Environment.NewLine}" +
+                $"  But was:  null{Environment.NewLine}"));
+        }
+    }
+}

--- a/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
@@ -6,7 +6,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.Attributes;
+#if ENABLE_TMP
 using TMPro;
+#endif
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -55,6 +57,7 @@ namespace TestHelper.Constraints
             return uguiText;
         }
 
+#if ENABLE_TMP
         private static TMP_Text CreateTmpText(Transform parent, string name, string text, Vector2 size,
             TextWrappingModes wrappingMode = TextWrappingModes.Normal, bool enableAutoSizing = false,
             TextOverflowModes overflowMode = TextOverflowModes.Overflow)
@@ -77,6 +80,7 @@ namespace TestHelper.Constraints
             tmpText.overflowMode = overflowMode;
             return tmpText;
         }
+#endif
 
         private static object AsActual(RectTransform rectTransform, ActualKind kind)
         {
@@ -424,6 +428,7 @@ namespace TestHelper.Constraints
             Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
         }
 
+#if ENABLE_TMP
         [Test]
         [CreateScene]
         [Category("Acceptance")]
@@ -562,6 +567,7 @@ namespace TestHelper.Constraints
 
             Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
         }
+#endif
 
         [Test]
         [CreateScene]

--- a/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
@@ -455,7 +455,8 @@ namespace TestHelper.Constraints
                 Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
             }, Throws.TypeOf<AssertionException>()
                 .With.Message.Contains("\"Label\"")
-                .And.Message.Contains("exceeds rect"));
+                .And.Message.Contains("exceeds rect")
+                .And.Message.Not.Contains("are not rendered"));
         }
 
         [Test]
@@ -508,6 +509,35 @@ namespace TestHelper.Constraints
             }, Throws.TypeOf<AssertionException>()
                 .With.Message.Contains("\"Label\"")
                 .And.Message.Contains("are not rendered (overflowMode: Truncate)"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_TmpEmptyText_Success()
+        {
+            var canvas = CreateCanvas();
+            var tmpText = CreateTmpText(canvas.transform, "Label", string.Empty, new Vector2(5f, 5f));
+            Assume.That(tmpText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await Awaitable.NextFrameAsync();
+
+            Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotTextOverflowing_TmpTextNotLaidOut_Success()
+        {
+            var canvas = CreateCanvas();
+            var tmpText = CreateTmpText(canvas.transform, "Label", "Some text", new Vector2(200f, 50f));
+            Assume.That(tmpText.font, Is.Not.Null);
+            // Note: intentionally skip Canvas.ForceUpdateCanvases()/frame wait, unlike the uGUI equivalent
+            // test: TMP_Text.preferredWidth/preferredHeight compute the layout on demand rather than
+            // depending on a prior OnPopulateMesh pass, so there is no "not laid out" state to detect here.
+
+            Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
         }
 
         [Test]

--- a/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
@@ -59,7 +59,7 @@ namespace TestHelper.Constraints
 
 #if ENABLE_TMP
         private static TMP_Text CreateTmpText(Transform parent, string name, string text, Vector2 size,
-            TextWrappingModes wrappingMode = TextWrappingModes.Normal, bool enableAutoSizing = false,
+            bool enableWordWrapping = true, bool enableAutoSizing = false,
             TextOverflowModes overflowMode = TextOverflowModes.Overflow)
         {
             var gameObject = new GameObject(name, typeof(RectTransform), typeof(TextMeshProUGUI));
@@ -75,7 +75,13 @@ namespace TestHelper.Constraints
             tmpText.font = TMP_Settings.defaultFontAsset;
             tmpText.text = text;
             tmpText.fontSize = 20;
-            tmpText.textWrappingMode = wrappingMode;
+            // textWrappingMode/TextWrappingModes isn't available in the TMP version bundled with
+            // older Unity LTS releases tested in CI (e.g. 2022.3); enableWordWrapping predates it
+            // and still works (just deprecated) on newer TMP too, so it compiles across the whole
+            // CI Unity version matrix.
+#pragma warning disable CS0618
+            tmpText.enableWordWrapping = enableWordWrapping;
+#pragma warning restore CS0618
             tmpText.enableAutoSizing = enableAutoSizing;
             tmpText.overflowMode = overflowMode;
             return tmpText;
@@ -487,7 +493,7 @@ namespace TestHelper.Constraints
         {
             var canvas = CreateCanvas();
             var tmpText = CreateTmpText(canvas.transform, "Label", "A very very very long single line of text",
-                new Vector2(5f, 100f), TextWrappingModes.NoWrap);
+                new Vector2(5f, 100f), enableWordWrapping: false);
             Assume.That(tmpText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
             await Awaitable.NextFrameAsync();
@@ -503,7 +509,7 @@ namespace TestHelper.Constraints
             var canvas = CreateCanvas();
             var tmpText = CreateTmpText(canvas.transform, "Label",
                 "This text will not fully fit and gets truncated", new Vector2(150f, 20f),
-                TextWrappingModes.Normal, false, TextOverflowModes.Truncate);
+                overflowMode: TextOverflowModes.Truncate);
             Assume.That(tmpText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
             await Awaitable.NextFrameAsync();
@@ -560,7 +566,7 @@ namespace TestHelper.Constraints
             Assume.That(uguiText.font, Is.Not.Null);
             var tmpText = CreateTmpText(canvas.transform, "OtherLabel",
                 "A very very very long single line of overflowing text content that exceeds the rect",
-                new Vector2(5f, 5f), TextWrappingModes.NoWrap);
+                new Vector2(5f, 5f), enableWordWrapping: false);
             Assume.That(tmpText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
             await Awaitable.NextFrameAsync();

--- a/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs.meta
+++ b/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 037dbc012ff744ca6bb4cfeebf22d0d4

--- a/Tests/Runtime/Constraints/WithinScreenConstraintTest.cs
+++ b/Tests/Runtime/Constraints/WithinScreenConstraintTest.cs
@@ -1,0 +1,379 @@
+// Copyright (c) 2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Threading;
+using NUnit.Framework;
+using TestHelper.Attributes;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TestHelper.Constraints
+{
+    [SuppressMessage("ReSharper", "AccessToStaticMemberViaDerivedType")]
+    public class WithinScreenConstraintTest
+    {
+        public enum ActualKind
+        {
+            RectTransform,
+            GameObject,
+            Component,
+        }
+
+        public enum VisibilityFactor
+        {
+            ClippingRectMask2DAncestor,
+            DisabledCanvas,
+            CanvasGroupAlphaZero,
+            InactiveInHierarchy,
+        }
+
+        private CultureInfo _originalCulture;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _originalCulture = Thread.CurrentThread.CurrentCulture;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Thread.CurrentThread.CurrentCulture = _originalCulture;
+        }
+
+        private static RectTransform CreateElement(string name, Vector2 anchoredPosition, Vector2 sizeDelta)
+        {
+            var canvasGameObject = new GameObject("Canvas", typeof(Canvas));
+            canvasGameObject.GetComponent<Canvas>().renderMode = RenderMode.ScreenSpaceOverlay;
+
+            var gameObject = new GameObject(name, typeof(RectTransform));
+            var rectTransform = (RectTransform)gameObject.transform;
+            rectTransform.SetParent(canvasGameObject.transform, worldPositionStays: false);
+            rectTransform.anchorMin = Vector2.zero;
+            rectTransform.anchorMax = Vector2.zero;
+            rectTransform.pivot = Vector2.zero;
+            rectTransform.anchoredPosition = anchoredPosition;
+            rectTransform.sizeDelta = sizeDelta;
+            return rectTransform;
+        }
+
+        private static object AsActual(RectTransform rectTransform, ActualKind kind)
+        {
+            switch (kind)
+            {
+                case ActualKind.GameObject:
+                    return rectTransform.gameObject;
+                case ActualKind.Component:
+                    return rectTransform.gameObject.AddComponent<Image>();
+                default:
+                    return rectTransform;
+            }
+        }
+
+        private static void ApplyVisibilityFactor(RectTransform element, VisibilityFactor factor)
+        {
+            switch (factor)
+            {
+                case VisibilityFactor.ClippingRectMask2DAncestor:
+                    element.parent.gameObject.AddComponent<RectMask2D>();
+                    break;
+                case VisibilityFactor.DisabledCanvas:
+                    element.GetComponentInParent<Canvas>().enabled = false;
+                    break;
+                case VisibilityFactor.CanvasGroupAlphaZero:
+                    element.gameObject.AddComponent<CanvasGroup>().alpha = 0f;
+                    break;
+                case VisibilityFactor.InactiveInHierarchy:
+                    element.gameObject.SetActive(false);
+                    break;
+            }
+        }
+
+        private static string FormatFloat(float value) => value.ToString("F1", CultureInfo.InvariantCulture);
+
+        private static string FormatRect(Rect rect) =>
+            $"({FormatFloat(rect.x)}, {FormatFloat(rect.y)}, {FormatFloat(rect.width)}, {FormatFloat(rect.height)})";
+
+        private static string ExpectedWithinScreenLine =>
+            $"RectTransform within screen (0, 0, {Screen.width}, {Screen.height})";
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsWithinScreen_ElementInsideScreen_Success()
+        {
+            var actual = CreateElement("Element", new Vector2(Screen.width / 4f, Screen.height / 4f),
+                new Vector2(Screen.width / 4f, Screen.height / 4f));
+
+            Assert.That(actual, Is.WithinScreen);
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsWithinScreen_AcceptedActualTypes_Success([Values] ActualKind kind)
+        {
+            var rectTransform = CreateElement("Element", new Vector2(Screen.width / 4f, Screen.height / 4f),
+                new Vector2(Screen.width / 4f, Screen.height / 4f));
+            var actual = AsActual(rectTransform, kind);
+
+            Assert.That(actual, Is.WithinScreen);
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsWithinScreen_ElementExceedsRightEdge_Failure()
+        {
+            const float Width = 50f;
+            const float Overshoot = 20f;
+            var element = CreateElement("CardView", new Vector2(Screen.width - Width + Overshoot, 10f),
+                new Vector2(Width, 50f));
+            var elementScreenRect = new Rect(Screen.width - Width + Overshoot, 10f, Width, 50f);
+
+            Assert.That(() =>
+            {
+                Assert.That(element, Is.WithinScreen);
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
+                $"  But was:  \"CardView\" {FormatRect(elementScreenRect)} exceeds the right edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        public void IsWithinScreen_ElementExceedsMultipleEdges_Failure()
+        {
+            const float Width = 50f;
+            const float Height = 50f;
+            var anchoredPosition = new Vector2(-12f, Screen.height - (Height - 7f));
+            var element = CreateElement("CardView", anchoredPosition, new Vector2(Width, Height));
+            var elementScreenRect = new Rect(anchoredPosition.x, anchoredPosition.y, Width, Height);
+
+            Assert.That(() =>
+            {
+                Assert.That(element, Is.WithinScreen);
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
+                $"  But was:  \"CardView\" {FormatRect(elementScreenRect)} exceeds the left edge by {FormatFloat(12f)}px" +
+                $" and the top edge by {FormatFloat(7f)}px{Environment.NewLine}"));
+        }
+
+        [TestCase(0.0f)]
+        [TestCase(0.5f)]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsWithinScreen_OvershootWithinDefaultTolerance_Success(float overshoot)
+        {
+            const float Width = 50f;
+            var actual = CreateElement("Element", new Vector2(Screen.width - Width + overshoot, 10f),
+                new Vector2(Width, 50f));
+
+            Assert.That(actual, Is.WithinScreen);
+        }
+
+        [Test]
+        [CreateScene]
+        public void IsWithinScreen_OvershootExceedsDefaultTolerance_Failure()
+        {
+            const float Width = 50f;
+            const float Overshoot = 5f;
+            var element = CreateElement("CardView", new Vector2(Screen.width - Width + Overshoot, 10f),
+                new Vector2(Width, 50f));
+            var elementScreenRect = new Rect(Screen.width - Width + Overshoot, 10f, Width, 50f);
+
+            Assert.That(() =>
+            {
+                Assert.That(element, Is.WithinScreen);
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
+                $"  But was:  \"CardView\" {FormatRect(elementScreenRect)} exceeds the right edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsWithinScreen_OvershootWithinSpecifiedTolerance_Success()
+        {
+            const float Width = 50f;
+            const float Overshoot = 1.5f;
+            var actual = CreateElement("Element", new Vector2(Screen.width - Width + Overshoot, 10f),
+                new Vector2(Width, 50f));
+
+            Assert.That(actual, Is.WithinScreen.Within(2f));
+        }
+
+        [Test]
+        [CreateScene]
+        public void IsWithinScreen_OvershootExceedsSpecifiedTolerance_Failure()
+        {
+            const float Width = 50f;
+            const float Overshoot = 5f;
+            var element = CreateElement("CardView", new Vector2(Screen.width - Width + Overshoot, 10f),
+                new Vector2(Width, 50f));
+            var elementScreenRect = new Rect(Screen.width - Width + Overshoot, 10f, Width, 50f);
+
+            Assert.That(() =>
+            {
+                Assert.That(element, Is.WithinScreen.Within(2f));
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
+                $"  But was:  \"CardView\" {FormatRect(elementScreenRect)} exceeds the right edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsWithinScreen_SubPixelOvershootWithNegativeTolerance_Failure()
+        {
+            const float Width = 50f;
+            const float Overshoot = 0.1f;
+            var element = CreateElement("CardView", new Vector2(Screen.width - Width + Overshoot, 10f),
+                new Vector2(Width, 50f));
+            var elementScreenRect = new Rect(Screen.width - Width + Overshoot, 10f, Width, 50f);
+
+            Assert.That(() =>
+            {
+                Assert.That(element, Is.WithinScreen.Within(-5f));
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
+                $"  But was:  \"CardView\" {FormatRect(elementScreenRect)} exceeds the right edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsWithinScreen_OutOfScreenElementWithNonGeometricVisibilityFactor_Failure(
+            [Values] VisibilityFactor factor)
+        {
+            const float Width = 50f;
+            const float Overshoot = 20f;
+            var element = CreateElement("CardView", new Vector2(Screen.width - Width + Overshoot, 10f),
+                new Vector2(Width, 50f));
+            var elementScreenRect = new Rect(Screen.width - Width + Overshoot, 10f, Width, 50f);
+            ApplyVisibilityFactor(element, factor);
+
+            Assert.That(() =>
+            {
+                Assert.That(element, Is.WithinScreen);
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
+                $"  But was:  \"CardView\" {FormatRect(elementScreenRect)} exceeds the right edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsWithinScreen_UnderCommaDecimalCulture_Failure()
+        {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+            const float Width = 50f;
+            const float Overshoot = 20.5f;
+            var element = CreateElement("CardView", new Vector2(Screen.width - Width + Overshoot, 10f),
+                new Vector2(Width, 50f));
+            var elementScreenRect = new Rect(Screen.width - Width + Overshoot, 10f, Width, 50f);
+
+            Assert.That(() =>
+            {
+                Assert.That(element, Is.WithinScreen);
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
+                $"  But was:  \"CardView\" {FormatRect(elementScreenRect)} exceeds the right edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+        }
+
+        [Test]
+        [Category("Acceptance")]
+        public void IsWithinScreen_Null_Failure()
+        {
+            Assert.That(() =>
+            {
+                Assert.That(null, Is.WithinScreen);
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
+                $"  But was:  null{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsWithinScreen_DestroyedGameObject_Failure()
+        {
+            var element = CreateElement("CardView", Vector2.zero, Vector2.zero);
+            GameObject.DestroyImmediate(element.gameObject);
+
+            Assert.That(() =>
+            {
+                Assert.That(element, Is.WithinScreen);
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
+                $"  But was:  destroyed UnityEngine.Object{Environment.NewLine}"));
+        }
+
+        [Test]
+        [Category("Acceptance")]
+        public void IsWithinScreen_UnsupportedActualType_Failure()
+        {
+            Assert.That(() =>
+            {
+                Assert.That("not a RectTransform", Is.WithinScreen);
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
+                $"  But was:  <System.String> is not a RectTransform, GameObject, or Component{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsWithinScreen_GameObjectWithoutRectTransform_Failure()
+        {
+            var gameObject = new GameObject("PlainObject");
+
+            Assert.That(() =>
+            {
+                Assert.That(gameObject, Is.WithinScreen);
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
+                $"  But was:  \"PlainObject\" has no RectTransform component{Environment.NewLine}"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotWithinScreen_ElementExceedsScreen_Success()
+        {
+            const float Width = 50f;
+            const float Overshoot = 20f;
+            var actual = CreateElement("Element", new Vector2(Screen.width - Width + Overshoot, 10f),
+                new Vector2(Width, 50f));
+
+            Assert.That(actual, Is.Not.WithinScreen()); // Note: Use it in method style when with operators
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotWithinScreen_ElementInsideScreen_Failure()
+        {
+            var element = CreateElement("Element", new Vector2(Screen.width / 4f, Screen.height / 4f),
+                new Vector2(Screen.width / 4f, Screen.height / 4f));
+            var elementScreenRect =
+                new Rect(Screen.width / 4f, Screen.height / 4f, Screen.width / 4f, Screen.height / 4f);
+
+            Assert.That(() =>
+            {
+                Assert.That(element, Is.Not.WithinScreen()); // Note: Use it in method style when with operators
+            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
+                $"  Expected: not {ExpectedWithinScreenLine}{Environment.NewLine}" +
+                $"  But was:  <\"Element\" {FormatRect(elementScreenRect)}>{Environment.NewLine}"));
+        }
+
+        [Test]
+        [Category("Acceptance")]
+        public void IsNotWithinScreen_Null_Success()
+        {
+            Assert.That(null, Is.Not.WithinScreen()); // Note: Use it in method style when with operators
+        }
+    }
+}

--- a/Tests/Runtime/Constraints/WithinScreenConstraintTest.cs
+++ b/Tests/Runtime/Constraints/WithinScreenConstraintTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;

--- a/Tests/Runtime/Constraints/WithinScreenConstraintTest.cs
+++ b/Tests/Runtime/Constraints/WithinScreenConstraintTest.cs
@@ -312,13 +312,12 @@ namespace TestHelper.Constraints
 
         [Test]
         [Category("Acceptance")]
-        // Not a swapped actual/expected: this constant IS the actual value under test, deliberately an
-        // unsupported type, to exercise the "not a RectTransform, GameObject, or Component" failure path.
-        [SuppressMessage("Assertion", "NUnit2007:The actual value should not be a constant")]
         public void IsWithinScreen_UnsupportedActualType_Failure()
         {
             Assert.That(() =>
             {
+                // Not a swapped actual/expected: this constant IS the actual value under test, deliberately an
+                // unsupported type, to exercise the "not a RectTransform, GameObject, or Component" failure path.
                 Assert.That("not a RectTransform", Is.WithinScreen);
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +

--- a/Tests/Runtime/Constraints/WithinScreenConstraintTest.cs
+++ b/Tests/Runtime/Constraints/WithinScreenConstraintTest.cs
@@ -284,20 +284,18 @@ namespace TestHelper.Constraints
 
         [Test]
         [Category("Acceptance")]
-        public void IsWithinScreen_Null_Failure()
+        public void IsWithinScreen_Null_ThrowsArgumentNullException()
         {
             Assert.That(() =>
             {
                 Assert.That(null, Is.WithinScreen);
-            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
-                $"  But was:  null{Environment.NewLine}"));
+            }, Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("actual"));
         }
 
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        public void IsWithinScreen_DestroyedGameObject_Failure()
+        public void IsWithinScreen_DestroyedGameObject_ThrowsArgumentException()
         {
             var element = CreateElement("CardView", Vector2.zero, Vector2.zero);
             GameObject.DestroyImmediate(element.gameObject);
@@ -305,38 +303,38 @@ namespace TestHelper.Constraints
             Assert.That(() =>
             {
                 Assert.That(element, Is.WithinScreen);
-            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
-                $"  But was:  destroyed UnityEngine.Object{Environment.NewLine}"));
+            }, Throws.TypeOf<ArgumentException>()
+                .With.Property("ParamName").EqualTo("actual")
+                .And.Message.Contains("destroyed UnityEngine.Object"));
         }
 
         [Test]
         [Category("Acceptance")]
-        public void IsWithinScreen_UnsupportedActualType_Failure()
+        public void IsWithinScreen_UnsupportedActualType_ThrowsArgumentException()
         {
             Assert.That(() =>
             {
                 // Not a swapped actual/expected: this constant IS the actual value under test, deliberately an
                 // unsupported type, to exercise the "not a RectTransform, GameObject, or Component" failure path.
                 Assert.That("not a RectTransform", Is.WithinScreen);
-            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
-                $"  But was:  <System.String> is not a RectTransform, GameObject, or Component{Environment.NewLine}"));
+            }, Throws.TypeOf<ArgumentException>()
+                .With.Property("ParamName").EqualTo("actual")
+                .And.Message.Contains("is not a RectTransform, GameObject, or Component"));
         }
 
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        public void IsWithinScreen_GameObjectWithoutRectTransform_Failure()
+        public void IsWithinScreen_GameObjectWithoutRectTransform_ThrowsArgumentException()
         {
             var gameObject = new GameObject("PlainObject");
 
             Assert.That(() =>
             {
                 Assert.That(gameObject, Is.WithinScreen);
-            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
-                $"  But was:  \"PlainObject\" has no RectTransform component{Environment.NewLine}"));
+            }, Throws.TypeOf<ArgumentException>()
+                .With.Property("ParamName").EqualTo("actual")
+                .And.Message.Contains("has no RectTransform component"));
         }
 
         [Test]
@@ -372,9 +370,12 @@ namespace TestHelper.Constraints
 
         [Test]
         [Category("Acceptance")]
-        public void IsNotWithinScreen_Null_Success()
+        public void IsNotWithinScreen_Null_ThrowsArgumentNullException()
         {
-            Assert.That(null, Is.Not.WithinScreen()); // Note: Use it in method style when with operators
+            Assert.That(() =>
+            {
+                Assert.That(null, Is.Not.WithinScreen()); // Note: Use it in method style when with operators
+            }, Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("actual"));
         }
     }
 }

--- a/Tests/Runtime/Constraints/WithinScreenConstraintTest.cs
+++ b/Tests/Runtime/Constraints/WithinScreenConstraintTest.cs
@@ -64,6 +64,8 @@ namespace TestHelper.Constraints
         {
             switch (kind)
             {
+                case ActualKind.RectTransform:
+                    return rectTransform;
                 case ActualKind.GameObject:
                     return rectTransform.gameObject;
                 case ActualKind.Component:
@@ -89,13 +91,10 @@ namespace TestHelper.Constraints
                 case VisibilityFactor.InactiveInHierarchy:
                     element.gameObject.SetActive(false);
                     break;
+                default:
+                    break;
             }
         }
-
-        private static string FormatFloat(float value) => value.ToString("F1", CultureInfo.InvariantCulture);
-
-        private static string FormatRect(Rect rect) =>
-            $"({FormatFloat(rect.x)}, {FormatFloat(rect.y)}, {FormatFloat(rect.width)}, {FormatFloat(rect.height)})";
 
         private static string ExpectedWithinScreenLine =>
             $"RectTransform within screen (0, 0, {Screen.width}, {Screen.height})";
@@ -139,7 +138,7 @@ namespace TestHelper.Constraints
                 Assert.That(element, Is.WithinScreen);
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
-                $"  But was:  \"CardView\" {FormatRect(elementScreenRect)} exceeds the right edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+                $"  But was:  \"CardView\" {ConstraintMessageFormatter.Format(elementScreenRect)} exceeds the right edge by {ConstraintMessageFormatter.Format(Overshoot)}px{Environment.NewLine}"));
         }
 
         [Test]
@@ -157,8 +156,8 @@ namespace TestHelper.Constraints
                 Assert.That(element, Is.WithinScreen);
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
-                $"  But was:  \"CardView\" {FormatRect(elementScreenRect)} exceeds the left edge by {FormatFloat(12f)}px" +
-                $" and the top edge by {FormatFloat(7f)}px{Environment.NewLine}"));
+                $"  But was:  \"CardView\" {ConstraintMessageFormatter.Format(elementScreenRect)} exceeds the left edge by {ConstraintMessageFormatter.Format(12f)}px" +
+                $" and the top edge by {ConstraintMessageFormatter.Format(7f)}px{Environment.NewLine}"));
         }
 
         [TestCase(0.0f)]
@@ -189,7 +188,7 @@ namespace TestHelper.Constraints
                 Assert.That(element, Is.WithinScreen);
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
-                $"  But was:  \"CardView\" {FormatRect(elementScreenRect)} exceeds the right edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+                $"  But was:  \"CardView\" {ConstraintMessageFormatter.Format(elementScreenRect)} exceeds the right edge by {ConstraintMessageFormatter.Format(Overshoot)}px{Environment.NewLine}"));
         }
 
         [Test]
@@ -220,7 +219,7 @@ namespace TestHelper.Constraints
                 Assert.That(element, Is.WithinScreen.Within(2f));
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
-                $"  But was:  \"CardView\" {FormatRect(elementScreenRect)} exceeds the right edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+                $"  But was:  \"CardView\" {ConstraintMessageFormatter.Format(elementScreenRect)} exceeds the right edge by {ConstraintMessageFormatter.Format(Overshoot)}px{Environment.NewLine}"));
         }
 
         [Test]
@@ -239,7 +238,7 @@ namespace TestHelper.Constraints
                 Assert.That(element, Is.WithinScreen.Within(-5f));
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
-                $"  But was:  \"CardView\" {FormatRect(elementScreenRect)} exceeds the right edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+                $"  But was:  \"CardView\" {ConstraintMessageFormatter.Format(elementScreenRect)} exceeds the right edge by {ConstraintMessageFormatter.Format(Overshoot)}px{Environment.NewLine}"));
         }
 
         [Test]
@@ -260,7 +259,7 @@ namespace TestHelper.Constraints
                 Assert.That(element, Is.WithinScreen);
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
-                $"  But was:  \"CardView\" {FormatRect(elementScreenRect)} exceeds the right edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+                $"  But was:  \"CardView\" {ConstraintMessageFormatter.Format(elementScreenRect)} exceeds the right edge by {ConstraintMessageFormatter.Format(Overshoot)}px{Environment.NewLine}"));
         }
 
         [Test]
@@ -280,7 +279,7 @@ namespace TestHelper.Constraints
                 Assert.That(element, Is.WithinScreen);
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: {ExpectedWithinScreenLine}{Environment.NewLine}" +
-                $"  But was:  \"CardView\" {FormatRect(elementScreenRect)} exceeds the right edge by {FormatFloat(Overshoot)}px{Environment.NewLine}"));
+                $"  But was:  \"CardView\" {ConstraintMessageFormatter.Format(elementScreenRect)} exceeds the right edge by {ConstraintMessageFormatter.Format(Overshoot)}px{Environment.NewLine}"));
         }
 
         [Test]
@@ -313,6 +312,9 @@ namespace TestHelper.Constraints
 
         [Test]
         [Category("Acceptance")]
+        // Not a swapped actual/expected: this constant IS the actual value under test, deliberately an
+        // unsupported type, to exercise the "not a RectTransform, GameObject, or Component" failure path.
+        [SuppressMessage("Assertion", "NUnit2007:The actual value should not be a constant")]
         public void IsWithinScreen_UnsupportedActualType_Failure()
         {
             Assert.That(() =>
@@ -366,7 +368,7 @@ namespace TestHelper.Constraints
                 Assert.That(element, Is.Not.WithinScreen()); // Note: Use it in method style when with operators
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: not {ExpectedWithinScreenLine}{Environment.NewLine}" +
-                $"  But was:  <\"Element\" {FormatRect(elementScreenRect)}>{Environment.NewLine}"));
+                $"  But was:  <\"Element\" {ConstraintMessageFormatter.Format(elementScreenRect)}>{Environment.NewLine}"));
         }
 
         [Test]

--- a/Tests/Runtime/Constraints/WithinScreenConstraintTest.cs.meta
+++ b/Tests/Runtime/Constraints/WithinScreenConstraintTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e5d5a67beb7af4ce7896073aab06e17f

--- a/Tests/Runtime/TestHelper.Tests.asmdef
+++ b/Tests/Runtime/TestHelper.Tests.asmdef
@@ -6,7 +6,9 @@
         "UnityEditor.TestRunner",
         "TestHelper",
         "TestHelper.RuntimeInternals",
-        "UniTask"
+        "UniTask",
+        "UnityEngine.UI",
+        "Unity.TextMeshPro"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -14,7 +16,8 @@
     "overrideReferences": true,
     "precompiledReferences": [
         "nunit.framework.dll",
-        "FlipBinding.CSharp.dll"
+        "FlipBinding.CSharp.dll",
+        "UnityEngine.UI.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [
@@ -30,6 +33,21 @@
             "name": "org.nuget.flipbinding.csharp",
             "expression": "1.0.0",
             "define": "ENABLE_FLIP_BINDING"
+        },
+        {
+            "name": "com.unity.ugui",
+            "expression": "",
+            "define": "ENABLE_UGUI"
+        },
+        {
+            "name": "com.unity.textmeshpro",
+            "expression": "",
+            "define": "ENABLE_TMP"
+        },
+        {
+            "name": "com.unity.ugui",
+            "expression": "2.0.0",
+            "define": "ENABLE_TMP"
         }
     ],
     "noEngineReferences": false

--- a/Tests/Runtime/TestHelper.Tests.asmdef
+++ b/Tests/Runtime/TestHelper.Tests.asmdef
@@ -35,11 +35,6 @@
             "define": "ENABLE_FLIP_BINDING"
         },
         {
-            "name": "com.unity.ugui",
-            "expression": "",
-            "define": "ENABLE_UGUI"
-        },
-        {
             "name": "com.unity.textmeshpro",
             "expression": "",
             "define": "ENABLE_TMP"


### PR DESCRIPTION
### Summary
- Add four new NUnit constraints for asserting uGUI/TMP layout in Play Mode tests: `Is.WithinScreen`, `Is.FullyWithin(container)`, `Is.Overlapping`, and `Is.TextOverflowing` (supporting both uGUI `Text` and TextMeshPro `TMP_Text`)
- Share resolution of `actual` (RectTransform / GameObject / Component) across all four constraints via `RectTransformResolver`
- When `actual` (or `FullyWithin`'s container, or an `Overlapping` element) is null, destroyed, of an unsupported type, or otherwise cannot be resolved to what the constraint needs to evaluate, throw `ArgumentNullException`/`ArgumentException` instead of silently reporting a non-match — this applies to `Is.Not.*` forms too, so a broken test setup surfaces as a test error rather than a vacuous pass
- Document the new constraints in the package README

### Spec

#### WithinScreen

`WithinScreenConstraint` tests that a `RectTransform` (or a `GameObject`/`Component` with one) is fully within the screen.

Usage:

```csharp
using Is = TestHelper.Constraints.Is;

[TestFixture]
public class MyTestClass
{
    [Test]
    public void MyTestMethod()
    {
        var confirmDialog = GameObject.Find("ConfirmDialog");

        Assert.That(confirmDialog, Is.WithinScreen);
    }
}
```

Chain `.Within(float)` to widen the tolerance in pixels (default `0.5f`), e.g., `Is.WithinScreen.Within(2f)`.


#### FullyWithin

`FullyWithinConstraint` tests that a `RectTransform` (or a `GameObject`/`Component` with one) is fully within another `RectTransform`'s screen rect.

Usage:

```csharp
using Is = TestHelper.Constraints.Is;

[TestFixture]
public class MyTestClass
{
    [Test]
    public void MyTestMethod()
    {
        var viewport = GameObject.Find("Viewport").GetComponent<RectTransform>();
        var card = GameObject.Find("Card (0)");

        Assert.That(card, Is.FullyWithin(viewport));
    }
}
```

Chain `.Horizontally()` or `.Vertically()` to narrow the check to a single axis (calling both is equivalent to specifying neither — both axes are checked by default), and `.Within(float)` to widen the tolerance in pixels (default `0.5f`), e.g., `Is.FullyWithin(viewport).Horizontally().Within(2f)`.


#### Overlapping

`OverlappingConstraint` tests that any pair in a collection of `RectTransform`s overlaps.

Usage:

```csharp
using Is = TestHelper.Constraints.Is;

[TestFixture]
public class MyTestClass
{
    [Test]
    public void MyTestMethod()
    {
        var cards = GameObject.Find("CardGrid").GetComponentsInChildren<Image>();

        Assert.That(cards, Is.Not.Overlapping());
    }
}
```

Chain `.Ignoring(group)` to exclude pairs where both members belong to `group` (a member is still checked against elements outside the group; call it more than once to register multiple groups), and `.Within(float)` to widen the tolerance in pixels (default `0.5f`), e.g.:

```csharp
// SkipButton must not overlap any card, but cards overlapping each other is a different test's concern.
Assert.That(cards.Prepend(skipButton), Is.Not.Overlapping().Ignoring(cards));
```


#### TextOverflowing (optional)

`TextOverflowingConstraint` tests that a uGUI `Text` or TextMeshPro `TMP_Text` component overflows its own `RectTransform` — its preferred size exceeds the rect, or characters are truncated.

Usage:

```csharp
using Is = TestHelper.Constraints.Is;

[TestFixture]
public class MyTestClass
{
    [Test]
    public void MyTestMethod()
    {
        var flavorText = GameObject.Find("Flavor Text");

        Assert.That(flavorText, Is.Not.TextOverflowing());
    }
}
```

Chain `.Within(float)` to widen the tolerance in pixels (default `0.5f`), e.g., `Is.Not.TextOverflowing().Within(1f)`.