### PR TITLE
Support property style for custom constraints with operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,9 +488,6 @@ public class MyTestClass
 }
 ```
 
-> [!NOTE]\
-> When used with operators, use it in method style. e.g., `Is.Not.Destroyed()`
-
 #### WithinScreen
 
 `WithinScreenConstraint` tests that a `RectTransform` (or a `GameObject`/`Component` with one) is fully within the screen.
@@ -518,9 +515,6 @@ Chain `.Within(float)` to widen the tolerance in pixels (default `0.5f`), e.g., 
 > [!IMPORTANT]\
 > This constraint is intended for scenes and prefabs authored by coding agents.
 > Do not use it where the layout intentionally overflows the screen.
-
-> [!NOTE]\
-> When used with operators, use it in method style. e.g., `Is.Not.WithinScreen()`
 
 #### FullyWithin
 
@@ -568,7 +562,7 @@ public class MyTestClass
     {
         var cards = GameObject.Find("CardGrid").GetComponentsInChildren<Image>();
 
-        Assert.That(cards, Is.Not.Overlapping());
+        Assert.That(cards, Is.Not.Overlapping);
     }
 }
 ```
@@ -577,15 +571,12 @@ Chain `.Ignoring(group)` to exclude pairs where both members belong to `group` (
 
 ```csharp
 // SkipButton must not overlap any card, but cards overlapping each other is a different test's concern.
-Assert.That(cards.Prepend(skipButton), Is.Not.Overlapping().Ignoring(cards));
+Assert.That(cards.Prepend(skipButton), Is.Not.Overlapping.Ignoring(cards));
 ```
 
 > [!IMPORTANT]\
 > This constraint is intended for scenes and prefabs authored by coding agents.
 > Do not use it where the layout intentionally allows elements to overlap.
-
-> [!NOTE]\
-> When used with operators, use it in method style. e.g., `Is.Not.Overlapping()`
 
 #### TextOverflowing (optional)
 
@@ -604,22 +595,19 @@ public class MyTestClass
     {
         var flavorText = GameObject.Find("Flavor Text");
 
-        Assert.That(flavorText, Is.Not.TextOverflowing());
+        Assert.That(flavorText, Is.Not.TextOverflowing);
     }
 }
 ```
 
-Chain `.Within(float)` to widen the tolerance in pixels (default `0.5f`), e.g., `Is.Not.TextOverflowing().Within(1f)`.
-
-> [!IMPORTANT]\
-> `TextOverflowingConstraint` is an optional functionality. It supports uGUI `Text` and TextMeshPro `TMP_Text`, both optional dependencies of this package ([com.unity.ugui](https://docs.unity3d.com/Packages/com.unity.ugui@latest), [com.unity.textmeshpro](https://docs.unity3d.com/Packages/com.unity.textmeshpro@latest) — or `com.unity.ugui` 2.0.0+ alone, which bundles TextMeshPro).
+Chain `.Within(float)` to widen the tolerance in pixels (default `0.5f`), e.g., `Is.Not.TextOverflowing.Within(1f)`.
 
 > [!IMPORTANT]\
 > This constraint is intended for scenes and prefabs authored by coding agents.
 > Do not use it where the layout intentionally lets text overflow its container.
 
 > [!NOTE]\
-> When used with operators, use it in method style. e.g., `Is.Not.TextOverflowing()`
+> `TextOverflowingConstraint` is an optional functionality. It supports uGUI `Text` and TextMeshPro `TMP_Text`, both optional dependencies of this package ([com.unity.ugui](https://docs.unity3d.com/Packages/com.unity.ugui@latest), [com.unity.textmeshpro](https://docs.unity3d.com/Packages/com.unity.textmeshpro@latest) — or `com.unity.ugui` 2.0.0+ alone, which bundles TextMeshPro).
 
 
 

--- a/Runtime/Constraints/ConstraintExtensions.cs
+++ b/Runtime/Constraints/ConstraintExtensions.cs
@@ -6,11 +6,17 @@ using UnityEngine;
 
 namespace TestHelper.Constraints
 {
+    /// <summary>
+    /// Method-style entry points for this package's custom constraints, for chains that don't start at
+    /// <see cref="Is.Not"/> or <see cref="Is.All"/> (e.g. <c>Has.None.Destroyed()</c>) or that land on NUnit's
+    /// own <see cref="ResolvableConstraintExpression"/> (e.g. <c>Is.Not.Null.And.Destroyed()</c>). When a
+    /// chain does start at <see cref="Is.Not"/>/<see cref="Is.All"/>, prefer the property style exposed by
+    /// <see cref="TestHelperConstraintExpression"/> instead, e.g. <c>Is.Not.Destroyed</c>.
+    /// </summary>
     public static class ConstraintExtensions
     {
         /// <summary>
         /// Create constraint to destroyed <see cref="UnityEngine.Object"/>.
-        /// When used with operators, use it in method style. e.g., `Is.Not.Destroyed()`
         /// </summary>
         /// <param name="expression"></param>
         /// <returns>constraint to destroyed <see cref="UnityEngine.Object"/></returns>
@@ -23,7 +29,6 @@ namespace TestHelper.Constraints
 
         /// <summary>
         /// Create constraint to <see cref="RectTransform"/> within the screen.
-        /// When used with operators, use it in method style. e.g., `Is.Not.WithinScreen()`
         /// </summary>
         /// <param name="expression"></param>
         /// <returns>constraint to <see cref="RectTransform"/> within the screen</returns>
@@ -36,7 +41,6 @@ namespace TestHelper.Constraints
 
         /// <summary>
         /// Create constraint to <see cref="RectTransform"/> fully within <paramref name="container"/>.
-        /// When used with operators, use it in method style. e.g., `Is.Not.FullyWithin(container)`
         /// </summary>
         /// <param name="expression"></param>
         /// <param name="container">Container to check containment against.</param>
@@ -50,7 +54,6 @@ namespace TestHelper.Constraints
 
         /// <summary>
         /// Create constraint to a collection of <see cref="RectTransform"/> where any pair overlaps.
-        /// When used with operators, use it in method style. e.g., `Is.Not.Overlapping()`
         /// </summary>
         /// <param name="expression"></param>
         /// <returns>constraint to a collection of <see cref="RectTransform"/> where any pair overlaps</returns>
@@ -63,7 +66,6 @@ namespace TestHelper.Constraints
 
         /// <summary>
         /// Create constraint to text overflowing its own <see cref="RectTransform"/>.
-        /// When used with operators, use it in method style. e.g., `Is.Not.TextOverflowing()`
         /// </summary>
         /// <param name="expression"></param>
         /// <returns>constraint to text overflowing its own <see cref="RectTransform"/></returns>

--- a/Runtime/Constraints/DestroyedConstraint.cs
+++ b/Runtime/Constraints/DestroyedConstraint.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023-2025 Koji Hasegawa.
+﻿// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using NUnit.Framework.Constraints;
@@ -21,12 +21,13 @@ namespace TestHelper.Constraints
     ///     GameObject.DestroyImmediate(actual);
     ///
     ///     Assert.That(actual, Is.Destroyed);
-    ///     // Note: When used with operators, use it in method style. e.g., `Is.Not.Destroyed()`
+    ///     // Note: Works with operators too, e.g., `Is.Not.Destroyed`. Method style (`Is.Not.Destroyed()`)
+    ///     // also remains available.
     ///   }
     /// }
     /// </code>
     /// </example>
-    public class DestroyedConstraint : Constraint
+    public class DestroyedConstraint : TestHelperConstraint
     {
         public DestroyedConstraint(params object[] args) : base(args)
         {

--- a/Runtime/Constraints/FullyWithinConstraint.cs
+++ b/Runtime/Constraints/FullyWithinConstraint.cs
@@ -11,7 +11,7 @@ namespace TestHelper.Constraints
     /// An NUnit test constraint class to a <see cref="RectTransform"/> fully within another
     /// <see cref="RectTransform"/>'s screen rect.
     /// </summary>
-    public class FullyWithinConstraint : Constraint
+    public class FullyWithinConstraint : TestHelperConstraint
     {
         private const float DefaultTolerance = 0.5f;
         private readonly RectTransform _container;
@@ -84,6 +84,8 @@ namespace TestHelper.Constraints
         {
             if (_container == null)
             {
+                // ReSharper disable once NotResolvedInText -- reports the constructor's own parameter name;
+                // ApplyTo has no local/parameter called "container" for nameof() to bind to.
                 throw new ArgumentNullException("container");
             }
 

--- a/Runtime/Constraints/Is.cs
+++ b/Runtime/Constraints/Is.cs
@@ -10,6 +10,19 @@ namespace TestHelper.Constraints
     public class Is : UnityEngine.TestTools.Constraints.Is
     {
         /// <summary>
+        /// Negates the constraint that follows. Hides <see cref="NUnit.Framework.Is.Not"/> so this package's
+        /// custom constraints (<see cref="TestHelperConstraintExpression"/>) can follow in property style,
+        /// e.g., <c>Is.Not.Destroyed</c>.
+        /// </summary>
+        public new static TestHelperConstraintExpression Not => new TestHelperConstraintExpression().Not;
+
+        /// <summary>
+        /// Requires the constraint that follows to be satisfied by every item of a collection. Hides
+        /// <see cref="NUnit.Framework.Is.All"/> for the same reason as <see cref="Not"/>.
+        /// </summary>
+        public new static TestHelperConstraintExpression All => new TestHelperConstraintExpression().All;
+
+        /// <summary>
         /// Create constraint to destroyed GameObject.
         /// </summary>
         public static DestroyedConstraint Destroyed => new DestroyedConstraint();

--- a/Runtime/Constraints/OverlappingConstraint.cs
+++ b/Runtime/Constraints/OverlappingConstraint.cs
@@ -13,7 +13,7 @@ namespace TestHelper.Constraints
     /// An NUnit test constraint class to a collection of <see cref="UnityEngine.RectTransform"/> where any
     /// pair overlaps.
     /// </summary>
-    public class OverlappingConstraint : Constraint
+    public class OverlappingConstraint : TestHelperConstraint
     {
         private const float DefaultTolerance = 0.5f;
         private readonly List<IEnumerable> _ignoredGroups = new List<IEnumerable>();

--- a/Runtime/Constraints/RectTransformResolver.cs
+++ b/Runtime/Constraints/RectTransformResolver.cs
@@ -27,7 +27,7 @@ namespace TestHelper.Constraints
         /// Resolves <paramref name="actual"/> to a <see cref="RectTransform"/> for a constraint's
         /// <c>ApplyTo</c>. A resolution failure cannot be reported as an ordinary non-match: the constraint
         /// has nothing to evaluate, so silently returning "not matched" would make a negated constraint
-        /// (e.g. <c>Is.Not.WithinScreen()</c>) vacuously pass on a null or unusable <paramref name="actual"/>.
+        /// (e.g. <c>Is.Not.WithinScreen</c>) vacuously pass on a null or unusable <paramref name="actual"/>.
         /// </summary>
         /// <param name="actual">Value to resolve.</param>
         /// <param name="paramName">Name reported on failure; does not need to be a real parameter of the

--- a/Runtime/Constraints/TestHelperConstraint.cs
+++ b/Runtime/Constraints/TestHelperConstraint.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2023-2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using NUnit.Framework.Constraints;
+
+namespace TestHelper.Constraints
+{
+    /// <summary>
+    /// Common base class for this package's custom constraints. Hides <see cref="Constraint.And"/>,
+    /// <see cref="Constraint.Or"/>, and <see cref="Constraint.With"/> so a chain that starts at one custom
+    /// constraint keeps property style for the next one too (e.g., <c>Is.Not.Destroyed.And.WithinScreen</c>),
+    /// instead of dropping into <see cref="ConstraintExtensions"/>'s method style.
+    /// </summary>
+    public abstract class TestHelperConstraint : Constraint
+    {
+        protected TestHelperConstraint(params object[] args) : base(args)
+        {
+        }
+
+        /// <summary>
+        /// Requires both this constraint and the one that follows to be satisfied.
+        /// </summary>
+        public new TestHelperConstraintExpression And => AppendOperator(new AndOperator());
+
+        /// <summary>
+        /// Requires either this constraint or the one that follows to be satisfied.
+        /// </summary>
+        public new TestHelperConstraintExpression Or => AppendOperator(new OrOperator());
+
+        /// <summary>
+        /// Alias of <see cref="And"/>, matching NUnit's own <see cref="Constraint.With"/>.
+        /// </summary>
+        public new TestHelperConstraintExpression With => AppendOperator(new AndOperator());
+
+        private TestHelperConstraintExpression AppendOperator(ConstraintOperator op)
+        {
+            // Same shape as NUnit's own Constraint.And/Or/With: a constraint written on its own (e.g.,
+            // `Is.WithinScreen`) has no Builder yet, so start one and push this constraint onto it first.
+            var builder = Builder;
+            if (builder == null)
+            {
+                builder = new ConstraintBuilder();
+                builder.Append(this);
+            }
+
+            builder.Append(op);
+            return new TestHelperConstraintExpression(builder);
+        }
+    }
+}

--- a/Runtime/Constraints/TestHelperConstraint.cs.meta
+++ b/Runtime/Constraints/TestHelperConstraint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4c0f3088bb3be401791b322d8161a52d

--- a/Runtime/Constraints/TestHelperConstraintExpression.cs
+++ b/Runtime/Constraints/TestHelperConstraintExpression.cs
@@ -1,0 +1,111 @@
+// Copyright (c) 2023-2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using NUnit.Framework.Constraints;
+
+namespace TestHelper.Constraints
+{
+    /// <summary>
+    /// A <see cref="ConstraintExpression"/> that exposes this package's custom constraints as properties, so
+    /// they can be written in property style after an operator (e.g., <c>Is.Not.Destroyed</c>) instead of the
+    /// method style required by <see cref="ConstraintExtensions"/> (e.g., <c>Is.Not.Destroyed()</c>).
+    /// </summary>
+    public class TestHelperConstraintExpression : ConstraintExpression
+    {
+        // Note: kept alongside the base class's own (non-public) builder field instead of reading it back,
+        // since relying on that field's existence/accessibility would couple this class to an NUnit
+        // implementation detail rather than its public contract.
+        private readonly ConstraintBuilder _builder;
+
+        public TestHelperConstraintExpression()
+            : this(new ConstraintBuilder())
+        {
+        }
+
+        public TestHelperConstraintExpression(ConstraintBuilder builder) : base(builder)
+        {
+            _builder = builder;
+        }
+
+        /// <summary>
+        /// Negates the constraint that follows.
+        /// </summary>
+        public new TestHelperConstraintExpression Not
+        {
+            get
+            {
+                _builder.Append(new NotOperator());
+                return this;
+            }
+        }
+
+        /// <summary>
+        /// Requires the constraint that follows to be satisfied by every item of a collection.
+        /// </summary>
+        public new TestHelperConstraintExpression All
+        {
+            get
+            {
+                _builder.Append(new AllOperator());
+                return this;
+            }
+        }
+
+        /// <summary>
+        /// Create constraint to destroyed <see cref="UnityEngine.Object"/>.
+        /// </summary>
+        public DestroyedConstraint Destroyed
+        {
+            get
+            {
+                var constraint = new DestroyedConstraint();
+                _builder.Append(constraint);
+                return constraint;
+            }
+        }
+
+        /// <summary>
+        /// Create constraint to <see cref="UnityEngine.RectTransform"/> within the screen.
+        /// </summary>
+        public WithinScreenConstraint WithinScreen
+        {
+            get
+            {
+                var constraint = new WithinScreenConstraint();
+                _builder.Append(constraint);
+                return constraint;
+            }
+        }
+
+        /// <summary>
+        /// Create constraint to a collection of <see cref="UnityEngine.RectTransform"/> where any pair overlaps.
+        /// </summary>
+        public OverlappingConstraint Overlapping
+        {
+            get
+            {
+                var constraint = new OverlappingConstraint();
+                _builder.Append(constraint);
+                return constraint;
+            }
+        }
+
+        /// <summary>
+        /// Create constraint to text overflowing its own <see cref="UnityEngine.RectTransform"/>.
+        /// </summary>
+        public TextOverflowingConstraint TextOverflowing
+        {
+            get
+            {
+                var constraint = new TextOverflowingConstraint();
+                _builder.Append(constraint);
+                return constraint;
+            }
+        }
+
+        // Note: FullyWithin is intentionally NOT exposed here. It takes a RectTransform argument, so it is
+        // always written in method style regardless (e.g., `Is.Not.FullyWithin(container)`); the existing
+        // ConstraintExtensions.FullyWithin(this ConstraintExpression, RectTransform) already binds to this
+        // type without any redeclaration.
+    }
+}

--- a/Runtime/Constraints/TestHelperConstraintExpression.cs.meta
+++ b/Runtime/Constraints/TestHelperConstraintExpression.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5d2ca36cae91544ff943491f2eb9c898

--- a/Runtime/Constraints/TextOverflowingConstraint.cs
+++ b/Runtime/Constraints/TextOverflowingConstraint.cs
@@ -13,7 +13,7 @@ namespace TestHelper.Constraints
     /// Supports uGUI <see cref="UnityEngine.UI.Text"/> and TextMeshPro <see cref="TMPro.TMP_Text"/> (uGUI is
     /// tried first; whichever is found on the target's own GameObject is used).
     /// </summary>
-    public class TextOverflowingConstraint : Constraint
+    public class TextOverflowingConstraint : TestHelperConstraint
     {
         private const float DefaultTolerance = 0.5f;
         private float _tolerance = DefaultTolerance;

--- a/Runtime/Constraints/WithinScreenConstraint.cs
+++ b/Runtime/Constraints/WithinScreenConstraint.cs
@@ -9,7 +9,7 @@ namespace TestHelper.Constraints
     /// <summary>
     /// An NUnit test constraint class to a <see cref="UnityEngine.RectTransform"/> within the screen.
     /// </summary>
-    public class WithinScreenConstraint : Constraint
+    public class WithinScreenConstraint : TestHelperConstraint
     {
         private const float DefaultTolerance = 0.5f;
         private float _tolerance = DefaultTolerance;

--- a/Tests/Runtime/Constraints/ConstraintExtensionsTest.cs
+++ b/Tests/Runtime/Constraints/ConstraintExtensionsTest.cs
@@ -1,0 +1,115 @@
+// Copyright (c) 2023-2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
+using NUnit.Framework;
+using TestHelper.Attributes;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TestHelper.Constraints
+{
+    // Regression coverage for ConstraintExtensions: adding property style (Is.Not.<X>) must not break the
+    // pre-existing method style (Is.Not.<X>()). Compiling and passing is the assertion here; per-constraint
+    // failure-message coverage already lives in each constraint's own test class.
+    [SuppressMessage("ReSharper", "AccessToStaticMemberViaDerivedType")]
+    public class ConstraintExtensionsTest
+    {
+        private static Canvas CreateCanvas()
+        {
+            var canvasGameObject = new GameObject("Canvas", typeof(Canvas));
+            canvasGameObject.GetComponent<Canvas>().renderMode = RenderMode.ScreenSpaceOverlay;
+            return canvasGameObject.GetComponent<Canvas>();
+        }
+
+        private static RectTransform CreateElement(Transform parent, string name, Vector2 anchoredPosition,
+            Vector2 sizeDelta)
+        {
+            var gameObject = new GameObject(name, typeof(RectTransform));
+            var rectTransform = (RectTransform)gameObject.transform;
+            rectTransform.SetParent(parent, worldPositionStays: false);
+            rectTransform.anchorMin = Vector2.zero;
+            rectTransform.anchorMax = Vector2.zero;
+            rectTransform.pivot = Vector2.zero;
+            rectTransform.anchoredPosition = anchoredPosition;
+            rectTransform.sizeDelta = sizeDelta;
+            return rectTransform;
+        }
+
+        [Test]
+        [CreateScene]
+        public void Destroyed_MethodStyleWithOperator_Available()
+        {
+            var actual = new GameObject("Foo");
+
+            Assert.That(actual, Is.Not.Destroyed());
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void WithinScreen_MethodStyleWithOperator_Available()
+        {
+            var canvas = CreateCanvas();
+            const float Width = 50f;
+            const float Overshoot = 20f;
+            var actual = CreateElement(canvas.transform, "Element",
+                new Vector2(Screen.width - Width + Overshoot, 10f), new Vector2(Width, 50f));
+
+            Assert.That(actual, Is.Not.WithinScreen());
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void FullyWithin_MethodStyleWithOperator_Available()
+        {
+            var canvas = CreateCanvas();
+            var container = CreateElement(canvas.transform, "Viewport", Vector2.zero, new Vector2(200f, 150f));
+            var actual = CreateElement(canvas.transform, "Element", new Vector2(300f, 300f), new Vector2(50f, 50f));
+
+            Assert.That(actual, Is.Not.FullyWithin(container));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void Overlapping_MethodStyleWithOperator_Available()
+        {
+            var canvas = CreateCanvas();
+            var actual = new[]
+            {
+                CreateElement(canvas.transform, "TestCard (0)", new Vector2(0f, 0f), new Vector2(50f, 50f)),
+                CreateElement(canvas.transform, "TestCard (1)", new Vector2(60f, 0f), new Vector2(50f, 50f)),
+            };
+
+            Assert.That(actual, Is.Not.Overlapping());
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task TextOverflowing_MethodStyleWithOperator_Available()
+        {
+            var canvas = CreateCanvas();
+            var element = CreateElement(canvas.transform, "Label", Vector2.zero, new Vector2(300f, 100f));
+            var text = element.gameObject.AddComponent<Text>();
+            text.font = Resources.GetBuiltinResource<Font>(
+#if UNITY_2022_2_OR_NEWER
+                "LegacyRuntime.ttf"
+#else
+                "Arial.ttf" // Arial.ttf was replaced by LegacyRuntime.ttf in Unity 2022.2
+#endif
+            );
+            text.text = "Hi";
+            text.fontSize = 20;
+            Assume.That(text.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await UniTask.NextFrame();
+
+            Assert.That(element, Is.Not.TextOverflowing());
+        }
+    }
+}

--- a/Tests/Runtime/Constraints/ConstraintExtensionsTest.cs.meta
+++ b/Tests/Runtime/Constraints/ConstraintExtensionsTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 95137da0927864bbcb49deb51ad2b7af

--- a/Tests/Runtime/Constraints/DestroyedConstraintTest.cs
+++ b/Tests/Runtime/Constraints/DestroyedConstraintTest.cs
@@ -70,7 +70,7 @@ namespace TestHelper.Constraints
 
             Assert.That(() =>
             {
-                Assert.That(actual, Is.Not.Destroyed()); // Note: Use it in method style when with operators
+                Assert.That(actual, Is.Not.Destroyed);
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: not destroyed UnityEngine.Object{Environment.NewLine}  But was:  <null>{Environment.NewLine}"));
         }
@@ -80,7 +80,7 @@ namespace TestHelper.Constraints
         {
             var actual = new GameObject("Foo");
 
-            Assert.That(actual, Is.Not.Destroyed()); // Note: Use it in method style when with operators
+            Assert.That(actual, Is.Not.Destroyed);
         }
     }
 }

--- a/Tests/Runtime/Constraints/FullyWithinConstraintTest.cs
+++ b/Tests/Runtime/Constraints/FullyWithinConstraintTest.cs
@@ -323,7 +323,7 @@ namespace TestHelper.Constraints
             var actual = CreateElement("Element", container, new Vector2(ContainerSize.x - 50f + Overshoot, 20f),
                 new Vector2(50f, 60f));
 
-            Assert.That(actual, Is.Not.FullyWithin(container)); // Note: Use it in method style when with operators
+            Assert.That(actual, Is.Not.FullyWithin(container));
         }
 
         [Test]
@@ -338,7 +338,7 @@ namespace TestHelper.Constraints
 
             Assert.That(() =>
             {
-                Assert.That(element, Is.Not.FullyWithin(container)); // Note: Use it in method style when with operators
+                Assert.That(element, Is.Not.FullyWithin(container));
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: not RectTransform fully within \"Viewport\" {ConstraintMessageFormatter.Format(ContainerScreenRect)}{Environment.NewLine}" +
                 $"  But was:  <\"Element\" {ConstraintMessageFormatter.Format(ElementScreenRect(localPosition, size))}>{Environment.NewLine}"));
@@ -353,7 +353,7 @@ namespace TestHelper.Constraints
 
             Assert.That(() =>
             {
-                Assert.That(null, Is.Not.FullyWithin(container)); // Note: Use it in method style when with operators
+                Assert.That(null, Is.Not.FullyWithin(container));
             }, Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("actual"));
         }
 
@@ -366,7 +366,7 @@ namespace TestHelper.Constraints
 
             Assert.That(() =>
             {
-                Assert.That(element, Is.Not.FullyWithin(null)); // Note: Use it in method style when with operators
+                Assert.That(element, Is.Not.FullyWithin(null));
             }, Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("container"));
         }
 
@@ -383,7 +383,6 @@ namespace TestHelper.Constraints
             Assert.That(() =>
             {
                 Assert.That(element, Is.Not.FullyWithin(container).Horizontally().Within(2f));
-                // Note: Use it in method style when with operators
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: not RectTransform horizontally fully within \"Viewport\" {ConstraintMessageFormatter.Format(ContainerScreenRect)}{Environment.NewLine}" +
                 $"  But was:  <\"Element\" {ConstraintMessageFormatter.Format(ElementScreenRect(localPosition, size))}>{Environment.NewLine}"));

--- a/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
@@ -79,7 +79,7 @@ namespace TestHelper.Constraints
                 CreateElement(canvas.transform, "TestCard (2)", new Vector2(120f, 0f), new Vector2(50f, 50f)),
             };
 
-            Assert.That(actual, Is.Not.Overlapping()); // Note: Use it in method style when with operators
+            Assert.That(actual, Is.Not.Overlapping);
         }
 
         [Test]
@@ -92,7 +92,7 @@ namespace TestHelper.Constraints
             var element1 = CreateElement(canvas.transform, "TestCard (1)", new Vector2(60f, 0f), new Vector2(50f, 50f));
             var actual = new[] { AsActual(element0, kind), AsActual(element1, kind) };
 
-            Assert.That(actual, Is.Not.Overlapping()); // Note: Use it in method style when with operators
+            Assert.That(actual, Is.Not.Overlapping);
         }
 
         [Test]
@@ -109,7 +109,7 @@ namespace TestHelper.Constraints
 
             Assert.That(() =>
             {
-                Assert.That(actual, Is.Not.Overlapping()); // Note: Use it in method style when with operators
+                Assert.That(actual, Is.Not.Overlapping);
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: not any pair of RectTransforms overlapping{Environment.NewLine}" +
                 $"  But was:  <\"TestCard (3)\" {ConstraintMessageFormatter.Format(new Rect(120f, 40f, 100f, 100f))} overlaps \"TestCard (4)\" {ConstraintMessageFormatter.Format(new Rect(200f, 40f, 100f, 100f))}>{Environment.NewLine}"));
@@ -131,7 +131,7 @@ namespace TestHelper.Constraints
 
             Assert.That(() =>
             {
-                Assert.That(actual, Is.Not.Overlapping()); // Note: Use it in method style when with operators
+                Assert.That(actual, Is.Not.Overlapping);
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: not any pair of RectTransforms overlapping{Environment.NewLine}" +
                 $"  But was:  <\"TestCard (0)\" {ConstraintMessageFormatter.Format(new Rect(0f, 0f, 100f, 100f))} overlaps \"TestCard (1)\" {ConstraintMessageFormatter.Format(new Rect(20f, 20f, 100f, 100f))} (and 2 more overlapping pairs)>{Environment.NewLine}"));
@@ -186,7 +186,7 @@ namespace TestHelper.Constraints
                     new Vector2(100f, 100f)),
             };
 
-            Assert.That(actual, Is.Not.Overlapping()); // Note: Use it in method style when with operators
+            Assert.That(actual, Is.Not.Overlapping);
         }
 
         [Test]
@@ -203,7 +203,7 @@ namespace TestHelper.Constraints
 
             Assert.That(() =>
             {
-                Assert.That(actual, Is.Not.Overlapping()); // Note: Use it in method style when with operators
+                Assert.That(actual, Is.Not.Overlapping);
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: not any pair of RectTransforms overlapping{Environment.NewLine}" +
                 $"  But was:  <\"TestCard (0)\" {ConstraintMessageFormatter.Format(new Rect(0f, 0f, 100f, 100f))} overlaps \"TestCard (1)\" {ConstraintMessageFormatter.Format(new Rect(100f - OverlapExtent, 0f, 100f, 100f))}>{Environment.NewLine}"));
@@ -223,7 +223,7 @@ namespace TestHelper.Constraints
                     new Vector2(100f, 100f)),
             };
 
-            Assert.That(actual, Is.Not.Overlapping().Within(2f));
+            Assert.That(actual, Is.Not.Overlapping.Within(2f));
         }
 
         [Test]
@@ -238,7 +238,7 @@ namespace TestHelper.Constraints
                 CreateElement(canvas.transform, "TestCard (1)", new Vector2(50f, 100f), new Vector2(100f, 50f)),
             };
 
-            Assert.That(actual, Is.Not.Overlapping()); // Note: Use it in method style when with operators
+            Assert.That(actual, Is.Not.Overlapping);
         }
 
         [TestCase(0)]
@@ -249,7 +249,7 @@ namespace TestHelper.Constraints
             var canvas = CreateCanvas();
             var actual = CreateElements(canvas.transform, memberCount);
 
-            Assert.That(actual, Is.Not.Overlapping()); // Note: Use it in method style when with operators
+            Assert.That(actual, Is.Not.Overlapping);
         }
 
         [Test]
@@ -265,7 +265,7 @@ namespace TestHelper.Constraints
             var actual = new[] { element0, element1 };
             var ignoredGroup = new[] { element0, element1 };
 
-            Assert.That(actual, Is.Not.Overlapping().Ignoring(ignoredGroup));
+            Assert.That(actual, Is.Not.Overlapping.Ignoring(ignoredGroup));
         }
 
         [Test]
@@ -283,7 +283,7 @@ namespace TestHelper.Constraints
 
             Assert.That(() =>
             {
-                Assert.That(actual, Is.Not.Overlapping().Ignoring(ignoredGroup));
+                Assert.That(actual, Is.Not.Overlapping.Ignoring(ignoredGroup));
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: not any pair of RectTransforms overlapping{Environment.NewLine}" +
                 $"  But was:  <\"TestCard (0)\" {ConstraintMessageFormatter.Format(new Rect(0f, 0f, 100f, 100f))} overlaps \"TestCard (1)\" {ConstraintMessageFormatter.Format(new Rect(20f, 20f, 100f, 100f))}>{Environment.NewLine}"));
@@ -307,7 +307,7 @@ namespace TestHelper.Constraints
             var groupA = new[] { element0, element1 };
             var groupB = new[] { element2, element3 };
 
-            Assert.That(actual, Is.Not.Overlapping().Ignoring(groupA).Ignoring(groupB));
+            Assert.That(actual, Is.Not.Overlapping.Ignoring(groupA).Ignoring(groupB));
         }
 
         [Test]
@@ -327,7 +327,7 @@ namespace TestHelper.Constraints
             var actual = new[] { element0, element1, element2, element3 };
             var ignoredGroup = new[] { element0, element1 };
 
-            Assert.That(actual, Is.Not.Overlapping().Ignoring(ignoredGroup).Within(2f));
+            Assert.That(actual, Is.Not.Overlapping.Ignoring(ignoredGroup).Within(2f));
         }
 
         [Test]
@@ -439,7 +439,7 @@ namespace TestHelper.Constraints
         {
             Assert.That(() =>
             {
-                Assert.That(null, Is.Not.Overlapping()); // Note: Use it in method style when with operators
+                Assert.That(null, Is.Not.Overlapping);
             }, Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("actual"));
         }
     }

--- a/Tests/Runtime/Constraints/TestHelperConstraintExpressionTest.cs
+++ b/Tests/Runtime/Constraints/TestHelperConstraintExpressionTest.cs
@@ -1,0 +1,132 @@
+// Copyright (c) 2023-2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using NUnit.Framework;
+using TestHelper.Attributes;
+using UnityEngine;
+
+namespace TestHelper.Constraints
+{
+    // Exercises the operator plumbing (Not, All, And, Or, With) shared by every custom constraint, using
+    // Destroyed and WithinScreen as representatives. Per-constraint property-style coverage of `Is.Not.<X>`
+    // itself lives in each constraint's own test class (e.g. DestroyedConstraintTest).
+    [SuppressMessage("ReSharper", "AccessToStaticMemberViaDerivedType")]
+    public class TestHelperConstraintExpressionTest
+    {
+        private static GameObject CreateDestroyedObject()
+        {
+            var gameObject = new GameObject();
+            GameObject.DestroyImmediate(gameObject);
+            return gameObject;
+        }
+
+        private static RectTransform CreateOnScreenElement()
+        {
+            var canvasGameObject = new GameObject("Canvas", typeof(Canvas));
+            canvasGameObject.GetComponent<Canvas>().renderMode = RenderMode.ScreenSpaceOverlay;
+
+            var gameObject = new GameObject("Element", typeof(RectTransform));
+            var rectTransform = (RectTransform)gameObject.transform;
+            rectTransform.SetParent(canvasGameObject.transform, worldPositionStays: false);
+            rectTransform.anchorMin = Vector2.zero;
+            rectTransform.anchorMax = Vector2.zero;
+            rectTransform.pivot = Vector2.zero;
+            rectTransform.anchoredPosition = new Vector2(Screen.width / 4f, Screen.height / 4f);
+            rectTransform.sizeDelta = new Vector2(Screen.width / 4f, Screen.height / 4f);
+            return rectTransform;
+        }
+
+        private static RectTransform CreateOffScreenElement()
+        {
+            var canvasGameObject = new GameObject("Canvas", typeof(Canvas));
+            canvasGameObject.GetComponent<Canvas>().renderMode = RenderMode.ScreenSpaceOverlay;
+
+            const float Width = 50f;
+            const float Overshoot = 20f;
+            var gameObject = new GameObject("Element", typeof(RectTransform));
+            var rectTransform = (RectTransform)gameObject.transform;
+            rectTransform.SetParent(canvasGameObject.transform, worldPositionStays: false);
+            rectTransform.anchorMin = Vector2.zero;
+            rectTransform.anchorMax = Vector2.zero;
+            rectTransform.pivot = Vector2.zero;
+            rectTransform.anchoredPosition = new Vector2(Screen.width - Width + Overshoot, 10f);
+            rectTransform.sizeDelta = new Vector2(Width, 50f);
+            return rectTransform;
+        }
+
+        [Test]
+        [CreateScene]
+        public void IsAllDestroyed_AllItemsDestroyed_Success()
+        {
+            var actual = new[] { CreateDestroyedObject(), CreateDestroyedObject() };
+
+            Assert.That(actual, Is.All.Destroyed);
+        }
+
+        [Test]
+        [CreateScene]
+        public void IsAllNotDestroyed_NoItemsDestroyed_Success()
+        {
+            var actual = new[] { new GameObject("Foo"), new GameObject("Bar") };
+
+            Assert.That(actual, Is.All.Not.Destroyed);
+        }
+
+        [Test]
+        [CreateScene]
+        public void IsNotDestroyedAndNotNull_AliveObject_Success()
+        {
+            var actual = new GameObject("Foo");
+
+            Assert.That(actual, Is.Not.Destroyed.And.Not.Null);
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotDestroyedAndWithinScreen_AliveOnScreenElement_Success()
+        {
+            var actual = CreateOnScreenElement();
+
+            Assert.That(actual, Is.Not.Destroyed.And.WithinScreen);
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotDestroyedAndWithinScreen_OffScreenElement_Failure()
+        {
+            var actual = CreateOffScreenElement();
+
+            Assert.That(() =>
+            {
+                Assert.That(actual, Is.Not.Destroyed.And.WithinScreen);
+            }, Throws.TypeOf<AssertionException>()
+                .With.Message.Contains("not destroyed UnityEngine.Object")
+                .And.Message.Contains("RectTransform within screen"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsDestroyedOrWithinScreen_OnScreenAliveElement_Success()
+        {
+            // Left (Destroyed) fails and right (WithinScreen) passes, so both sides are actually evaluated.
+            // Not a destroyed actual: WithinScreenConstraint throws on a destroyed RectTransform, which would
+            // make this pass only by luck of OrConstraint's short-circuit, not because Or itself works.
+            var actual = CreateOnScreenElement();
+
+            Assert.That(actual, Is.Destroyed.Or.WithinScreen);
+        }
+
+        [Test]
+        [CreateScene]
+        public void IsNotDestroyedWithNotNull_AliveObject_Success()
+        {
+            var actual = new GameObject("Foo");
+
+            Assert.That(actual, Is.Not.Destroyed.With.Not.Null);
+        }
+    }
+}

--- a/Tests/Runtime/Constraints/TestHelperConstraintExpressionTest.cs.meta
+++ b/Tests/Runtime/Constraints/TestHelperConstraintExpressionTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 39f1cc16efa254d4bb2af2ce519988aa

--- a/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
@@ -143,7 +143,7 @@ namespace TestHelper.Constraints
             Canvas.ForceUpdateCanvases();
             await UniTask.NextFrame();
 
-            Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
         }
 
         [Test]
@@ -158,7 +158,7 @@ namespace TestHelper.Constraints
             await UniTask.NextFrame();
             var actual = AsActual(uguiText.GetComponent<RectTransform>(), kind);
 
-            Assert.That(actual, Is.Not.TextOverflowing());
+            Assert.That(actual, Is.Not.TextOverflowing);
         }
 
         [Test]
@@ -195,7 +195,7 @@ namespace TestHelper.Constraints
 
             Assert.That(() =>
             {
-                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
             }, Throws.TypeOf<AssertionException>()
                 .With.Message.Contains("Expected: not text overflowing its RectTransform")
                 .And.Message.Contains("\"Label\"")
@@ -219,7 +219,7 @@ namespace TestHelper.Constraints
             Canvas.ForceUpdateCanvases();
             await UniTask.NextFrame();
 
-            Assert.That(rectTransform, Is.Not.TextOverflowing());
+            Assert.That(rectTransform, Is.Not.TextOverflowing);
         }
 
         [Test]
@@ -239,7 +239,7 @@ namespace TestHelper.Constraints
             Canvas.ForceUpdateCanvases();
             await UniTask.NextFrame();
 
-            Assert.That(rectTransform, Is.Not.TextOverflowing().Within(2f));
+            Assert.That(rectTransform, Is.Not.TextOverflowing.Within(2f));
         }
 
         [Test]
@@ -254,7 +254,7 @@ namespace TestHelper.Constraints
             Canvas.ForceUpdateCanvases();
             await UniTask.NextFrame();
 
-            Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
         }
 
         [Test]
@@ -289,7 +289,7 @@ namespace TestHelper.Constraints
             Canvas.ForceUpdateCanvases();
             await UniTask.NextFrame();
 
-            Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
         }
 
         [Test]
@@ -327,7 +327,7 @@ namespace TestHelper.Constraints
 
             Assert.That(() =>
             {
-                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
             }, Throws.TypeOf<AssertionException>()
                 .With.Message.Contains("\"Label\"")
                 .And.Message.Contains("exceeds rect"));
@@ -347,7 +347,7 @@ namespace TestHelper.Constraints
 
             Assert.That(() =>
             {
-                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
             }, Throws.TypeOf<AssertionException>()
                 .With.Message.Contains("\"Label\"")
                 .And.Message.Contains("exceeds rect"));
@@ -368,7 +368,7 @@ namespace TestHelper.Constraints
 
             Assert.That(() =>
             {
-                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
             }, Throws.TypeOf<AssertionException>()
                 .With.Message.Contains("\"Label\"")
                 .And.Message.Contains("are rendered"));
@@ -388,7 +388,7 @@ namespace TestHelper.Constraints
 
             Assert.That(() =>
             {
-                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
             }, Throws.TypeOf<AssertionException>()
                 .With.Message.Contains("\"Label\"")
                 .And.Message.Contains("are rendered"));
@@ -408,7 +408,7 @@ namespace TestHelper.Constraints
 
             Assert.That(() =>
             {
-                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
             }, Throws.TypeOf<AssertionException>()
                 .With.Message.Contains("\"Label\"")
                 .And.Message.Contains("exceeds rect")
@@ -427,7 +427,7 @@ namespace TestHelper.Constraints
 
             Assert.That(() =>
             {
-                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
             }, Throws.TypeOf<AssertionException>()
                 .With.Message.Contains("\"Label\"")
                 .And.Message.Contains("has not been laid out; call Canvas.ForceUpdateCanvases() before asserting")
@@ -445,7 +445,7 @@ namespace TestHelper.Constraints
             Canvas.ForceUpdateCanvases();
             await UniTask.NextFrame();
 
-            Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
         }
 
         [Test]
@@ -460,7 +460,7 @@ namespace TestHelper.Constraints
             Canvas.ForceUpdateCanvases();
             await UniTask.NextFrame();
 
-            Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
         }
 
 #if ENABLE_TMP
@@ -475,7 +475,7 @@ namespace TestHelper.Constraints
             Canvas.ForceUpdateCanvases();
             await UniTask.NextFrame();
 
-            Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
         }
 
         [Test]
@@ -492,7 +492,7 @@ namespace TestHelper.Constraints
 
             Assert.That(() =>
             {
-                Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+                Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
             }, Throws.TypeOf<AssertionException>()
                 .With.Message.Contains("\"Label\"")
                 .And.Message.Contains("exceeds rect")
@@ -512,7 +512,7 @@ namespace TestHelper.Constraints
             Canvas.ForceUpdateCanvases();
             await UniTask.NextFrame();
 
-            Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
         }
 
         [Test]
@@ -527,7 +527,7 @@ namespace TestHelper.Constraints
             Canvas.ForceUpdateCanvases();
             await UniTask.NextFrame();
 
-            Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
         }
 
         [Test]
@@ -545,7 +545,7 @@ namespace TestHelper.Constraints
 
             Assert.That(() =>
             {
-                Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+                Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
             }, Throws.TypeOf<AssertionException>()
                 .With.Message.Contains("\"Label\"")
                 .And.Message.Contains("are not rendered (overflowMode: Truncate)"));
@@ -562,7 +562,7 @@ namespace TestHelper.Constraints
             Canvas.ForceUpdateCanvases();
             await UniTask.NextFrame();
 
-            Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
         }
 
         [Test]
@@ -577,7 +577,7 @@ namespace TestHelper.Constraints
             // test: TMP_Text.preferredWidth/preferredHeight compute the layout on demand rather than
             // depending on a prior OnPopulateMesh pass, so there is no "not laid out" state to detect here.
 
-            Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
         }
 
         [Test]
@@ -600,7 +600,7 @@ namespace TestHelper.Constraints
             Canvas.ForceUpdateCanvases();
             await UniTask.NextFrame();
 
-            Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+            Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
         }
 #endif
 
@@ -632,7 +632,7 @@ namespace TestHelper.Constraints
 
             Assert.That(() =>
             {
-                Assert.That(gameObject.GetComponent<RectTransform>(), Is.Not.TextOverflowing());
+                Assert.That(gameObject.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
             }, Throws.TypeOf<ArgumentException>()
                 .With.Property("ParamName").EqualTo("actual")
                 .And.Message.Contains("has no Text or TMP_Text component"));
@@ -652,7 +652,7 @@ namespace TestHelper.Constraints
         {
             Assert.That(() =>
             {
-                Assert.That(null, Is.Not.TextOverflowing());
+                Assert.That(null, Is.Not.TextOverflowing);
             }, Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("actual"));
         }
 

--- a/Tests/Runtime/Constraints/WithinScreenConstraintTest.cs
+++ b/Tests/Runtime/Constraints/WithinScreenConstraintTest.cs
@@ -347,7 +347,7 @@ namespace TestHelper.Constraints
             var actual = CreateElement("Element", new Vector2(Screen.width - Width + Overshoot, 10f),
                 new Vector2(Width, 50f));
 
-            Assert.That(actual, Is.Not.WithinScreen()); // Note: Use it in method style when with operators
+            Assert.That(actual, Is.Not.WithinScreen);
         }
 
         [Test]
@@ -362,7 +362,7 @@ namespace TestHelper.Constraints
 
             Assert.That(() =>
             {
-                Assert.That(element, Is.Not.WithinScreen()); // Note: Use it in method style when with operators
+                Assert.That(element, Is.Not.WithinScreen);
             }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
                 $"  Expected: not {ExpectedWithinScreenLine}{Environment.NewLine}" +
                 $"  But was:  <\"Element\" {ConstraintMessageFormatter.Format(elementScreenRect)}>{Environment.NewLine}"));
@@ -374,7 +374,7 @@ namespace TestHelper.Constraints
         {
             Assert.That(() =>
             {
-                Assert.That(null, Is.Not.WithinScreen()); // Note: Use it in method style when with operators
+                Assert.That(null, Is.Not.WithinScreen);
             }, Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("actual"));
         }
     }


### PR DESCRIPTION
## Summary

- `Is.Not.Destroyed()` and similar chains required method style because NUnit's `ConstraintExpression`/`Constraint` types offer no hook for adding properties.
- Add `TestHelperConstraintExpression`/`TestHelperConstraint`, which hide `Not`/`All`/`And`/`Or`/`With` to return a type that exposes this package's constraints as properties, so `Is.Not.Destroyed`, `Is.All.WithinScreen`, and `Is.Not.Destroyed.And.WithinScreen` all read naturally.
- Method style keeps working unchanged (a property and an extension method of the same name coexist in C#'s member lookup, the same way `List<T>.Count` and `Enumerable.Count()` do), so existing call sites and `ConstraintExtensions` are unaffected -- no breaking change.
- `FullyWithin` always takes an argument, so it stays method style regardless, e.g. `Is.Not.FullyWithin(container)`.
- Updated README, XML docs, and code comments accordingly; existing tests rewritten to property style, with a new `ConstraintExtensionsTest` covering the method-style regression.

## Test plan

- [x] `get_unity_compilation_result`: no errors, no `CS0109` warnings
- [x] `run_unity_tests` (PlayMode, `TestHelper.Tests`, `TestHelper.Constraints.*`): 163 passed, 0 failed
- [x] `/resolve-diagnostics` applied to `Runtime/Constraints` and `Tests/Runtime/Constraints`
