### PR TITLE
Throw ArgumentException in DestroyedConstraint when actual is not a UnityEngine.Object

### DIFF
--- a/Runtime/Constraints/DestroyedConstraint.cs
+++ b/Runtime/Constraints/DestroyedConstraint.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using System;
 using NUnit.Framework.Constraints;
-using UnityEngine;
 
 namespace TestHelper.Constraints
 {
@@ -34,14 +34,25 @@ namespace TestHelper.Constraints
             base.Description = "destroyed UnityEngine.Object";
         }
 
+        /// <inheritdoc/>
+        /// <exception cref="System.ArgumentNullException"><paramref name="actual"/> is null.</exception>
+        /// <exception cref="System.ArgumentException"><paramref name="actual"/> is not a
+        /// <see cref="UnityEngine.Object"/>.</exception>
         public override ConstraintResult ApplyTo(object actual)
         {
-            if (actual is Object actualObject)
+            if (actual == null)
             {
-                return new ConstraintResult(this, actual, !(bool)actualObject);
+                throw new ArgumentNullException(nameof(actual));
             }
 
-            return new ConstraintResult(this, actual, false);
+            if (!(actual is UnityEngine.Object actualObject))
+            {
+                throw new ArgumentException(
+                    $"{ConstraintMessageFormatter.DescribeActual(actual)} is not a UnityEngine.Object",
+                    nameof(actual));
+            }
+
+            return new ConstraintResult(this, actual, !(bool)actualObject);
         }
     }
 }

--- a/Tests/Runtime/Constraints/DestroyedConstraintTest.cs
+++ b/Tests/Runtime/Constraints/DestroyedConstraintTest.cs
@@ -48,7 +48,7 @@ namespace TestHelper.Constraints
                 case ObjectKind.ScriptableObject:
                     return ScriptableObject.CreateInstance<ScriptableObject>();
                 default:
-                    return new GameObject("Foo");
+                    throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unsupported ObjectKind");
             }
         }
 

--- a/Tests/Runtime/Constraints/DestroyedConstraintTest.cs
+++ b/Tests/Runtime/Constraints/DestroyedConstraintTest.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
 using System.Diagnostics.CodeAnalysis;
 using NUnit.Framework;
+using TestHelper.Attributes;
 using UnityEngine;
 
 namespace TestHelper.Constraints
@@ -11,23 +12,65 @@ namespace TestHelper.Constraints
     [SuppressMessage("ReSharper", "AccessToStaticMemberViaDerivedType")]
     public class DestroyedConstraintTest
     {
-        private static GameObject CreateDestroyedObject()
+        public enum ObjectKind
         {
-            var gameObject = new GameObject();
-            GameObject.DestroyImmediate(gameObject);
-            return gameObject;
+            GameObject,
+            Component,
+            ScriptableObject,
+        }
+
+        private class DemoComponent : MonoBehaviour
+        {
+        }
+
+        // Cleans up the ScriptableObject created by IsNotDestroyed_AliveObject_Success: unlike a GameObject,
+        // it is not covered by [CreateScene] and would otherwise leak into subsequent tests.
+        private ScriptableObject _createdScriptableObject;
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_createdScriptableObject != null)
+            {
+                UnityEngine.Object.DestroyImmediate(_createdScriptableObject);
+                _createdScriptableObject = null;
+            }
+        }
+
+        private static UnityEngine.Object CreateObject(ObjectKind kind)
+        {
+            switch (kind)
+            {
+                case ObjectKind.GameObject:
+                    return new GameObject("Foo");
+                case ObjectKind.Component:
+                    return new GameObject("Foo").AddComponent<DemoComponent>();
+                case ObjectKind.ScriptableObject:
+                    return ScriptableObject.CreateInstance<ScriptableObject>();
+                default:
+                    return new GameObject("Foo");
+            }
+        }
+
+        private static UnityEngine.Object CreateDestroyedObject(ObjectKind kind)
+        {
+            var actual = CreateObject(kind);
+            UnityEngine.Object.DestroyImmediate(actual);
+            return actual;
         }
 
         [Test]
-        public void IsDestroyed_DestroyedGameObject_Success()
+        [CreateScene]
+        public void IsDestroyed_DestroyedObject_Success([Values] ObjectKind kind)
         {
-            var actual = CreateDestroyedObject();
+            var actual = CreateDestroyedObject(kind);
 
             Assert.That(actual, Is.Destroyed);
         }
 
         [Test]
-        public void IsDestroyed_NotDestroyedGameObject_Failure()
+        [CreateScene]
+        public void IsDestroyed_AliveGameObject_Failure()
         {
             var actual = new GameObject("Foo");
 
@@ -39,34 +82,42 @@ namespace TestHelper.Constraints
         }
 
         [Test]
-        public void IsDestroyed_Null_Failure()
+        public void IsDestroyed_Null_ThrowsArgumentNullException()
         {
-            GameObject actual = null;
-
             Assert.That(() =>
             {
-                // ReSharper disable once ExpressionIsAlwaysNull
-                Assert.That(actual, Is.Destroyed);
-            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: destroyed UnityEngine.Object{Environment.NewLine}  But was:  null{Environment.NewLine}"));
+                Assert.That(null, Is.Destroyed);
+            }, Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("actual"));
         }
 
         [Test]
-        public void IsDestroyed_NotGameObject_Failure()
+        public void IsDestroyed_UnsupportedActualType_ThrowsArgumentException()
         {
-            var actual = string.Empty;
-
             Assert.That(() =>
             {
-                Assert.That(actual, Is.Destroyed);
-            }, Throws.TypeOf<AssertionException>().With.Message.EqualTo(
-                $"  Expected: destroyed UnityEngine.Object{Environment.NewLine}  But was:  <string.Empty>{Environment.NewLine}"));
+                // Not a swapped actual/expected: this constant IS the actual value under test, deliberately an
+                // unsupported type, to exercise the "not a UnityEngine.Object" failure path.
+                Assert.That("not a UnityEngine.Object", Is.Destroyed);
+            }, Throws.TypeOf<ArgumentException>()
+                .With.Property("ParamName").EqualTo("actual")
+                .And.Message.Contains("is not a UnityEngine.Object"));
         }
 
         [Test]
+        [CreateScene]
+        public void IsNotDestroyed_AliveObject_Success([Values] ObjectKind kind)
+        {
+            var actual = CreateObject(kind);
+            _createdScriptableObject = actual as ScriptableObject;
+
+            Assert.That(actual, Is.Not.Destroyed);
+        }
+
+        [Test]
+        [CreateScene]
         public void IsNotDestroyed_DestroyedGameObject_Failure()
         {
-            var actual = CreateDestroyedObject();
+            var actual = CreateDestroyedObject(ObjectKind.GameObject);
 
             Assert.That(() =>
             {
@@ -76,11 +127,25 @@ namespace TestHelper.Constraints
         }
 
         [Test]
-        public void IsNotDestroyed_NotDestroyedGameObject_Success()
+        public void IsNotDestroyed_Null_ThrowsArgumentNullException()
         {
-            var actual = new GameObject("Foo");
+            Assert.That(() =>
+            {
+                Assert.That(null, Is.Not.Destroyed);
+            }, Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("actual"));
+        }
 
-            Assert.That(actual, Is.Not.Destroyed);
+        [Test]
+        public void IsNotDestroyed_UnsupportedActualType_ThrowsArgumentException()
+        {
+            Assert.That(() =>
+            {
+                // Not a swapped actual/expected: this constant IS the actual value under test, deliberately an
+                // unsupported type, to exercise the "not a UnityEngine.Object" failure path.
+                Assert.That("not a UnityEngine.Object", Is.Not.Destroyed);
+            }, Throws.TypeOf<ArgumentException>()
+                .With.Property("ParamName").EqualTo("actual")
+                .And.Message.Contains("is not a UnityEngine.Object"));
         }
     }
 }


### PR DESCRIPTION
## Summary

- `Is.Not.Destroyed` previously succeeded vacuously on `null` or a non-`UnityEngine.Object` `actual`, since `ApplyTo` returned a plain non-match for anything it couldn't resolve. `DestroyedConstraint.ApplyTo` now throws `ArgumentNullException`/`ArgumentException` instead, matching the convention already used by `WithinScreenConstraint`, `FullyWithinConstraint`, `OverlappingConstraint`, and `TextOverflowingConstraint`.
- Expanded `DestroyedConstraintTest` from 6 to 8 methods: full equivalence-partition coverage (destroyed / alive / null / unsupported type) on both `Is.Destroyed` and `Is.Not.Destroyed`, and representative coverage across `GameObject`, `Component`, and `ScriptableObject` (previously `GameObject` only).

## Test plan

- [x] `TestHelper.Tests` (PlayMode): `DestroyedConstraintTest`, `TestHelperConstraintExpressionTest`, `ConstraintExtensionsTest` -- 24/24 pass
- [x] `TestHelper.Tests` full assembly (PlayMode) -- 365/368 pass (3 pre-existing, unrelated `FocusGameViewAttributeTest` failures from GameView focus in this environment)
- [x] `TestHelper.RuntimeInternals.Tests` (PlayMode) -- 126/126 pass
- [x] `TestHelper.Editor.Tests` (EditMode) -- 20/20 pass
- [x] Confirmed against the latest `master` CI run (`testMode: Standalone`, Unity 6000.0.63f1, IL2CPP, managed stripping High) that `DestroyedConstraintTest` already runs and passes on a Player build, so this behavior is Editor/Player-consistent
- [x] CI (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
