### PR TITLE
Improve layout constraints: TMP rendered-size overflow, Ellipsis, min-count guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,12 @@ public class MyTestClass
 Chain `.Within(float)` to widen the tolerance in pixels (default `0.5f`), e.g., `Is.WithinScreen.Within(2f)`.
 
 > [!IMPORTANT]\
+> This constraint compares only axis-aligned bounding boxes computed from the four world corners — geometry only (rotated elements are over-approximated).\
+> `RectMask2D` clipping, `Canvas.enabled`, `CanvasGroup.alpha`, and `activeInHierarchy` are not considered.\
+> To verify an element stays inside a mask, use `Is.FullyWithin(container)` with the mask's `RectTransform` as container, plus `Assume.That(container.GetComponent<RectMask2D>(), Is.Not.Null);`.\
+> To verify actual visibility/reachability, use `TestHelper.UI.GameObjectFinder` in the [test-helper.ui](https://github.com/nowsprinting/test-helper.ui) package with `reachable: true`.
+
+> [!NOTE]\
 > This constraint is intended for scenes and prefabs authored by coding agents.
 > Do not use it where the layout intentionally overflows the screen.
 
@@ -542,6 +548,12 @@ public class MyTestClass
 Chain `.Horizontally()` or `.Vertically()` to narrow the check to a single axis (calling both is equivalent to specifying neither — both axes are checked by default), and `.Within(float)` to widen the tolerance in pixels (default `0.5f`), e.g., `Is.FullyWithin(viewport).Horizontally().Within(2f)`.
 
 > [!IMPORTANT]\
+> This constraint compares only axis-aligned bounding boxes computed from the four world corners — geometry only (rotated elements are over-approximated).\
+> `RectMask2D` clipping, `Canvas.enabled`, `CanvasGroup.alpha`, and `activeInHierarchy` are not considered.\
+> To verify an element stays inside a mask, use `Is.FullyWithin(container)` with the mask's `RectTransform` as container, plus `Assume.That(container.GetComponent<RectMask2D>(), Is.Not.Null);`.\
+> To verify actual visibility/reachability, use `TestHelper.UI.GameObjectFinder` in the [test-helper.ui](https://github.com/nowsprinting/test-helper.ui) package with `reachable: true`.
+
+> [!NOTE]\
 > This constraint is intended for scenes and prefabs authored by coding agents.
 > Do not use it where the layout intentionally overflows its container.
 
@@ -575,12 +587,18 @@ Assert.That(cards.Prepend(skipButton), Is.Not.Overlapping.Ignoring(cards));
 ```
 
 > [!IMPORTANT]\
+> This constraint compares only axis-aligned bounding boxes computed from the four world corners — geometry only (rotated elements are over-approximated).\
+> `RectMask2D` clipping, `Canvas.enabled`, `CanvasGroup.alpha`, and `activeInHierarchy` are not considered.\
+> To verify an element stays inside a mask, use `Is.FullyWithin(container)` with the mask's `RectTransform` as container, plus `Assume.That(container.GetComponent<RectMask2D>(), Is.Not.Null);`.\
+> To verify actual visibility/reachability, use `TestHelper.UI.GameObjectFinder` in the [test-helper.ui](https://github.com/nowsprinting/test-helper.ui) package with `reachable: true`.
+
+> [!NOTE]\
 > This constraint is intended for scenes and prefabs authored by coding agents.
 > Do not use it where the layout intentionally allows elements to overlap.
 
 #### TextOverflowing (optional)
 
-`TextOverflowingConstraint` tests that a uGUI `Text` or TextMeshPro `TMP_Text` component overflows its own `RectTransform` — its preferred size exceeds the rect, or characters are truncated.
+`TextOverflowingConstraint` tests that a uGUI `Text` or TextMeshPro `TMP_Text` component overflows its own `RectTransform` — its measured text size exceeds the rect, or characters are truncated.
 
 Usage:
 
@@ -603,6 +621,12 @@ public class MyTestClass
 Chain `.Within(float)` to widen the tolerance in pixels (default `0.5f`), e.g., `Is.Not.TextOverflowing.Within(1f)`.
 
 > [!IMPORTANT]\
+> This constraint compares only axis-aligned bounding boxes computed from the four world corners — geometry only (rotated elements are over-approximated).\
+> `RectMask2D` clipping, `Canvas.enabled`, `CanvasGroup.alpha`, and `activeInHierarchy` are not considered.\
+> To verify an element stays inside a mask, use `Is.FullyWithin(container)` with the mask's `RectTransform` as container, plus `Assume.That(container.GetComponent<RectMask2D>(), Is.Not.Null);`.\
+> To verify actual visibility/reachability, use `TestHelper.UI.GameObjectFinder` in the [test-helper.ui](https://github.com/nowsprinting/test-helper.ui) package with `reachable: true`.
+
+> [!NOTE]\
 > This constraint is intended for scenes and prefabs authored by coding agents.
 > Do not use it where the layout intentionally lets text overflow its container.
 

--- a/Runtime/Constraints/OverlappingConstraint.cs
+++ b/Runtime/Constraints/OverlappingConstraint.cs
@@ -60,8 +60,9 @@ namespace TestHelper.Constraints
         /// <exception cref="ArgumentNullException"><paramref name="actual"/>, or an element within it (or
         /// within an <see cref="Ignoring"/> group), is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="actual"/> is not a single resolvable element
-        /// or a collection of RectTransforms, or an element within it (or within an <see cref="Ignoring"/>
-        /// group) cannot be resolved to a <see cref="RectTransform"/>.</exception>
+        /// or a collection of RectTransforms, contains fewer than 2 elements, or an element within it (or
+        /// within an <see cref="Ignoring"/> group) cannot be resolved to a
+        /// <see cref="RectTransform"/>.</exception>
         public override ConstraintResult ApplyTo(object actual)
         {
             if (actual == null)
@@ -89,6 +90,16 @@ namespace TestHelper.Constraints
             }
 
             var elements = ResolveAll((IEnumerable)actual, "element");
+
+            // A 0/1-element collection has no pair to compare, so Is.Not.Overlapping would vacuously
+            // succeed — silently validating nothing when a dynamic query (e.g. GetComponentsInChildren)
+            // comes up empty. Rejected like the single-RectTransform case above instead.
+            if (elements.Count < 2)
+            {
+                throw new ArgumentException(
+                    $"collection has {elements.Count} element(s); Overlapping requires at least 2 to compare",
+                    nameof(actual));
+            }
 
             var ignoredSets = new List<HashSet<RectTransform>>();
             foreach (var rawGroup in _ignoredGroups)

--- a/Runtime/Constraints/TextOverflowDetection.cs
+++ b/Runtime/Constraints/TextOverflowDetection.cs
@@ -11,7 +11,7 @@ namespace TestHelper.Constraints
     /// </summary>
     internal class TextOverflowDetection
     {
-        internal Vector2 PreferredSize;
+        internal Vector2 MeasuredSize;
         internal Vector2 RectSize;
         internal bool WidthChecked;
         internal bool HeightChecked;

--- a/Runtime/Constraints/TextOverflowingConstraint.cs
+++ b/Runtime/Constraints/TextOverflowingConstraint.cs
@@ -100,7 +100,7 @@ namespace TestHelper.Constraints
             if (detection.SizeExceeded)
             {
                 clauses.Add(
-                    $"preferred size {ConstraintMessageFormatter.Format(detection.MeasuredSize)} exceeds rect {ConstraintMessageFormatter.Format(detection.RectSize)} by {ConstraintMessageFormatter.Format(detection.Excess)}");
+                    $"measured size {ConstraintMessageFormatter.Format(detection.MeasuredSize)} exceeds rect {ConstraintMessageFormatter.Format(detection.RectSize)} by {ConstraintMessageFormatter.Format(detection.Excess)}");
             }
 
             if (detection.CharactersTruncated)
@@ -122,7 +122,7 @@ namespace TestHelper.Constraints
             if (detection.WidthChecked || detection.HeightChecked)
             {
                 notes.Add(
-                    $"preferred size {ConstraintMessageFormatter.Format(detection.MeasuredSize)} within rect {ConstraintMessageFormatter.Format(detection.RectSize)}");
+                    $"measured size {ConstraintMessageFormatter.Format(detection.MeasuredSize)} within rect {ConstraintMessageFormatter.Format(detection.RectSize)}");
             }
 
             if (!string.IsNullOrEmpty(detection.SkipReason))

--- a/Runtime/Constraints/TextOverflowingConstraint.cs
+++ b/Runtime/Constraints/TextOverflowingConstraint.cs
@@ -82,10 +82,10 @@ namespace TestHelper.Constraints
             }
 
             var excessX = detection.WidthChecked
-                ? Mathf.Max(0f, detection.PreferredSize.x - detection.RectSize.x)
+                ? Mathf.Max(0f, detection.MeasuredSize.x - detection.RectSize.x)
                 : 0f;
             var excessY = detection.HeightChecked
-                ? Mathf.Max(0f, detection.PreferredSize.y - detection.RectSize.y)
+                ? Mathf.Max(0f, detection.MeasuredSize.y - detection.RectSize.y)
                 : 0f;
             var exceedsX = detection.WidthChecked && excessX > _tolerance;
             var exceedsY = detection.HeightChecked && excessY > _tolerance;
@@ -100,7 +100,7 @@ namespace TestHelper.Constraints
             if (detection.SizeExceeded)
             {
                 clauses.Add(
-                    $"preferred size {ConstraintMessageFormatter.Format(detection.PreferredSize)} exceeds rect {ConstraintMessageFormatter.Format(detection.RectSize)} by {ConstraintMessageFormatter.Format(detection.Excess)}");
+                    $"preferred size {ConstraintMessageFormatter.Format(detection.MeasuredSize)} exceeds rect {ConstraintMessageFormatter.Format(detection.RectSize)} by {ConstraintMessageFormatter.Format(detection.Excess)}");
             }
 
             if (detection.CharactersTruncated)
@@ -122,7 +122,7 @@ namespace TestHelper.Constraints
             if (detection.WidthChecked || detection.HeightChecked)
             {
                 notes.Add(
-                    $"preferred size {ConstraintMessageFormatter.Format(detection.PreferredSize)} within rect {ConstraintMessageFormatter.Format(detection.RectSize)}");
+                    $"preferred size {ConstraintMessageFormatter.Format(detection.MeasuredSize)} within rect {ConstraintMessageFormatter.Format(detection.RectSize)}");
             }
 
             if (!string.IsNullOrEmpty(detection.SkipReason))

--- a/Runtime/Constraints/TmpTextOverflowProbe.cs
+++ b/Runtime/Constraints/TmpTextOverflowProbe.cs
@@ -65,10 +65,12 @@ namespace TestHelper.Constraints
                 return true;
             }
 
-            // renderedWidth/renderedHeight reflect the actual post-wrap layout (unlike preferredWidth, which
-            // is always measured without wrapping), so both axes can be checked without reading the wrapping
-            // mode — which cannot be read across the supported Unity range without an obsolete API.
-            detection.MeasuredSize = new Vector2(text.renderedWidth, text.renderedHeight);
+            // GetRenderedValues() reflects the actual post-wrap layout (unlike preferredWidth, which is
+            // always measured without wrapping), so both axes can be checked without reading the wrapping
+            // mode — which cannot be read across the supported Unity range without an obsolete API. Called
+            // once instead of reading the renderedWidth/renderedHeight properties, each of which walks the
+            // whole textInfo.characterInfo separately.
+            detection.MeasuredSize = text.GetRenderedValues();
 
             // TMP_Text.margin shrinks the effective text area inside the rect; comparing against the raw
             // rect size would under-report overflow by the margin amount. Negative adjusted size (margins

--- a/Runtime/Constraints/TmpTextOverflowProbe.cs
+++ b/Runtime/Constraints/TmpTextOverflowProbe.cs
@@ -30,33 +30,56 @@ namespace TestHelper.Constraints
             }
 
             // Under TextOverflowModes.Overflow, firstOverflowCharacterIndex is still populated to indicate
-            // where text WOULD be cut, but no characters are actually hidden — only Truncate really drops
-            // them, so only Truncate is treated as an overflow signal here.
+            // where text WOULD be cut, but no characters are actually hidden — only Truncate and Ellipsis
+            // really drop them (Ellipsis replaces the tail with "…"), so only those two are treated as an
+            // overflow signal here. Masking is excluded: it is a deliberate presentation mode combined with
+            // RectMask2D; Page/Linked/ScrollRect deliberately show the continuation elsewhere.
             detection.CharactersTruncated =
-                text.overflowMode == TextOverflowModes.Truncate && text.firstOverflowCharacterIndex >= 0;
+                (text.overflowMode == TextOverflowModes.Truncate ||
+                 text.overflowMode == TextOverflowModes.Ellipsis)
+                && text.firstOverflowCharacterIndex >= 0;
             if (detection.CharactersTruncated)
             {
-                var total = text.textInfo != null ? text.textInfo.characterCount : text.text.Length;
                 detection.TruncationDetail =
-                    $"characters from index {text.firstOverflowCharacterIndex} of {total} are not rendered (overflowMode: {text.overflowMode})";
+                    $"characters from index {text.firstOverflowCharacterIndex} of {text.text.Length} are not rendered (overflowMode: {text.overflowMode})";
+            }
+
+            // The rendered values below come from textInfo, which is only populated by mesh generation.
+            // Checked AFTER the truncation check above, not before: Truncate/Ellipsis in a rect too small
+            // for even one line legitimately generates zero characters, which is a truncation result
+            // (firstOverflowCharacterIndex >= 0 only after generation; it stays -1 while never laid out),
+            // not an unlaid-out one. Known edge: text consisting solely of rich-text tags parses to zero
+            // characters and reports NotLaidOut; acceptable, as there is nothing renderable to check anyway.
+            if (!detection.CharactersTruncated
+                && (text.textInfo == null || text.textInfo.characterCount == 0))
+            {
+                detection.NotLaidOut = true;
+                return true;
             }
 
             if (text.enableAutoSizing)
             {
-                // Auto Sizing shrinks the font to the rect, so comparing preferred height against the rect
-                // would be meaningless.
+                // Auto Sizing shrinks the font to the rect, so the rendered size would trivially fit and
+                // comparing it would be meaningless.
                 detection.SkipReason = "auto size enabled";
                 return true;
             }
 
-            detection.MeasuredSize = new Vector2(text.preferredWidth, text.preferredHeight);
-            detection.RectSize = rectTransform.rect.size;
-            detection.HeightChecked = true;
+            // renderedWidth/renderedHeight reflect the actual post-wrap layout (unlike preferredWidth, which
+            // is always measured without wrapping), so both axes can be checked without reading the wrapping
+            // mode — which cannot be read across the supported Unity range without an obsolete API.
+            detection.MeasuredSize = new Vector2(text.renderedWidth, text.renderedHeight);
 
-            // TMP's preferred width is always measured without wrapping, and its wrapping mode cannot be
-            // read across the supported Unity range without an obsolete API, so the width is never checked.
-            detection.WidthChecked = false;
-            detection.SkipReason = "TMP preferred width is measured without wrapping";
+            // TMP_Text.margin shrinks the effective text area inside the rect; comparing against the raw
+            // rect size would under-report overflow by the margin amount. Negative adjusted size (margins
+            // larger than the rect) is left unclamped: the rendered size exceeds it, which correctly reads
+            // as overflow.
+            var margin = text.margin; // x=left, y=top, z=right, w=bottom
+            detection.RectSize = new Vector2(
+                rectTransform.rect.width - (margin.x + margin.z),
+                rectTransform.rect.height - (margin.y + margin.w));
+            detection.WidthChecked = true;
+            detection.HeightChecked = true;
 
             return true;
         }

--- a/Runtime/Constraints/TmpTextOverflowProbe.cs
+++ b/Runtime/Constraints/TmpTextOverflowProbe.cs
@@ -49,7 +49,7 @@ namespace TestHelper.Constraints
                 return true;
             }
 
-            detection.PreferredSize = new Vector2(text.preferredWidth, text.preferredHeight);
+            detection.MeasuredSize = new Vector2(text.preferredWidth, text.preferredHeight);
             detection.RectSize = rectTransform.rect.size;
             detection.HeightChecked = true;
 

--- a/Runtime/Constraints/TmpTextOverflowProbe.cs
+++ b/Runtime/Constraints/TmpTextOverflowProbe.cs
@@ -40,6 +40,11 @@ namespace TestHelper.Constraints
                 && text.firstOverflowCharacterIndex >= 0;
             if (detection.CharactersTruncated)
             {
+                // The total is text.Length even though it includes rich-text markup while the index is in
+                // parsed-character space: TMP offers no post-truncation source for the parsed total —
+                // textInfo.characterCount and GetParsedText() both reflect only the characters that
+                // survived truncation (measured: parsed total 47 → characterCount 17, truncated at
+                // index 15), which would be even more misleading as a total.
                 detection.TruncationDetail =
                     $"characters from index {text.firstOverflowCharacterIndex} of {text.text.Length} are not rendered (overflowMode: {text.overflowMode})";
             }

--- a/Runtime/Constraints/UguiTextOverflowProbe.cs
+++ b/Runtime/Constraints/UguiTextOverflowProbe.cs
@@ -57,7 +57,7 @@ namespace TestHelper.Constraints
                 return true;
             }
 
-            detection.PreferredSize = new Vector2(text.preferredWidth, text.preferredHeight);
+            detection.MeasuredSize = new Vector2(text.preferredWidth, text.preferredHeight);
             detection.RectSize = rectTransform.rect.size;
             detection.HeightChecked = true;
 

--- a/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
@@ -384,6 +384,24 @@ namespace TestHelper.Constraints
                 .And.Message.Contains("is a single RectTransform, not a collection"));
         }
 
+        [TestCase(0)]
+        [TestCase(1)]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsOverlapping_FewerThanTwoMembers_ThrowsArgumentException(int memberCount)
+        {
+            var canvas = CreateCanvas();
+            var actual = CreateElements(canvas.transform, memberCount);
+
+            Assert.That(() =>
+            {
+                Assert.That(actual, Is.Overlapping);
+            }, Throws.TypeOf<ArgumentException>()
+                .With.Property("ParamName").EqualTo("actual")
+                .And.Message.Contains($"collection has {memberCount} element")
+                .And.Message.Contains("at least 2"));
+        }
+
         [Test]
         [Category("Acceptance")]
         public void IsOverlapping_NonCollectionActual_ThrowsArgumentException()

--- a/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
@@ -244,12 +244,19 @@ namespace TestHelper.Constraints
         [TestCase(0)]
         [TestCase(1)]
         [CreateScene]
-        public void IsNotOverlapping_FewerThanTwoMembers_Success(int memberCount)
+        [Category("Acceptance")]
+        public void IsNotOverlapping_FewerThanTwoMembers_ThrowsArgumentException(int memberCount)
         {
             var canvas = CreateCanvas();
             var actual = CreateElements(canvas.transform, memberCount);
 
-            Assert.That(actual, Is.Not.Overlapping);
+            Assert.That(() =>
+            {
+                Assert.That(actual, Is.Not.Overlapping);
+            }, Throws.TypeOf<ArgumentException>()
+                .With.Property("ParamName").EqualTo("actual")
+                .And.Message.Contains(
+                    $"collection has {memberCount} element(s); Overlapping requires at least 2 to compare"));
         }
 
         [Test]

--- a/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
@@ -255,8 +255,8 @@ namespace TestHelper.Constraints
                 Assert.That(actual, Is.Not.Overlapping);
             }, Throws.TypeOf<ArgumentException>()
                 .With.Property("ParamName").EqualTo("actual")
-                .And.Message.Contains(
-                    $"collection has {memberCount} element(s); Overlapping requires at least 2 to compare"));
+                .And.Message.Contains($"collection has {memberCount} element")
+                .And.Message.Contains("at least 2"));
         }
 
         [Test]

--- a/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
@@ -28,7 +28,8 @@ namespace TestHelper.Constraints
 #if UNITY_2022_2_OR_NEWER
         private const string BuiltinFontName = "LegacyRuntime.ttf";
 #else
-        private const string BuiltinFontName = "Arial.ttf"; // Arial.ttf was replaced by LegacyRuntime.ttf in Unity 2022.2
+        private const string BuiltinFontName = "Arial.ttf";
+        // Arial.ttf was replaced by LegacyRuntime.ttf in Unity 2022.2
 #endif
 
         private static Canvas CreateCanvas()
@@ -559,13 +560,10 @@ namespace TestHelper.Constraints
             var tmpText = CreateTmpText(canvas.transform, "Label", "Measure me", new Vector2(1000f, 100f),
                 enableWordWrapping: false);
             Assume.That(tmpText.font, Is.Not.Null);
-            tmpText.margin = new Vector4(10f, 0f, 10f, 0f); // x=left, z=right
-            Canvas.ForceUpdateCanvases();
-            await UniTask.NextFrame();
-            // Shrink the rect so the rendered width still fits the rect but exceeds the rect minus the
-            // horizontal margins (renderedWidth <= rect width, renderedWidth > rect width - 20).
-            var renderedWidth = tmpText.renderedWidth;
-            tmpText.rectTransform.sizeDelta = new Vector2(renderedWidth + 10f, 100f);
+            // Any rendered text is wider than the 20px left between the margins yet narrower than the
+            // 1000px rect, so the rendered width fits the rect but exceeds the rect minus the margins —
+            // no font-dependent measure-then-resize choreography needed.
+            tmpText.margin = new Vector4(490f, 0f, 490f, 0f); // x=left, z=right
             Canvas.ForceUpdateCanvases();
             await UniTask.NextFrame();
 

--- a/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
@@ -261,6 +261,32 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_UguiBestFitEnabledAndTruncateDropsCharacters_Failure()
+        {
+            var canvas = CreateCanvas();
+            var uguiText = CreateUguiText(canvas.transform, "Label", "Very long overflowing label text",
+                new Vector2(5f, 5f), HorizontalWrapMode.Wrap, VerticalWrapMode.Truncate,
+                resizeTextForBestFit: true);
+            Assume.That(uguiText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await UniTask.NextFrame();
+            // Best fit cannot shrink below resizeTextMinSize, so a rect smaller than the minimum-size
+            // glyphs drops characters under Truncate. Guard the fixture: if a font's metrics keep every
+            // character visible, report Inconclusive instead of a false result.
+            Assume.That(uguiText.cachedTextGenerator.characterCountVisible,
+                Is.LessThan(uguiText.text.Length));
+
+            Assert.That(() =>
+            {
+                Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
+            }, Throws.TypeOf<AssertionException>()
+                .With.Message.Contains("\"Label\"")
+                .And.Message.Contains("are rendered"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
         public async Task IsTextOverflowing_UguiBestFitEnabled_Failure()
         {
             var canvas = CreateCanvas();
@@ -512,6 +538,34 @@ namespace TestHelper.Constraints
             await UniTask.NextFrame();
 
             Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_TmpAutoSizingEnabledAndTruncateDropsCharacters_Failure()
+        {
+            var canvas = CreateCanvas();
+            var tmpText = CreateTmpText(canvas.transform, "Label",
+                "This text will not fully fit and gets truncated", new Vector2(150f, 20f),
+                enableAutoSizing: true, overflowMode: TextOverflowModes.Truncate);
+            // Auto sizing cannot shrink below fontSizeMin; pin the bounds so the fixture drops
+            // characters regardless of the serialized TMP defaults.
+            tmpText.fontSizeMin = 10f;
+            tmpText.fontSizeMax = 40f;
+            Assume.That(tmpText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await UniTask.NextFrame();
+            // Guard the fixture: if a font's metrics let the text fit at the minimum size after all,
+            // report Inconclusive instead of a false result.
+            Assume.That(tmpText.firstOverflowCharacterIndex, Is.GreaterThanOrEqualTo(0));
+
+            Assert.That(() =>
+            {
+                Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
+            }, Throws.TypeOf<AssertionException>()
+                .With.Message.Contains("\"Label\"")
+                .And.Message.Contains("are not rendered (overflowMode: Truncate)"));
         }
 
         [Test]

--- a/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
@@ -480,8 +480,7 @@ namespace TestHelper.Constraints
 
         [Test]
         [CreateScene]
-        [Category("Acceptance")]
-        public async Task IsNotTextOverflowing_TmpPreferredHeightExceedsRectHeight_Failure()
+        public async Task IsNotTextOverflowing_TmpRenderedHeightExceedsRectHeight_Failure()
         {
             var canvas = CreateCanvas();
             var tmpText = CreateTmpText(canvas.transform, "Label",
@@ -501,8 +500,7 @@ namespace TestHelper.Constraints
 
         [Test]
         [CreateScene]
-        [Category("Acceptance")]
-        public async Task IsNotTextOverflowing_TmpAutoSizingEnabledAndPreferredHeightExceedsRectHeight_Success()
+        public async Task IsNotTextOverflowing_TmpAutoSizingEnabledAndTextExceedsRect_Success()
         {
             var canvas = CreateCanvas();
             var tmpText = CreateTmpText(canvas.transform, "Label",
@@ -518,27 +516,11 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        public async Task IsNotTextOverflowing_TmpPreferredWidthExceedsRectWidth_Success()
+        public async Task IsNotTextOverflowing_TmpRenderedWidthExceedsRectWidth_Failure()
         {
             var canvas = CreateCanvas();
             var tmpText = CreateTmpText(canvas.transform, "Label", "A very very very long single line of text",
                 new Vector2(5f, 100f), enableWordWrapping: false);
-            Assume.That(tmpText.font, Is.Not.Null);
-            Canvas.ForceUpdateCanvases();
-            await UniTask.NextFrame();
-
-            Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
-        }
-
-        [Test]
-        [CreateScene]
-        [Category("Acceptance")]
-        public async Task IsNotTextOverflowing_TmpCharactersNotRendered_Failure()
-        {
-            var canvas = CreateCanvas();
-            var tmpText = CreateTmpText(canvas.transform, "Label",
-                "This text will not fully fit and gets truncated", new Vector2(150f, 20f),
-                overflowMode: TextOverflowModes.Truncate);
             Assume.That(tmpText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
             await UniTask.NextFrame();
@@ -548,16 +530,19 @@ namespace TestHelper.Constraints
                 Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
             }, Throws.TypeOf<AssertionException>()
                 .With.Message.Contains("\"Label\"")
-                .And.Message.Contains("are not rendered (overflowMode: Truncate)"));
+                .And.Message.Contains("exceeds rect"));
         }
 
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        public async Task IsNotTextOverflowing_TmpEmptyText_Success()
+        public async Task IsNotTextOverflowing_TmpWrappedTextWithinRect_Success()
         {
             var canvas = CreateCanvas();
-            var tmpText = CreateTmpText(canvas.transform, "Label", string.Empty, new Vector2(5f, 5f));
+            // Every word is narrower than the 150px line box, so wrapping keeps the rendered width
+            // within the rect; the rect is tall enough for all wrapped lines.
+            var tmpText = CreateTmpText(canvas.transform, "Label",
+                "This is a long sentence that will wrap over lines", new Vector2(150f, 300f));
             Assume.That(tmpText.font, Is.Not.Null);
             Canvas.ForceUpdateCanvases();
             await UniTask.NextFrame();
@@ -568,16 +553,85 @@ namespace TestHelper.Constraints
         [Test]
         [CreateScene]
         [Category("Acceptance")]
-        public void IsNotTextOverflowing_TmpTextNotLaidOut_Success()
+        public async Task IsNotTextOverflowing_TmpRenderedWidthWithinRectButExceedsMargin_Failure()
+        {
+            var canvas = CreateCanvas();
+            var tmpText = CreateTmpText(canvas.transform, "Label", "Measure me", new Vector2(1000f, 100f),
+                enableWordWrapping: false);
+            Assume.That(tmpText.font, Is.Not.Null);
+            tmpText.margin = new Vector4(10f, 0f, 10f, 0f); // x=left, z=right
+            Canvas.ForceUpdateCanvases();
+            await UniTask.NextFrame();
+            // Shrink the rect so the rendered width still fits the rect but exceeds the rect minus the
+            // horizontal margins (renderedWidth <= rect width, renderedWidth > rect width - 20).
+            var renderedWidth = tmpText.renderedWidth;
+            tmpText.rectTransform.sizeDelta = new Vector2(renderedWidth + 10f, 100f);
+            Canvas.ForceUpdateCanvases();
+            await UniTask.NextFrame();
+
+            Assert.That(() =>
+            {
+                Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
+            }, Throws.TypeOf<AssertionException>()
+                .With.Message.Contains("\"Label\"")
+                .And.Message.Contains("exceeds rect"));
+        }
+
+        [TestCase(TextOverflowModes.Truncate)]
+        [TestCase(TextOverflowModes.Ellipsis)]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task IsNotTextOverflowing_TmpTruncatingOverflowMode_Failure(TextOverflowModes overflowMode)
+        {
+            var canvas = CreateCanvas();
+            var tmpText = CreateTmpText(canvas.transform, "Label",
+                "This text will not fully fit and gets truncated", new Vector2(150f, 20f),
+                overflowMode: overflowMode);
+            Assume.That(tmpText.font, Is.Not.Null);
+            Canvas.ForceUpdateCanvases();
+            await UniTask.NextFrame();
+
+            Assert.That(() =>
+            {
+                Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
+            }, Throws.TypeOf<AssertionException>()
+                .With.Message.Contains("\"Label\"")
+                .And.Message.Contains("characters from index")
+                .And.Message.Contains($"are not rendered (overflowMode: {overflowMode})"));
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotTextOverflowing_TmpEmptyTextNotLaidOut_Success()
+        {
+            var canvas = CreateCanvas();
+            var tmpText = CreateTmpText(canvas.transform, "Label", string.Empty, new Vector2(5f, 5f));
+            Assume.That(tmpText.font, Is.Not.Null);
+            // Note: intentionally skip Canvas.ForceUpdateCanvases()/frame wait — empty text has nothing to
+            // overflow, so it must pass without being reported as "not laid out".
+
+            Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
+        }
+
+        [Test]
+        [CreateScene]
+        [Category("Acceptance")]
+        public void IsNotTextOverflowing_TmpTextNotLaidOut_Failure()
         {
             var canvas = CreateCanvas();
             var tmpText = CreateTmpText(canvas.transform, "Label", "Some text", new Vector2(200f, 50f));
             Assume.That(tmpText.font, Is.Not.Null);
-            // Note: intentionally skip Canvas.ForceUpdateCanvases()/frame wait, unlike the uGUI equivalent
-            // test: TMP_Text.preferredWidth/preferredHeight compute the layout on demand rather than
-            // depending on a prior OnPopulateMesh pass, so there is no "not laid out" state to detect here.
+            // Note: intentionally skip Canvas.ForceUpdateCanvases()/frame wait so the text mesh is never
+            // generated: rendered sizes are only valid after a layout pass, so an un-laid-out element must
+            // be reported instead of silently passing.
 
-            Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
+            Assert.That(() =>
+            {
+                Assert.That(tmpText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
+            }, Throws.TypeOf<AssertionException>()
+                .With.Message.Contains("\"Label\"")
+                .And.Message.Contains("has not been laid out; call Canvas.ForceUpdateCanvases() before asserting"));
         }
 
         [Test]


### PR DESCRIPTION
## Summary
- `TmpTextOverflowProbe` now measures TMP text via `renderedWidth`/`renderedHeight` instead of `preferredWidth`, so single-line horizontal overflow (wrap off) is detected; also adds a NotLaidOut guard and accounts for `TMP_Text.margin`.
- `TextOverflowModes.Ellipsis` is now treated as truncation, matching `Truncate`.
- `OverlappingConstraint` throws `ArgumentException` when the collection has fewer than 2 elements (previously only a single non-collection actual was rejected), for both `Is.Overlapping` and `Is.Not.Overlapping`.
- README: documented that the rect-based constraints (WithinScreen, FullyWithin, Overlapping, TextOverflowing) compare geometry only and don't consider clipping/visibility, with each constraint's section carrying its own copy of the note.

## Test plan
- [x] `TextOverflowingConstraintTest` (PlayMode) passes, including new/updated TMP rendered-size, margin, NotLaidOut, and Ellipsis cases
- [x] `OverlappingConstraintTest` (PlayMode) passes, including new fewer-than-2-elements cases for both `Is.Overlapping` and `Is.Not.Overlapping`

🤖 Generated with [Claude Code](https://claude.com/claude-code)