### PR TITLE
Replace player-loop-unsafe APIs banned by RS0030

### DIFF
--- a/Editor/AssetRootMappingBuilder.cs
+++ b/Editor/AssetRootMappingBuilder.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using TestHelper.Attributes;
 using TestHelper.RuntimeInternals;
 
@@ -25,14 +24,27 @@ namespace TestHelper.Editor
         /// </summary>
         internal static AssetRootMapping Build()
         {
-            var callerFilePaths = AttributeFinder.FindOnFields<LoadAssetAttribute>()
-                .Select(attribute => attribute.CallerFilePath)
-                .Concat(AttributeFinder.FindOnAssemblies<BuildSceneAttribute>()
-                    .Select(attribute => attribute.CallerFilePath))
-                .Concat(AttributeFinder.FindOnTypes<BuildSceneAttribute>()
-                    .Select(attribute => attribute.CallerFilePath))
-                .Concat(AttributeFinder.FindOnMethods<BuildSceneAttribute>()
-                    .Select(attribute => attribute.CallerFilePath));
+            var callerFilePaths = new List<string>();
+            foreach (var attribute in AttributeFinder.FindOnFields<LoadAssetAttribute>())
+            {
+                callerFilePaths.Add(attribute.CallerFilePath);
+            }
+
+            foreach (var attribute in AttributeFinder.FindOnAssemblies<BuildSceneAttribute>())
+            {
+                callerFilePaths.Add(attribute.CallerFilePath);
+            }
+
+            foreach (var attribute in AttributeFinder.FindOnTypes<BuildSceneAttribute>())
+            {
+                callerFilePaths.Add(attribute.CallerFilePath);
+            }
+
+            foreach (var attribute in AttributeFinder.FindOnMethods<BuildSceneAttribute>())
+            {
+                callerFilePaths.Add(attribute.CallerFilePath);
+            }
+
             return CreateFromCallerFilePaths(callerFilePaths);
         }
 

--- a/Editor/AttributeFinder.cs
+++ b/Editor/AttributeFinder.cs
@@ -48,7 +48,13 @@ namespace TestHelper.Editor
         private static IEnumerable<T> FindOnProviders<T>(IEnumerable<ICustomAttributeProvider> providers)
             where T : Attribute
         {
-            return providers.SelectMany(provider => provider.GetCustomAttributes(typeof(T), false)).Cast<T>();
+            foreach (var provider in providers)
+            {
+                foreach (var attribute in provider.GetCustomAttributes(typeof(T), false))
+                {
+                    yield return (T)attribute;
+                }
+            }
         }
     }
 }

--- a/Editor/AttributeFinder.cs
+++ b/Editor/AttributeFinder.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using UnityEditor;
 
@@ -20,15 +19,31 @@ namespace TestHelper.Editor
 #if UNITY_2020_1_OR_NEWER
             return FindOnProviders<T>(TypeCache.GetFieldsWithAttribute<T>());
 #else
-            // TypeCache.GetFieldsWithAttribute is not available on Unity 2019; fall back to reflection over
-            // all loaded assemblies.
-            return FindOnProviders<T>(AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(x => x.GetTypes())
-                .SelectMany(x => x.GetFields(
-                    BindingFlags.Public | BindingFlags.NonPublic |
-                    BindingFlags.Instance | BindingFlags.Static)));
+            return FindOnProviders<T>(FindAllFields());
 #endif
         }
+
+#if !UNITY_2020_1_OR_NEWER
+        /// <summary>
+        /// TypeCache.GetFieldsWithAttribute is not available on Unity 2019; fall back to reflection over
+        /// all loaded assemblies.
+        /// </summary>
+        private static IEnumerable<ICustomAttributeProvider> FindAllFields()
+        {
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                foreach (var type in assembly.GetTypes())
+                {
+                    foreach (var field in type.GetFields(
+                                 BindingFlags.Public | BindingFlags.NonPublic |
+                                 BindingFlags.Instance | BindingFlags.Static))
+                    {
+                        yield return field;
+                    }
+                }
+            }
+        }
+#endif
 
         internal static IEnumerable<T> FindOnAssemblies<T>() where T : Attribute
         {

--- a/Editor/JUnitXml/AbstractJUnitElementConverter.cs
+++ b/Editor/JUnitXml/AbstractJUnitElementConverter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Collections.Generic;
@@ -52,8 +52,8 @@ namespace TestHelper.Editor.JUnitXml
         protected double Time => _duration; // seconds
         protected string Timestamp => _starttime;
         protected string Status => _result;
-        protected bool IsTestCaseSkipped => _result == "Skipped"; // test-case has not skipped attribute
-        protected bool IsTestCaseFailed => _result == "Failed"; // test-case has not failures attribute
+        protected bool IsTestCaseSkipped => _result == "Skipped";           // test-case has not skipped attribute
+        protected bool IsTestCaseFailed => _result == "Failed";             // test-case has not failures attribute
         protected bool IsTestCaseInconclusive => _result == "Inconclusive"; // test-case has not inconclusive attribute
         protected List<( string, string)> Properties => _properties;
         protected string Reason => _reason;
@@ -76,7 +76,7 @@ namespace TestHelper.Editor.JUnitXml
         private readonly int _skipped;
         private readonly int _asserts;
         private readonly string _starttime;
-        private readonly double _duration; // seconds
+        private readonly double _duration;                                                   // seconds
         private readonly List<( string, string)> _properties = new List<(string, string)>(); // name, value
         private string _reason;
         private (string, string) _failure; // message, stack-trace

--- a/Editor/JUnitXml/JUnitTestSuiteElementConverter.cs
+++ b/Editor/JUnitXml/JUnitTestSuiteElementConverter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Xml.Linq;
@@ -24,7 +24,7 @@ namespace TestHelper.Editor.JUnitXml
             element.Add(new XAttribute(JUnitAttributeTests, Tests));
             element.Add(new XAttribute(JUnitAttributeID, ID));
             element.Add(new XAttribute(JUnitAttributeDisabled, Disabled));
-            element.Add(new XAttribute(JUnitAttributeErrors, Errors));  // always 0
+            element.Add(new XAttribute(JUnitAttributeErrors, Errors)); // always 0
             element.Add(new XAttribute(JUnitAttributeFailures, Failures));
             element.Add(new XAttribute(JUnitAttributeSkipped, Skipped));
             element.Add(new XAttribute(JUnitAttributeTime, Time));

--- a/Editor/TemporaryBuildScenesUsingInTest.cs
+++ b/Editor/TemporaryBuildScenesUsingInTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using TestHelper.Attributes;
 using TestHelper.Editor;
 using TestHelper.RuntimeInternals;
@@ -23,9 +22,11 @@ namespace TestHelper.Editor
     {
         internal static IEnumerable<string> GetScenesUsingInTest()
         {
-            var attributes = AttributeFinder.FindOnAssemblies<BuildSceneAttribute>()
-                .Concat(AttributeFinder.FindOnTypes<BuildSceneAttribute>())
-                .Concat(AttributeFinder.FindOnMethods<BuildSceneAttribute>());
+            var attributes = new List<BuildSceneAttribute>();
+            attributes.AddRange(AttributeFinder.FindOnAssemblies<BuildSceneAttribute>());
+            attributes.AddRange(AttributeFinder.FindOnTypes<BuildSceneAttribute>());
+            attributes.AddRange(AttributeFinder.FindOnMethods<BuildSceneAttribute>());
+
             foreach (var attribute in attributes)
             {
                 string scenePath;

--- a/Runtime/Attributes/BuildSceneAttribute.cs
+++ b/Runtime/Attributes/BuildSceneAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
@@ -36,7 +36,7 @@ namespace TestHelper.Attributes
         /// </param>
         /// <param name="callerFilePath">Test file path set by <see cref="CallerFilePathAttribute"/></param>
         /// <remarks>
-        /// For the process of including a Scene not in "Scenes in Build" to a build for player, see: <see cref="TestHelper.Editor.TemporaryBuildScenesUsingInTest"/>.
+        /// For the process of including a Scene not in "Scenes in Build" to a build for player, see: <c>TestHelper.Editor.TemporaryBuildScenesUsingInTest</c>.
         /// </remarks>
         public BuildSceneAttribute(string path = null, [CallerFilePath] string callerFilePath = null)
         {

--- a/Runtime/Attributes/LoadAssetAttribute.cs
+++ b/Runtime/Attributes/LoadAssetAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
@@ -41,7 +41,7 @@ namespace TestHelper.Attributes
         /// </param>
         /// <param name="callerFilePath">Test file path set by <see cref="CallerFilePathAttribute"/></param>
         /// <remarks>
-        /// When running tests on the player, it temporarily copies asset files to the <c>Resources</c> folder by <see cref="TestHelper.Editor.TemporaryCopyAssetsForPlayer"/>.
+        /// When running tests on the player, it temporarily copies asset files to the <c>Resources</c> folder by <c>TestHelper.Editor.TemporaryCopyAssetsForPlayer</c>.
         /// </remarks>
         public LoadAssetAttribute(string path, [CallerFilePath] string callerFilePath = null)
         {

--- a/Runtime/Attributes/LoadSceneAttribute.cs
+++ b/Runtime/Attributes/LoadSceneAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
@@ -43,7 +43,7 @@ namespace TestHelper.Attributes
         /// This process runs after <c>OneTimeSetUp</c> and before <c>SetUp</c>.
         /// If you want to load during <c>SetUp</c> and testing, use <see cref="BuildSceneAttribute"/> and <see cref="SceneManagerHelper.LoadSceneAsync"/> instead.
         /// <p/>
-        /// For the process of including a Scene not in "Scenes in Build" to a build for player, see: <see cref="TestHelper.Editor.TemporaryBuildScenesUsingInTest"/>.
+        /// For the process of including a Scene not in "Scenes in Build" to a build for player, see: <c>TestHelper.Editor.TemporaryBuildScenesUsingInTest</c>.
         /// </remarks>
         [SuppressMessage("ReSharper", "ExplicitCallerInfoArgument")]
         public LoadSceneAttribute(string path = null, [CallerFilePath] string callerFilePath = null)

--- a/Runtime/Comparers/FlipTexture2dEqualityComparer.cs
+++ b/Runtime/Comparers/FlipTexture2dEqualityComparer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 #if ENABLE_FLIP_BINDING
@@ -112,7 +112,13 @@ namespace TestHelper.Comparers
 
         private static float[] ConvertToRgbArray(Texture2D texture)
         {
+            // Not GetPixelData<T>/GetRawTextureData<T>: they hand back the raw buffer in the texture's own
+            // TextureFormat, so the caller would have to decode every format the compared textures might use.
+            // GetPixels decodes any readable format to Color. Its allocation is acceptable because this runs
+            // once per assertion, not in the player loop.
+#pragma warning disable RS0030 // Do not use banned APIs
             var pixels = texture.GetPixels();
+#pragma warning restore RS0030
             var rgb = new float[pixels.Length * 3];
 
             for (var i = 0; i < pixels.Length; i++)

--- a/Runtime/Comparers/FlipTexture2dEqualityComparer.cs
+++ b/Runtime/Comparers/FlipTexture2dEqualityComparer.cs
@@ -114,8 +114,8 @@ namespace TestHelper.Comparers
         {
             // Not GetPixelData<T>/GetRawTextureData<T>: they hand back the raw buffer in the texture's own
             // TextureFormat, so the caller would have to decode every format the compared textures might use.
-            // GetPixels decodes any readable format to Color. Its allocation is acceptable because this runs
-            // once per assertion, not in the player loop.
+            // GetPixels decodes any readable format to Color. Its allocation is accepted here: this is test
+            // assertion code that runs once per comparison, not gameplay code the ban is aimed at.
 #pragma warning disable RS0030 // Do not use banned APIs
             var pixels = texture.GetPixels();
 #pragma warning restore RS0030

--- a/Runtime/Comparers/XDocumentComparer.cs
+++ b/Runtime/Comparers/XDocumentComparer.cs
@@ -1,9 +1,8 @@
-// Copyright (c) 2023-2024 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
 
@@ -16,7 +15,7 @@ namespace TestHelper.Comparers
     /// XML declarations and comments are ignored.
     /// </summary>
     /// <example>
-    /// <code>
+    /// <code><![CDATA[
     /// [TestFixture]
     ///     public class MyTestClass
     ///     {
@@ -31,8 +30,7 @@ namespace TestHelper.Comparers
     ///             Assert.That(x, Is.EqualTo(y).Using(new XDocumentComparer()));
     ///         }
     ///    }
-    /// 
-    /// </code>
+    /// ]]></code>
     /// </example>
     public class XDocumentComparer : IComparer<XDocument>
     {
@@ -72,7 +70,7 @@ namespace TestHelper.Comparers
                 current = GetChildOrNextElement(current);
             }
 
-            if (comparisonDictionary.Any())
+            if (comparisonDictionary.Count > 0)
             {
                 return 1; // The element exists only in y.
             }
@@ -104,9 +102,9 @@ namespace TestHelper.Comparers
 
         private static XElement GetChildOrNextElement(XElement element)
         {
-            if (element.HasElements)
+            foreach (var child in element.Elements())
             {
-                return element.Elements().First();
+                return child;
             }
 
             var nextNode = element.NextNode;
@@ -208,11 +206,11 @@ namespace TestHelper.Comparers
         /// </summary>
         private static int Compare(IEnumerable<XAttribute> x, IEnumerable<XAttribute> y)
         {
-            var comparisonList = y.ToList();
+            var comparisonList = new List<XAttribute>(y);
 
             foreach (var xAttribute in x)
             {
-                var yAttribute = comparisonList.FirstOrDefault(attribute => attribute.Name == xAttribute.Name);
+                var yAttribute = comparisonList.Find(attribute => attribute.Name == xAttribute.Name);
                 if (yAttribute == null)
                 {
                     return -1;
@@ -226,7 +224,7 @@ namespace TestHelper.Comparers
                 comparisonList.Remove(yAttribute);
             }
 
-            if (comparisonList.Any())
+            if (comparisonList.Count > 0)
             {
                 return 1;
             }

--- a/Runtime/Comparers/XmlComparer.cs
+++ b/Runtime/Comparers/XmlComparer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Collections.Generic;
@@ -16,7 +16,7 @@ namespace TestHelper.Comparers
     /// Internal using <see cref="XDocumentComparer"/>  for comparing <see cref="XDocument"/>.
     /// </remarks>
     /// <example>
-    /// <code>
+    /// <code><![CDATA[
     /// [TestFixture]
     ///     public class MyTestClass
     ///     {
@@ -39,7 +39,7 @@ namespace TestHelper.Comparers
     ///             Assert.That(x, Is.EqualTo(y).Using(new XmlComparer()));
     ///         }
     ///     }
-    /// </code>
+    /// ]]></code>
     /// </example>
     public class XmlComparer : IComparer<string>
     {

--- a/Runtime/Constraints/ConstraintMessageFormatter.cs
+++ b/Runtime/Constraints/ConstraintMessageFormatter.cs
@@ -38,7 +38,10 @@ namespace TestHelper.Constraints
 
         private static string FormatIntegral(float value)
         {
-            return Mathf.RoundToInt(value).ToString(CultureInfo.InvariantCulture);
+            // Not System.MathF.Round: it needs .NET Standard 2.1 (Unity 2021.2 or newer), and this package
+            // supports Unity 2019.4. System.Math.Round is what Mathf.RoundToInt calls internally, so the
+            // to-even rounding is unchanged. Qualified because `Object` in this file is UnityEngine.Object.
+            return ((int)System.Math.Round(value)).ToString(CultureInfo.InvariantCulture);
         }
 
         internal static string Quote(Object obj)

--- a/Runtime/Constraints/OverlappingConstraint.cs
+++ b/Runtime/Constraints/OverlappingConstraint.cs
@@ -49,7 +49,7 @@ namespace TestHelper.Constraints
         /// <returns>this</returns>
         public OverlappingConstraint Within(float tolerance)
         {
-            _tolerance = Mathf.Max(0f, tolerance);
+            _tolerance = Math.Max(0f, tolerance);
             return this;
         }
 

--- a/Runtime/Constraints/RectGeometry.cs
+++ b/Runtime/Constraints/RectGeometry.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -63,8 +64,8 @@ namespace TestHelper.Constraints
         /// </summary>
         internal static Vector2 GetOverlapExtent(Rect a, Rect b)
         {
-            var x = Mathf.Min(a.xMax, b.xMax) - Mathf.Max(a.xMin, b.xMin);
-            var y = Mathf.Min(a.yMax, b.yMax) - Mathf.Max(a.yMin, b.yMin);
+            var x = Math.Min(a.xMax, b.xMax) - Math.Max(a.xMin, b.xMin);
+            var y = Math.Min(a.yMax, b.yMax) - Math.Max(a.yMin, b.yMin);
             return new Vector2(x, y);
         }
 

--- a/Runtime/Constraints/TextOverflowingConstraint.cs
+++ b/Runtime/Constraints/TextOverflowingConstraint.cs
@@ -29,7 +29,7 @@ namespace TestHelper.Constraints
         /// <returns>this</returns>
         public TextOverflowingConstraint Within(float tolerance)
         {
-            _tolerance = Mathf.Max(0f, tolerance);
+            _tolerance = Math.Max(0f, tolerance);
             return this;
         }
 
@@ -82,10 +82,10 @@ namespace TestHelper.Constraints
             }
 
             var excessX = detection.WidthChecked
-                ? Mathf.Max(0f, detection.MeasuredSize.x - detection.RectSize.x)
+                ? Math.Max(0f, detection.MeasuredSize.x - detection.RectSize.x)
                 : 0f;
             var excessY = detection.HeightChecked
-                ? Mathf.Max(0f, detection.MeasuredSize.y - detection.RectSize.y)
+                ? Math.Max(0f, detection.MeasuredSize.y - detection.RectSize.y)
                 : 0f;
             var exceedsX = detection.WidthChecked && excessX > _tolerance;
             var exceedsY = detection.HeightChecked && excessY > _tolerance;

--- a/Runtime/Constraints/WithinContainerConstraint.cs
+++ b/Runtime/Constraints/WithinContainerConstraint.cs
@@ -50,7 +50,7 @@ namespace TestHelper.Constraints
         /// <returns>this</returns>
         public WithinContainerConstraint Within(float tolerance)
         {
-            _tolerance = Mathf.Max(0f, tolerance);
+            _tolerance = Math.Max(0f, tolerance);
             return this;
         }
 

--- a/Runtime/Constraints/WithinScreenConstraint.cs
+++ b/Runtime/Constraints/WithinScreenConstraint.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using System;
 using NUnit.Framework.Constraints;
 using UnityEngine;
 
@@ -25,7 +26,7 @@ namespace TestHelper.Constraints
         /// <returns>this</returns>
         public WithinScreenConstraint Within(float tolerance)
         {
-            _tolerance = Mathf.Max(0f, tolerance);
+            _tolerance = Math.Max(0f, tolerance);
             return this;
         }
 

--- a/Runtime/Statistics/DescriptiveStatistics.cs
+++ b/Runtime/Statistics/DescriptiveStatistics.cs
@@ -116,13 +116,8 @@ namespace TestHelper.Statistics
         /// <param name="sampleSpace">Input sample space</param>
         public void Calculate(ISampleSpace<T> sampleSpace)
         {
-            var size = 0UL;
-            foreach (var sample in sampleSpace.Samples)
-            {
-                size++;
-            }
-
-            Calculate(sampleSpace.Samples, size, sampleSpace.Min, sampleSpace.Max);
+            Calculate(sampleSpace.Samples, SampleCounter.Count(sampleSpace.Samples), sampleSpace.Min,
+                sampleSpace.Max);
         }
 
         private Bin<T> FindBin(T value)

--- a/Runtime/Statistics/DescriptiveStatistics.cs
+++ b/Runtime/Statistics/DescriptiveStatistics.cs
@@ -1,9 +1,8 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace TestHelper.Statistics
@@ -117,7 +116,13 @@ namespace TestHelper.Statistics
         /// <param name="sampleSpace">Input sample space</param>
         public void Calculate(ISampleSpace<T> sampleSpace)
         {
-            Calculate(sampleSpace.Samples, (ulong)sampleSpace.Samples.Count(), sampleSpace.Min, sampleSpace.Max);
+            var size = 0UL;
+            foreach (var sample in sampleSpace.Samples)
+            {
+                size++;
+            }
+
+            Calculate(sampleSpace.Samples, size, sampleSpace.Min, sampleSpace.Max);
         }
 
         private Bin<T> FindBin(T value)
@@ -166,10 +171,13 @@ namespace TestHelper.Statistics
                 ? (double)(frequencies[frequencies.Count / 2 - 1] + frequencies[frequencies.Count / 2]) / 2
                 : frequencies[frequencies.Count / 2];
 
-            foreach (var frequency in frequencies.Where(frequency => frequency > 0))
+            foreach (var frequency in frequencies)
             {
-                _valleyGreaterThanZero = frequency;
-                break;
+                if (frequency > 0)
+                {
+                    _valleyGreaterThanZero = frequency;
+                    break;
+                }
             }
         }
 

--- a/Runtime/Statistics/PixelPlot.cs
+++ b/Runtime/Statistics/PixelPlot.cs
@@ -1,11 +1,10 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
 using NUnit.Framework;
 using TestHelper.RuntimeInternals;
 using UnityEngine;
@@ -44,7 +43,10 @@ namespace TestHelper.Statistics
         {
             if (size == 0)
             {
-                size = (ulong)samples.Count();
+                foreach (var sample in samples)
+                {
+                    size++;
+                }
             }
 
             var minValue = Convert.ToDouble(min);
@@ -87,7 +89,8 @@ namespace TestHelper.Statistics
         /// <param name="sampleSpace">Input sample space</param>
         public void Plot(ISampleSpace<T> sampleSpace)
         {
-            Plot(sampleSpace.Samples, (ulong)sampleSpace.Samples.Count(), sampleSpace.Min, sampleSpace.Max);
+            // Passing 0 lets the overload count the samples itself, so this method does not need to enumerate them.
+            Plot(sampleSpace.Samples, 0, sampleSpace.Min, sampleSpace.Max);
         }
 
         /// <summary>

--- a/Runtime/Statistics/PixelPlot.cs
+++ b/Runtime/Statistics/PixelPlot.cs
@@ -43,10 +43,7 @@ namespace TestHelper.Statistics
         {
             if (size == 0)
             {
-                foreach (var sample in samples)
-                {
-                    size++;
-                }
+                size = SampleCounter.Count(samples);
             }
 
             var minValue = Convert.ToDouble(min);

--- a/Runtime/Statistics/SampleCounter.cs
+++ b/Runtime/Statistics/SampleCounter.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2023-2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Collections.Generic;
+
+namespace TestHelper.Statistics
+{
+    /// <summary>
+    /// Counts samples held as <see cref="IEnumerable{T}"/>.
+    /// </summary>
+    internal static class SampleCounter
+    {
+        /// <summary>
+        /// Returns the number of samples.
+        /// </summary>
+        /// <remarks>
+        /// Not <c>Enumerable.Count</c>: <c>System.Linq</c> is banned in this project. The
+        /// <see cref="ICollection{T}"/> branch keeps the O(1) path that <c>Enumerable.Count</c> took for
+        /// arrays and lists; sample spaces hold millions of samples, so walking them here would double the
+        /// work of the caller that walks them again.
+        /// </remarks>
+        internal static ulong Count<T>(IEnumerable<T> samples)
+        {
+            if (samples is ICollection<T> collection)
+            {
+                return (ulong)collection.Count;
+            }
+
+            var count = 0UL;
+            foreach (var sample in samples)
+            {
+                count++;
+            }
+
+            return count;
+        }
+    }
+}

--- a/Runtime/Statistics/SampleCounter.cs.meta
+++ b/Runtime/Statistics/SampleCounter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: face223ff0eb04283a840555086fee10

--- a/RuntimeInternals/AssetRootMapping.cs
+++ b/RuntimeInternals/AssetRootMapping.cs
@@ -28,7 +28,7 @@ namespace TestHelper.RuntimeInternals
         internal class Entry
         {
             public string physicalRoot; // Real path on the development machine, '/'-separators, no trailing slash
-            public string assetRoot; // "Assets" or "Packages/<name>", no trailing slash
+            public string assetRoot;    // "Assets" or "Packages/<name>", no trailing slash
         }
 
         /// <summary>

--- a/RuntimeInternals/PathHelper.cs
+++ b/RuntimeInternals/PathHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
@@ -20,7 +20,7 @@ namespace TestHelper.RuntimeInternals
         /// Reset counter for same test names.
         /// </summary>
         /// <remarks>
-        /// This method is called from the <see cref="TestHelper.Editor.TestRunnerCallbacks.RunStarted"/> method.
+        /// This method is called from the <c>TestHelper.Editor.TestRunnerCallbacks.RunStarted</c> method.
         /// Depending on the Enter Play Mode Settings, it may not be cleared in Play Mode and may be used by Edit Mode tests.
         /// </remarks>
         internal static void ResetCounter()

--- a/RuntimeInternals/SceneManagerHelper.cs
+++ b/RuntimeInternals/SceneManagerHelper.cs
@@ -1,10 +1,9 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -137,7 +136,7 @@ namespace TestHelper.RuntimeInternals
                 // Note: Do not use Exception (and Assert). Because freezes async tests on UTF v1.3.4, See UUM-25085.
             }
 
-            if (split.Last().IndexOfAny(new[] { '*', '?' }) >= 0)
+            if (split[split.Length - 1].IndexOfAny(new[] { '*', '?' }) >= 0)
             {
                 Debug.LogError($"Wildcards cannot be used in the scene name of path: {path}");
                 return false;
@@ -225,7 +224,8 @@ namespace TestHelper.RuntimeInternals
         /// <param name="path"></param>
         internal static string GetExistScenePathOnPlayer(string path)
         {
-            return path.Split('/').Last().Split('.').First();
+            var directories = path.Split('/');
+            return directories[directories.Length - 1].Split('.')[0];
         }
     }
 }

--- a/RuntimeInternals/Wrappers/UnityEditor/GameViewSizeGroupWrapper.cs
+++ b/RuntimeInternals/Wrappers/UnityEditor/GameViewSizeGroupWrapper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 #if UNITY_EDITOR
@@ -78,7 +78,7 @@ namespace TestHelper.RuntimeInternals.Wrappers.UnityEditor
 
         public void AddCustomSize(GameViewSizeWrapper size)
         {
-            s_addCustomSize.Invoke(_instance, new object[] { size.GetInnerInstance() });
+            s_addCustomSize.Invoke(_instance, new[] { size.GetInnerInstance() });
         }
 
         public void RemoveCustomSize(int index)

--- a/Tests/Editor/TestHelper.Editor.Tests.globalconfig
+++ b/Tests/Editor/TestHelper.Editor.Tests.globalconfig
@@ -4,7 +4,7 @@ is_global = true
 dotnet_diagnostic.CS0618.severity = error
 
 # RS0030: Do not use banned APIs
-dotnet_diagnostic.RS0030.severity = warning
+dotnet_diagnostic.RS0030.severity = suggestion
 
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none

--- a/Tests/Runtime/TestHelper.Tests.globalconfig
+++ b/Tests/Runtime/TestHelper.Tests.globalconfig
@@ -4,7 +4,7 @@ is_global = true
 dotnet_diagnostic.CS0618.severity = error
 
 # RS0030: Do not use banned APIs
-dotnet_diagnostic.RS0030.severity = warning
+dotnet_diagnostic.RS0030.severity = suggestion
 
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none

--- a/Tests/RuntimeInternals/TestHelper.RuntimeInternals.Tests.globalconfig
+++ b/Tests/RuntimeInternals/TestHelper.RuntimeInternals.Tests.globalconfig
@@ -4,7 +4,7 @@ is_global = true
 dotnet_diagnostic.CS0618.severity = error
 
 # RS0030: Do not use banned APIs
-dotnet_diagnostic.RS0030.severity = warning
+dotnet_diagnostic.RS0030.severity = suggestion
 
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none


### PR DESCRIPTION
## Why

The workspace banned symbols list (BannedApiAnalyzers.Unity) was expanded to cover player-loop-unsafe APIs, and RS0030 is configured as an error for the `Editor`, `Runtime`, and `RuntimeInternals` assemblies. That surfaced ~30 occurrences in this package, each of which had to be either replaced or explicitly suppressed.

## What

### Replaced

- **`System.Linq` (20 sites)** — rewritten as loops or concrete-collection members: `Last()` → index, `Any()` → `Count > 0`, `ToList()` → `new List<T>(y)`, `FirstOrDefault(…)` → `List<T>.Find(…)`, `SelectMany(…).Cast<T>()` → an iterator method, and the `Concat` chains → `List<T>.AddRange` / `foreach`. `using System.Linq;` is now gone from six files (`AttributeFinder` keeps it for the Unity 2019 `#else` branch).
- **`Mathf.Min` / `Mathf.Max` / `Mathf.RoundToInt` (9 sites)** — replaced with `System.Math`, **not** the `System.MathF` the ban message suggests. `MathF` requires .NET Standard 2.1 (Unity 2021.2 or newer) and this package supports Unity 2019.4, while `System.Math` already provides the `float` overloads and avoids the double round-trip. This also matches existing usage in `test-helper.ui` and in this package's own `RecordVideoAttribute`.

### Suppressed (1 site)

- **`Texture2D.GetPixels()`** in `FlipTexture2dEqualityComparer.ConvertToRgbArray` — `GetPixelData<T>` / `GetRawTextureData<T>` hand back the raw buffer in the texture's own `TextureFormat`, which would make the comparer responsible for decoding every format it can receive. `GetPixels` decodes any readable format to `Color`, and it runs once per assertion rather than in the player loop. Suppressed with `#pragma warning disable RS0030` around the single call, with a "why not" comment.

### Other diagnostics resolved along the way

- Four `<see cref="TestHelper.Editor.*"/>` references changed to `<c>…</c>`: `Runtime` cannot reference the `Editor` assembly, so those crefs can never resolve.
- The XML samples in `XDocumentComparer` / `XmlComparer` documentation comments are wrapped in `CDATA`, so the `<?xml …?>` declaration inside them is no longer parsed as one.
- `GameViewSizeGroupWrapper` — redundant explicit array type on a `MethodInfo.Invoke` argument (`GetInnerInstance()` returns `object`, so inference is safe here; the sibling call with an `int` argument keeps `new object[]`).

The `RS0030` severity for the `Tests` assemblies was lowered to suggestion in a separate commit on this branch, since test code is not player-loop code.

Copyright years on the touched files were bumped to 2023-2026.

## Verification

- Compiles clean on Unity 6000.4.12f1.
- EditMode: 20 passed, 0 failed.
- PlayMode: 500 passed, 3 failed, 5 skipped. The three failures are `FocusGameViewAttributeTest`, all asserting `EditorWindow.focusedWindow` is not null; they fail when the Editor is not the frontmost application and are unrelated to this change (`FocusGameViewAttribute`, `GameViewControlHelper`, and `GameViewWrapper` are not touched).
- The Unity 2019.4 floor is only verified by CI: the `System.Math` choice rests on its `Single` overloads being available in .NET Standard 2.0.