### PR TITLE
Resolve warnings surfaced by the stricter non-Tests globalconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -266,26 +266,11 @@ resharper_switch_statement_handles_some_known_enum_values_with_default_highlight
 # Must call where another overload of the same method accepts a CancellationToken if a suitable token is already available in the current scope
 resharper_method_supports_cancellation_highlighting = warning
 
-# Must use Array.Empty<T>() instead of a zero-length array creation expression, which allocates a new array on every evaluation
-resharper_use_array_empty_method_highlighting = warning
-
 # Must use the 'is' operator instead of Type.IsInstanceOfType, which performs the type check through reflection at run time
 resharper_can_simplify_is_instance_of_type_highlighting = warning
 
 # Must use the 'is' operator instead of Type.IsAssignableFrom against a known type, which performs the type check through reflection at run time
 resharper_can_simplify_is_assignable_from_highlighting = warning
-
-# Must use TryGetValue instead of checking ContainsKey and then reading through the indexer
-resharper_can_simplify_dictionary_lookup_with_try_get_value_highlighting = warning
-
-# Must use TryAdd instead of checking ContainsKey and then calling Add
-resharper_can_simplify_dictionary_lookup_with_try_add_highlighting = warning
-
-# Must call Remove directly and inspect its return value instead of checking ContainsKey first
-resharper_can_simplify_dictionary_removing_with_single_call_highlighting = warning
-
-# Must call Add directly and inspect its return value instead of checking Contains first
-resharper_can_simplify_set_adding_with_single_call_highlighting = warning
 
 # Must declare a non-mutating struct as readonly so that the compiler stops emitting defensive copies when its members are invoked through readonly references
 resharper_struct_can_be_made_read_only_highlighting = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -147,9 +147,6 @@ dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
 file_header_template = Copyright (c) 2023-${CurrentDate.Year} Koji Hasegawa.\nThis software is released under the MIT License.
 
-# RS0016: Only enable if API files are present
-dotnet_public_api_analyzer.require_api_files = true
-
 # IDE0055: Fix formatting
 # Workaround for https://github.com/dotnet/roslyn/issues/70570
 dotnet_diagnostic.IDE0055.severity = warning
@@ -180,6 +177,8 @@ csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
+
+# Attributes are not on the same line
 csharp_place_type_attribute_on_same_line = false
 csharp_place_method_attribute_on_same_line = false
 csharp_place_accessorholder_attribute_on_same_line = false
@@ -263,6 +262,33 @@ resharper_csharp_keep_existing_initializer_arrangement = true
 
 # Some values of the enum are not processed inside 'switch' statement and are handled via default section
 resharper_switch_statement_handles_some_known_enum_values_with_default_highlighting = warning
+
+# Must call where another overload of the same method accepts a CancellationToken if a suitable token is already available in the current scope
+resharper_method_supports_cancellation_highlighting = warning
+
+# Must use Array.Empty<T>() instead of a zero-length array creation expression, which allocates a new array on every evaluation
+resharper_use_array_empty_method_highlighting = warning
+
+# Must use the 'is' operator instead of Type.IsInstanceOfType, which performs the type check through reflection at run time
+resharper_can_simplify_is_instance_of_type_highlighting = warning
+
+# Must use the 'is' operator instead of Type.IsAssignableFrom against a known type, which performs the type check through reflection at run time
+resharper_can_simplify_is_assignable_from_highlighting = warning
+
+# Must use TryGetValue instead of checking ContainsKey and then reading through the indexer
+resharper_can_simplify_dictionary_lookup_with_try_get_value_highlighting = warning
+
+# Must use TryAdd instead of checking ContainsKey and then calling Add
+resharper_can_simplify_dictionary_lookup_with_try_add_highlighting = warning
+
+# Must call Remove directly and inspect its return value instead of checking ContainsKey first
+resharper_can_simplify_dictionary_removing_with_single_call_highlighting = warning
+
+# Must call Add directly and inspect its return value instead of checking Contains first
+resharper_can_simplify_set_adding_with_single_call_highlighting = warning
+
+# Must declare a non-mutating struct as readonly so that the compiler stops emitting defensive copies when its members are invoked through readonly references
+resharper_struct_can_be_made_read_only_highlighting = warning
 
 # Type and member is never used (for coding agents)
 resharper_unused_type_local_highlighting = warning

--- a/Editor/GameViewResolutionSwitcher.cs
+++ b/Editor/GameViewResolutionSwitcher.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
@@ -42,11 +42,11 @@ namespace TestHelper.Editor
                 var (w, h, name) = resolution.GetParameter();
                 if (w == width && h == height)
                 {
-                    return $"{name} ({width}x{height})";
+                    return $"{name} ({width.ToString()}x{height.ToString()})";
                 }
             }
 
-            return $"{width}x{height}";
+            return $"{width.ToString()}x{height.ToString()}";
         }
     }
 }

--- a/Editor/TestHelper.Editor.globalconfig
+++ b/Editor/TestHelper.Editor.globalconfig
@@ -12,6 +12,12 @@ dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
 dotnet_analyzer_diagnostic.category-Naming.severity = warning
 dotnet_analyzer_diagnostic.category-Performance.severity = warning
 
+# CA1016: Mark assemblies with assembly version; Not for Unity
+dotnet_diagnostic.CA1016.severity = none
+
+# CA1051: Do not declare visible instance fields; Not for Unity
+dotnet_diagnostic.CA1051.severity = none
+
 # RCS1174: Remove redundant async/await
 dotnet_diagnostic.RCS1174.severity = warning
 

--- a/Editor/TestHelper.Editor.globalconfig
+++ b/Editor/TestHelper.Editor.globalconfig
@@ -6,6 +6,35 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = error
 
+# Microsoft.CodeAnalysis.NetAnalyzers categories
+dotnet_analyzer_diagnostic.category-Design.severity = warning
+dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
+dotnet_analyzer_diagnostic.category-Naming.severity = warning
+dotnet_analyzer_diagnostic.category-Performance.severity = warning
+
+# RCS1174: Remove redundant async/await
+dotnet_diagnostic.RCS1174.severity = warning
+
+# RCS1198: Avoid unnecessary boxing of value type
+dotnet_diagnostic.RCS1198.severity = warning
+
+# UNT0009: Missing static constructor with InitializeOnLoad attribute
+dotnet_diagnostic.UNT0009.severity = warning
+
+# UNT0023: Coalescing assignment on Unity objects
+dotnet_diagnostic.UNT0023.severity = warning
+
+# UNT0030: Calling Destroy or DestroyImmediate on a Transform
+dotnet_diagnostic.UNT0030.severity = warning
+
+# IDISP017: Prefer using
+# The IDE's suggested fix is a `using var` declaration, which requires C# 8.0; this package
+# supports Unity 2019.4 (C# 7.3), so manual Dispose() calls stay as-is.
+dotnet_diagnostic.IDISP017.severity = none
+
+# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
+dotnet_diagnostic.VSTHRD003.severity = none
+
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none
 dotnet_diagnostic.CS8600.severity = none

--- a/Runtime/Attributes/GameViewResolutionAttribute.cs
+++ b/Runtime/Attributes/GameViewResolutionAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
@@ -41,11 +41,11 @@ namespace TestHelper.Attributes
                 var (w, h, name) = resolution.GetParameter();
                 if (w == width && h == height)
                 {
-                    return $"{name} ({width}x{height})";
+                    return $"{name} ({width.ToString()}x{height.ToString()})";
                 }
             }
 
-            return $"{width}x{height}";
+            return $"{width.ToString()}x{height.ToString()}";
         }
 
         /// <summary>

--- a/Runtime/Comparers/FlipTexture2dEqualityComparer.cs
+++ b/Runtime/Comparers/FlipTexture2dEqualityComparer.cs
@@ -106,7 +106,7 @@ namespace TestHelper.Comparers
             }
 
             Debug.Log($"Mean FLIP error value: {result.MeanError.ToString(CultureInfo.InvariantCulture)}\n" +
-                      $"Exceeds the specified tolerance {_meanErrorTolerance:0.######}");
+                      $"Exceeds the specified tolerance {_meanErrorTolerance.ToString("0.######", CultureInfo.InvariantCulture)}");
             SaveErrorMap(result);
             return -1;
         }

--- a/Runtime/Comparers/FlipTexture2dEqualityComparer.cs
+++ b/Runtime/Comparers/FlipTexture2dEqualityComparer.cs
@@ -3,6 +3,7 @@
 
 #if ENABLE_FLIP_BINDING
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using FlipBinding.CSharp;
 using TestHelper.RuntimeInternals;
@@ -78,8 +79,8 @@ namespace TestHelper.Comparers
             if (x!.width != y!.width || x.height != y.height)
             {
                 Debug.Log("Texture sizes are different.\n" +
-                          $"  Expected: {x.width}x{x.height}\n" +
-                          $"  But was:  {y.width}x{y.height}\n");
+                          $"  Expected: {x.width.ToString()}x{x.height.ToString()}\n" +
+                          $"  But was:  {y.width.ToString()}x{y.height.ToString()}\n");
                 return -1;
             }
 
@@ -104,7 +105,7 @@ namespace TestHelper.Comparers
                 return 0;
             }
 
-            Debug.Log($"Mean FLIP error value: {result.MeanError}\n" +
+            Debug.Log($"Mean FLIP error value: {result.MeanError.ToString(CultureInfo.InvariantCulture)}\n" +
                       $"Exceeds the specified tolerance {_meanErrorTolerance:0.######}");
             SaveErrorMap(result);
             return -1;

--- a/Runtime/Constraints/OverlappingConstraint.cs
+++ b/Runtime/Constraints/OverlappingConstraint.cs
@@ -97,7 +97,7 @@ namespace TestHelper.Constraints
             if (elements.Count < 2)
             {
                 throw new ArgumentException(
-                    $"collection has {elements.Count} element(s); Overlapping requires at least 2 to compare",
+                    $"collection has {elements.Count.ToString()} element(s); Overlapping requires at least 2 to compare",
                     nameof(actual));
             }
 
@@ -143,13 +143,13 @@ namespace TestHelper.Constraints
                     $" overlaps {ConstraintMessageFormatter.Quote(first.B)} {ConstraintMessageFormatter.Format(first.RectB)}";
                 if (overlappingPairs.Count > 1)
                 {
-                    pairMessage += $" (and {overlappingPairs.Count - 1} more overlapping pairs)";
+                    pairMessage += $" (and {(overlappingPairs.Count - 1).ToString()} more overlapping pairs)";
                 }
 
                 return new ReportingConstraintResult(this, new ConstraintReport(pairMessage), true);
             }
 
-            var noOverlapMessage = $"no overlapping pair among {elements.Count} RectTransforms";
+            var noOverlapMessage = $"no overlapping pair among {elements.Count.ToString()} RectTransforms";
             return new ReportingConstraintResult(this, new ConstraintReport(noOverlapMessage), false);
         }
 
@@ -168,7 +168,7 @@ namespace TestHelper.Constraints
             var index = 0;
             foreach (var item in source)
             {
-                resolved.Add(RectTransformResolver.ResolveOrThrow(item, $"{label} at index {index}"));
+                resolved.Add(RectTransformResolver.ResolveOrThrow(item, $"{label} at index {index.ToString()}"));
                 index++;
             }
 

--- a/Runtime/Constraints/TmpTextOverflowProbe.cs
+++ b/Runtime/Constraints/TmpTextOverflowProbe.cs
@@ -14,8 +14,7 @@ namespace TestHelper.Constraints
     {
         internal static bool TryDetect(RectTransform rectTransform, out TextOverflowDetection detection)
         {
-            var text = rectTransform.GetComponent<TMP_Text>();
-            if (text == null)
+            if (!rectTransform.TryGetComponent<TMP_Text>(out var text))
             {
                 detection = null;
                 return false;
@@ -46,7 +45,7 @@ namespace TestHelper.Constraints
                 // survived truncation (measured: parsed total 47 → characterCount 17, truncated at
                 // index 15), which would be even more misleading as a total.
                 detection.TruncationDetail =
-                    $"characters from index {text.firstOverflowCharacterIndex} of {text.text.Length} are not rendered (overflowMode: {text.overflowMode})";
+                    $"characters from index {text.firstOverflowCharacterIndex.ToString()} of {text.text.Length.ToString()} are not rendered (overflowMode: {text.overflowMode.ToString()})";
             }
 
             // The rendered values below come from textInfo, which is only populated by mesh generation.

--- a/Runtime/Constraints/UguiTextOverflowProbe.cs
+++ b/Runtime/Constraints/UguiTextOverflowProbe.cs
@@ -13,8 +13,7 @@ namespace TestHelper.Constraints
     {
         internal static bool TryDetect(RectTransform rectTransform, out TextOverflowDetection detection)
         {
-            var text = rectTransform.GetComponent<Text>();
-            if (text == null)
+            if (!rectTransform.TryGetComponent<Text>(out var text))
             {
                 detection = null;
                 return false;
@@ -46,7 +45,7 @@ namespace TestHelper.Constraints
             if (detection.CharactersTruncated)
             {
                 detection.TruncationDetail =
-                    $"only {generator.characterCountVisible} of {text.text.Length} characters are rendered";
+                    $"only {generator.characterCountVisible.ToString()} of {text.text.Length.ToString()} characters are rendered";
             }
 
             if (text.resizeTextForBestFit)

--- a/Runtime/Statistics/SampleCounter.cs
+++ b/Runtime/Statistics/SampleCounter.cs
@@ -27,7 +27,7 @@ namespace TestHelper.Statistics
             }
 
             var count = 0UL;
-            foreach (var sample in samples)
+            foreach (var _ in samples)
             {
                 count++;
             }

--- a/Runtime/TestHelper.globalconfig
+++ b/Runtime/TestHelper.globalconfig
@@ -12,6 +12,12 @@ dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
 dotnet_analyzer_diagnostic.category-Naming.severity = warning
 dotnet_analyzer_diagnostic.category-Performance.severity = warning
 
+# CA1016: Mark assemblies with assembly version; Not for Unity
+dotnet_diagnostic.CA1016.severity = none
+
+# CA1051: Do not declare visible instance fields; Not for Unity
+dotnet_diagnostic.CA1051.severity = none
+
 # RCS1174: Remove redundant async/await
 dotnet_diagnostic.RCS1174.severity = warning
 

--- a/Runtime/TestHelper.globalconfig
+++ b/Runtime/TestHelper.globalconfig
@@ -6,6 +6,35 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = error
 
+# Microsoft.CodeAnalysis.NetAnalyzers categories
+dotnet_analyzer_diagnostic.category-Design.severity = warning
+dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
+dotnet_analyzer_diagnostic.category-Naming.severity = warning
+dotnet_analyzer_diagnostic.category-Performance.severity = warning
+
+# RCS1174: Remove redundant async/await
+dotnet_diagnostic.RCS1174.severity = warning
+
+# RCS1198: Avoid unnecessary boxing of value type
+dotnet_diagnostic.RCS1198.severity = warning
+
+# UNT0009: Missing static constructor with InitializeOnLoad attribute
+dotnet_diagnostic.UNT0009.severity = warning
+
+# UNT0023: Coalescing assignment on Unity objects
+dotnet_diagnostic.UNT0023.severity = warning
+
+# UNT0030: Calling Destroy or DestroyImmediate on a Transform
+dotnet_diagnostic.UNT0030.severity = warning
+
+# IDISP017: Prefer using
+# The IDE's suggested fix is a `using var` declaration, which requires C# 8.0; this package
+# supports Unity 2019.4 (C# 7.3), so manual Dispose() calls stay as-is.
+dotnet_diagnostic.IDISP017.severity = none
+
+# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
+dotnet_diagnostic.VSTHRD003.severity = none
+
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none
 dotnet_diagnostic.CS8600.severity = none

--- a/RuntimeInternals/PathHelper.cs
+++ b/RuntimeInternals/PathHelper.cs
@@ -136,7 +136,7 @@ namespace TestHelper.RuntimeInternals
             if (s_counter.TryGetValue(name, out var count))
             {
                 s_counter[name] = ++count;
-                return $"{name.TrimEnd('_')}_{count}";
+                return $"{name.TrimEnd('_')}_{count.ToString()}";
             }
 
             s_counter[name] = 0;

--- a/RuntimeInternals/TestHelper.RuntimeInternals.globalconfig
+++ b/RuntimeInternals/TestHelper.RuntimeInternals.globalconfig
@@ -12,6 +12,12 @@ dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
 dotnet_analyzer_diagnostic.category-Naming.severity = warning
 dotnet_analyzer_diagnostic.category-Performance.severity = warning
 
+# CA1016: Mark assemblies with assembly version; Not for Unity
+dotnet_diagnostic.CA1016.severity = none
+
+# CA1051: Do not declare visible instance fields; Not for Unity
+dotnet_diagnostic.CA1051.severity = none
+
 # RCS1174: Remove redundant async/await
 dotnet_diagnostic.RCS1174.severity = warning
 

--- a/RuntimeInternals/TestHelper.RuntimeInternals.globalconfig
+++ b/RuntimeInternals/TestHelper.RuntimeInternals.globalconfig
@@ -6,6 +6,35 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = error
 
+# Microsoft.CodeAnalysis.NetAnalyzers categories
+dotnet_analyzer_diagnostic.category-Design.severity = warning
+dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
+dotnet_analyzer_diagnostic.category-Naming.severity = warning
+dotnet_analyzer_diagnostic.category-Performance.severity = warning
+
+# RCS1174: Remove redundant async/await
+dotnet_diagnostic.RCS1174.severity = warning
+
+# RCS1198: Avoid unnecessary boxing of value type
+dotnet_diagnostic.RCS1198.severity = warning
+
+# UNT0009: Missing static constructor with InitializeOnLoad attribute
+dotnet_diagnostic.UNT0009.severity = warning
+
+# UNT0023: Coalescing assignment on Unity objects
+dotnet_diagnostic.UNT0023.severity = warning
+
+# UNT0030: Calling Destroy or DestroyImmediate on a Transform
+dotnet_diagnostic.UNT0030.severity = warning
+
+# IDISP017: Prefer using
+# The IDE's suggested fix is a `using var` declaration, which requires C# 8.0; this package
+# supports Unity 2019.4 (C# 7.3), so manual Dispose() calls stay as-is.
+dotnet_diagnostic.IDISP017.severity = none
+
+# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
+dotnet_diagnostic.VSTHRD003.severity = none
+
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none
 dotnet_diagnostic.CS8600.severity = none

--- a/Tests/Editor/TestHelper.Editor.Tests.globalconfig
+++ b/Tests/Editor/TestHelper.Editor.Tests.globalconfig
@@ -6,6 +6,14 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = suggestion
 
+# IDISP017: Prefer using
+# The IDE's suggested fix is a `using var` declaration, which requires C# 8.0; this package
+# supports Unity 2019.4 (C# 7.3), so manual Dispose() calls stay as-is.
+dotnet_diagnostic.IDISP017.severity = none
+
+# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
+dotnet_diagnostic.VSTHRD003.severity = none
+
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none
 dotnet_diagnostic.CS8600.severity = none
@@ -61,8 +69,8 @@ dotnet_diagnostic.CS8824.severity = none
 dotnet_diagnostic.CS8825.severity = none
 dotnet_diagnostic.CS8847.severity = none
 
-# NUnit2045: Use Assert.Multiple
-dotnet_diagnostic.NUnit2045.severity = none
-
 # VSTHRD200: Use "Async" suffix for async methods
 dotnet_diagnostic.VSTHRD200.severity = none
+
+# NUnit2045: Use Assert.Multiple
+dotnet_diagnostic.NUnit2045.severity = none

--- a/Tests/Editor/Validators/SceneValidator.cs
+++ b/Tests/Editor/Validators/SceneValidator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Collections.Generic;
@@ -15,7 +15,7 @@ namespace TestHelper.Editor.Validators
     public class SceneValidator
     {
         private static IEnumerable<TestCaseData> Scenes => AssetDatabase
-            .FindAssets("t:SceneAsset", new string[] { "Packages/com.nowsprinting.test-helper" })
+            .FindAssets("t:SceneAsset", new[] { "Packages/com.nowsprinting.test-helper" })
             .Select(AssetDatabase.GUIDToAssetPath)
             .Select(path => new TestCaseData(path).SetName(Path.GetFileName(path)));
 

--- a/Tests/Runtime/Attributes/BuildSceneAttributeTest.cs
+++ b/Tests/Runtime/Attributes/BuildSceneAttributeTest.cs
@@ -1,14 +1,18 @@
-// Copyright (c) 2023-2024 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Threading.Tasks;
-using Cysharp.Threading.Tasks; // Required for Unity 2022 or older
+// ReSharper disable once RedundantUsingDirective -- required to enable async Task test support on Unity 2022 or older
+using Cysharp.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.RuntimeInternals;
 using UnityEngine;
 
 namespace TestHelper.Attributes
 {
+    /// <summary>
+    /// Tests running on the player, where the scene must be added to "Scenes in Build" first.
+    /// </summary>
     /// <seealso cref="LoadSceneAttributeTest"/>
     [TestFixture]
     [BuildScene(TestScene)]
@@ -27,7 +31,7 @@ namespace TestHelper.Attributes
             cube = GameObject.Find(ObjectName);
             Assume.That(cube, Is.Not.Null);
         }
-        
+
         private const string InferredObjectName = "CubeInInferredBuildSceneAttribute";
         private readonly string InferredScene = $"./{nameof(BuildSceneAttributeTest)}.unity";
 

--- a/Tests/Runtime/Attributes/BuildSceneAttributeTest.cs
+++ b/Tests/Runtime/Attributes/BuildSceneAttributeTest.cs
@@ -2,11 +2,14 @@
 // This software is released under the MIT License.
 
 using System.Threading.Tasks;
-// ReSharper disable once RedundantUsingDirective -- required to enable async Task test support on Unity 2022 or older
-using Cysharp.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.RuntimeInternals;
 using UnityEngine;
+#if !UNITY_2023_1_OR_NEWER
+// Unity 2023.1 or newer provides the awaiter for AsyncOperation;
+// on older versions it comes from UniTask.
+using Cysharp.Threading.Tasks;
+#endif
 
 namespace TestHelper.Attributes
 {

--- a/Tests/Runtime/Attributes/LoadAssetAttributeTest.cs
+++ b/Tests/Runtime/Attributes/LoadAssetAttributeTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Collections.Generic;
@@ -78,6 +78,7 @@ namespace TestHelper.Attributes
         [Category("Internal")]
         public void Constructor_WithCallerFilePath_RetainsCallerFilePath()
         {
+            // ReSharper disable once ExplicitCallerInfoArgument -- deliberately overriding the caller-supplied path under test
             var sut = new LoadAssetAttribute("Assets/Tests/Prefabs/Foo.prefab", "Assets/Tests/Runtime/Caller.cs");
 
             Assert.That(sut.CallerFilePath, Is.EqualTo("Assets/Tests/Runtime/Caller.cs"));

--- a/Tests/Runtime/Attributes/LoadSceneAttributeTest.cs
+++ b/Tests/Runtime/Attributes/LoadSceneAttributeTest.cs
@@ -66,7 +66,7 @@ namespace TestHelper.Attributes
 
             Object.Destroy(cube); // For not giving false negatives in subsequent tests.
         }
-        
+
         [Test]
         [LoadScene]
         public void UsingInferredPath_LoadedSceneNotInBuild()

--- a/Tests/Runtime/Constraints/DestroyedConstraintTest.cs
+++ b/Tests/Runtime/Constraints/DestroyedConstraintTest.cs
@@ -97,7 +97,9 @@ namespace TestHelper.Constraints
             {
                 // Not a swapped actual/expected: this constant IS the actual value under test, deliberately an
                 // unsupported type, to exercise the "not a UnityEngine.Object" failure path.
+#pragma warning disable NUnit2007
                 Assert.That("not a UnityEngine.Object", Is.Destroyed);
+#pragma warning restore NUnit2007
             }, Throws.TypeOf<ArgumentException>()
                 .With.Property("ParamName").EqualTo("actual")
                 .And.Message.Contains("is not a UnityEngine.Object"));
@@ -142,7 +144,9 @@ namespace TestHelper.Constraints
             {
                 // Not a swapped actual/expected: this constant IS the actual value under test, deliberately an
                 // unsupported type, to exercise the "not a UnityEngine.Object" failure path.
+#pragma warning disable NUnit2007
                 Assert.That("not a UnityEngine.Object", Is.Not.Destroyed);
+#pragma warning restore NUnit2007
             }, Throws.TypeOf<ArgumentException>()
                 .With.Property("ParamName").EqualTo("actual")
                 .And.Message.Contains("is not a UnityEngine.Object"));

--- a/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/OverlappingConstraintTest.cs
@@ -410,7 +410,9 @@ namespace TestHelper.Constraints
             {
                 // Not a swapped actual/expected: this constant IS the actual value under test, deliberately a
                 // non-collection, to exercise the "not a collection of RectTransforms" failure path.
+#pragma warning disable NUnit2007
                 Assert.That("not a collection", Is.Overlapping);
+#pragma warning restore NUnit2007
             }, Throws.TypeOf<ArgumentException>()
                 .With.Property("ParamName").EqualTo("actual")
                 .And.Message.Contains("is not a collection of RectTransforms"));

--- a/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
@@ -788,7 +788,9 @@ namespace TestHelper.Constraints
             {
                 // Not a swapped actual/expected: this constant IS the actual value under test, deliberately an
                 // unsupported type, to exercise the "not a RectTransform, GameObject, or Component" failure path.
+#pragma warning disable NUnit2007
                 Assert.That("not a RectTransform", Is.TextOverflowing);
+#pragma warning restore NUnit2007
             }, Throws.TypeOf<ArgumentException>()
                 .With.Property("ParamName").EqualTo("actual")
                 .And.Message.Contains("is not a RectTransform, GameObject, or Component"));

--- a/Tests/Runtime/Constraints/WithinScreenConstraintTest.cs
+++ b/Tests/Runtime/Constraints/WithinScreenConstraintTest.cs
@@ -91,6 +91,7 @@ namespace TestHelper.Constraints
                 case VisibilityFactor.InactiveInHierarchy:
                     element.gameObject.SetActive(false);
                     break;
+                // ReSharper disable once RedundantEmptySwitchSection -- kept so the switch stays exhaustive if VisibilityFactor grows
                 default:
                     break;
             }
@@ -316,7 +317,9 @@ namespace TestHelper.Constraints
             {
                 // Not a swapped actual/expected: this constant IS the actual value under test, deliberately an
                 // unsupported type, to exercise the "not a RectTransform, GameObject, or Component" failure path.
+#pragma warning disable NUnit2007
                 Assert.That("not a RectTransform", Is.WithinScreen);
+#pragma warning restore NUnit2007
             }, Throws.TypeOf<ArgumentException>()
                 .With.Property("ParamName").EqualTo("actual")
                 .And.Message.Contains("is not a RectTransform, GameObject, or Component"));

--- a/Tests/Runtime/Statistics/BinCountComparerTest.cs
+++ b/Tests/Runtime/Statistics/BinCountComparerTest.cs
@@ -18,11 +18,11 @@ namespace TestHelper.Statistics
         }
 
         [TestCase(-1, 10, 100u)] // different min
-        [TestCase(1, 10, 100u)] // different min
-        [TestCase(0, 9, 100u)] // different max
-        [TestCase(0, 11, 100u)] // different max
-        [TestCase(0, 10, 99u)] // different count
-        [TestCase(0, 10, 101u)] // different count
+        [TestCase(1, 10, 100u)]  // different min
+        [TestCase(0, 9, 100u)]   // different max
+        [TestCase(0, 11, 100u)]  // different max
+        [TestCase(0, 10, 99u)]   // different count
+        [TestCase(0, 10, 101u)]  // different count
         public void Compare_Failure(int min, int max, uint frequency)
         {
             var expected = new Bin<int>(0, 10) { Frequency = 100 };

--- a/Tests/Runtime/Statistics/DescriptiveStatisticsTest.cs
+++ b/Tests/Runtime/Statistics/DescriptiveStatisticsTest.cs
@@ -86,11 +86,11 @@ namespace TestHelper.Statistics
             {
                 Bins = new SortedList<int, Bin<int>>
                 {
-                    { 0, new Bin<int>(0) { Frequency = 4 } }, // Median
-                    { 1, new Bin<int>(1) { Frequency = 6 } }, //
-                    { 2, new Bin<int>(2) { Frequency = 2 } }, // 
+                    { 0, new Bin<int>(0) { Frequency = 4 } },  // Median
+                    { 1, new Bin<int>(1) { Frequency = 6 } },  //
+                    { 2, new Bin<int>(2) { Frequency = 2 } },  // 
                     { 3, new Bin<int>(3) { Frequency = 10 } }, // Peak
-                    { 4, new Bin<int>(4) { Frequency = 0 } }, // Valley
+                    { 4, new Bin<int>(4) { Frequency = 0 } },  // Valley
                 }
             };
             sut.CalculateInternal();
@@ -108,19 +108,19 @@ namespace TestHelper.Statistics
             {
                 Bins = new SortedList<int, Bin<int>>
                 {
-                    { 0, new Bin<int>(0) { Frequency = 4 } }, //
-                    { 1, new Bin<int>(1) { Frequency = 6 } }, //
-                    { 2, new Bin<int>(2) { Frequency = 2 } }, // 
+                    { 0, new Bin<int>(0) { Frequency = 4 } },  //
+                    { 1, new Bin<int>(1) { Frequency = 6 } },  //
+                    { 2, new Bin<int>(2) { Frequency = 2 } },  // 
                     { 3, new Bin<int>(3) { Frequency = 10 } }, // Peak
-                    { 4, new Bin<int>(4) { Frequency = 0 } }, // Valley
-                    { 5, new Bin<int>(5) { Frequency = 3 } }, // 
+                    { 4, new Bin<int>(4) { Frequency = 0 } },  // Valley
+                    { 5, new Bin<int>(5) { Frequency = 3 } },  // 
                 }
             };
             sut.CalculateInternal();
 
             Assert.That(sut.PeakFrequency, Is.EqualTo(10));
             Assert.That(sut.ValleyFrequency, Is.EqualTo(0));
-            Assert.That(sut.MedianFrequency, Is.EqualTo(3.5)); // (3 + 4) / 2
+            Assert.That(sut.MedianFrequency, Is.EqualTo(3.5));             // (3 + 4) / 2
             Assert.That(sut.MeanFrequency, Is.EqualTo(4.17).Within(0.01)); // 25 / 6
         }
 
@@ -172,8 +172,8 @@ namespace TestHelper.Statistics
                 Bins = new SortedList<int, Bin<int>>
                 {
                     { 0, new Bin<int>(0) { Frequency = 1000 } }, // full block
-                    { 1, new Bin<int>(1) { Frequency = 0 } }, // space
-                    { 2, new Bin<int>(2) { Frequency = 1 } }, // lower 1:8 block
+                    { 1, new Bin<int>(1) { Frequency = 0 } },    // space
+                    { 2, new Bin<int>(2) { Frequency = 1 } },    // lower 1:8 block
                 }
             };
             sut.CalculateInternal();

--- a/Tests/Runtime/Statistics/ExperimentTest.cs
+++ b/Tests/Runtime/Statistics/ExperimentTest.cs
@@ -28,7 +28,7 @@ namespace TestHelper.Statistics
         {
             var actual = Experiment.Run(
                 () => DiceGenerator.Roll(2, 6), // 2D6
-                1 << 20); // 1,048,576 times
+                1 << 20);                       // 1,048,576 times
 
             Assert.That(actual.Min, Is.EqualTo(2));
             Assert.That(actual.Max, Is.EqualTo(12));
@@ -39,7 +39,7 @@ namespace TestHelper.Statistics
         {
             var sampleSpace = Experiment.Run(
                 () => Random.value, // 0.0f to 1.0f
-                1 << 20); // 1,048,576 times
+                1 << 20);           // 1,048,576 times
 
             var range = sampleSpace.Max - sampleSpace.Min;
             Assert.That(range, Is.EqualTo(1.0f).Within(0.01f));

--- a/Tests/Runtime/TestHelper.Tests.globalconfig
+++ b/Tests/Runtime/TestHelper.Tests.globalconfig
@@ -6,6 +6,14 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = suggestion
 
+# IDISP017: Prefer using
+# The IDE's suggested fix is a `using var` declaration, which requires C# 8.0; this package
+# supports Unity 2019.4 (C# 7.3), so manual Dispose() calls stay as-is.
+dotnet_diagnostic.IDISP017.severity = none
+
+# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
+dotnet_diagnostic.VSTHRD003.severity = none
+
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none
 dotnet_diagnostic.CS8600.severity = none
@@ -61,8 +69,8 @@ dotnet_diagnostic.CS8824.severity = none
 dotnet_diagnostic.CS8825.severity = none
 dotnet_diagnostic.CS8847.severity = none
 
-# NUnit2045: Use Assert.Multiple
-dotnet_diagnostic.NUnit2045.severity = none
-
 # VSTHRD200: Use "Async" suffix for async methods
 dotnet_diagnostic.VSTHRD200.severity = none
+
+# NUnit2045: Use Assert.Multiple
+dotnet_diagnostic.NUnit2045.severity = none

--- a/Tests/RuntimeInternals/AssetPathHelperTest.cs
+++ b/Tests/RuntimeInternals/AssetPathHelperTest.cs
@@ -142,8 +142,7 @@ namespace TestHelper.RuntimeInternals
         }
 
         [Test]
-        public void
-            GetAssetPath_RelativePathContainsPackagesSubstringNotAtSegmentBoundary_OutputLogErrorAndReturnsNull()
+        public void GetAssetPath_PackagesSubstringNotAtSegmentBoundary_OutputLogErrorAndReturnsNull()
         {
             // "SceneInLocalPackages.unity" contains "Packages" as a substring (inside "LocalPackages"), not as
             // a path segment; the naive fallback must not mistake it for the Packages folder segment.

--- a/Tests/RuntimeInternals/AssetPathHelperTest.cs
+++ b/Tests/RuntimeInternals/AssetPathHelperTest.cs
@@ -142,7 +142,8 @@ namespace TestHelper.RuntimeInternals
         }
 
         [Test]
-        public void GetAssetPath_RelativePathContainsPackagesSubstringNotAtSegmentBoundary_OutputLogErrorAndReturnsNull()
+        public void
+            GetAssetPath_RelativePathContainsPackagesSubstringNotAtSegmentBoundary_OutputLogErrorAndReturnsNull()
         {
             // "SceneInLocalPackages.unity" contains "Packages" as a substring (inside "LocalPackages"), not as
             // a path segment; the naive fallback must not mistake it for the Packages folder segment.

--- a/Tests/RuntimeInternals/AssetRootMappingTest.cs
+++ b/Tests/RuntimeInternals/AssetRootMappingTest.cs
@@ -84,7 +84,7 @@ namespace TestHelper.RuntimeInternals
             Assert.That(actual, Is.EqualTo("Packages/com.example.fakepackage/Tests/Foo.txt"));
         }
 
-        [TestCase("/dev/packages/com.example.fake")] // path equals physicalRoot
+        [TestCase("/dev/packages/com.example.fake")]              // path equals physicalRoot
         [TestCase("/dev/packages/com.example.fakeextra/Foo.txt")] // continues physicalRoot without a separator
         public void Resolve_PathNotAtSegmentBoundary_ReturnsNull(string absolutePath)
         {
@@ -127,8 +127,10 @@ namespace TestHelper.RuntimeInternals
         [Test]
         public void Resolve_NullEntries_ReturnsNull()
         {
-            var sut = new AssetRootMapping();
-            sut.entries = null;
+            var sut = new AssetRootMapping
+            {
+                entries = null
+            };
 
             var actual = sut.Resolve("/dev/packages/com.example.fake/Tests/Foo.txt");
 

--- a/Tests/RuntimeInternals/SceneManagerHelperTest.cs
+++ b/Tests/RuntimeInternals/SceneManagerHelperTest.cs
@@ -4,7 +4,8 @@
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Cysharp.Threading.Tasks; // Required for Unity 2022 or older
+// ReSharper disable once RedundantUsingDirective -- required to enable async Task test support on Unity 2022 or older
+using Cysharp.Threading.Tasks;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -87,7 +88,7 @@ namespace TestHelper.RuntimeInternals
         }
 
         [TestCase("Packages/com.nowsprinting.test-helper/Tests/Scenes/NotExistScene.unity")] // Not exist path
-        [TestCase("Packages/com.nowsprinting.test-helper/*/NotInScenesInBuild.unity")] // Not match path pattern
+        [TestCase("Packages/com.nowsprinting.test-helper/*/NotInScenesInBuild.unity")]       // Not match path pattern
         [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
         // Note: Returns scene name when running on player.
         public void GetExistScenePath_NotExistPath_InEditor_OutputLogError(string path)

--- a/Tests/RuntimeInternals/SceneManagerHelperTest.cs
+++ b/Tests/RuntimeInternals/SceneManagerHelperTest.cs
@@ -4,11 +4,14 @@
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-// ReSharper disable once RedundantUsingDirective -- required to enable async Task test support on Unity 2022 or older
-using Cysharp.Threading.Tasks;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
+#if !UNITY_2023_1_OR_NEWER
+// Unity 2023.1 or newer provides the awaiter for AsyncOperation;
+// on older versions it comes from UniTask.
+using Cysharp.Threading.Tasks;
+#endif
 
 namespace TestHelper.RuntimeInternals
 {

--- a/Tests/RuntimeInternals/TestHelper.RuntimeInternals.Tests.globalconfig
+++ b/Tests/RuntimeInternals/TestHelper.RuntimeInternals.Tests.globalconfig
@@ -6,6 +6,14 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = suggestion
 
+# IDISP017: Prefer using
+# The IDE's suggested fix is a `using var` declaration, which requires C# 8.0; this package
+# supports Unity 2019.4 (C# 7.3), so manual Dispose() calls stay as-is.
+dotnet_diagnostic.IDISP017.severity = none
+
+# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
+dotnet_diagnostic.VSTHRD003.severity = none
+
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none
 dotnet_diagnostic.CS8600.severity = none
@@ -61,8 +69,8 @@ dotnet_diagnostic.CS8824.severity = none
 dotnet_diagnostic.CS8825.severity = none
 dotnet_diagnostic.CS8847.severity = none
 
-# NUnit2045: Use Assert.Multiple
-dotnet_diagnostic.NUnit2045.severity = none
-
 # VSTHRD200: Use "Async" suffix for async methods
 dotnet_diagnostic.VSTHRD200.severity = none
+
+# NUnit2045: Use Assert.Multiple
+dotnet_diagnostic.NUnit2045.severity = none


### PR DESCRIPTION
## Summary
- Sync the non-Tests/Tests .globalconfig files with test-helper.ui analyzer categories, RCS/UNT rules, and severities
- Fix the boxing, GetComponent-allocation, and style warnings the stricter settings surfaced, following the same patterns already used in test-helper.ui (explicit ToString() on interpolated value types, TryGetComponent over GetComponent plus null-check)
- Suppress the handful that do not fit the code intent: a deliberate caller-info override in a test, a UniTask import kept only to enable async Task test support on old Unity, and NUnit2007 (ConstActualValueUsageAnalyzer) on assertions where the constant actual value is intentional

## Test plan
- [x] get_unity_compilation_result: compiles cleanly
- [x] EditMode TestHelper.Editor.Tests: 20/20 passed
- [x] PlayMode TestHelper.RuntimeInternals.Tests: 126/126 passed
- [x] PlayMode TestHelper.Tests (full): 374/377 passed (3 pre-existing FocusGameViewAttributeTest failures, unrelated to this change, reproduced on 2 consecutive runs, looks like a GameView-focus environment flake)
- [x] PlayMode TestHelper.Tests (TestHelper.Constraints group, re-run after later edits): 178/178 passed