### PR TITLE
Enumerate Design/Maintainability/Naming rules individually in globalconfig

### DIFF
--- a/Editor/TestHelper.Editor.globalconfig
+++ b/Editor/TestHelper.Editor.globalconfig
@@ -6,17 +6,81 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = error
 
-# Microsoft.CodeAnalysis.NetAnalyzers categories
-dotnet_analyzer_diagnostic.category-Design.severity = warning
-dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
-dotnet_analyzer_diagnostic.category-Naming.severity = warning
+# CA1018: Mark attributes with AttributeUsageAttribute
+dotnet_diagnostic.CA1018.severity = warning
+
+# CA1041: Provide ObsoleteAttribute message
+dotnet_diagnostic.CA1041.severity = warning
+
+# CA1050: Declare types in namespaces
+dotnet_diagnostic.CA1050.severity = warning
+
+# CA1061: Do not hide base class methods
+dotnet_diagnostic.CA1061.severity = warning
+
+# CA1067: Override Object.Equals(object) when implementing IEquatable<T>
+dotnet_diagnostic.CA1067.severity = warning
+
+# CA1068: CancellationToken parameters must come last
+dotnet_diagnostic.CA1068.severity = warning
+
+# CA1069: Enums values should not be duplicated
+dotnet_diagnostic.CA1069.severity = warning
+
+# CA1070: Do not declare event fields as virtual
+dotnet_diagnostic.CA1070.severity = warning
+
+# CA1507: Use nameof to express symbol names
+dotnet_diagnostic.CA1507.severity = warning
+
+# CA1510: Use ArgumentNullException throw helper
+dotnet_diagnostic.CA1510.severity = warning
+
+# CA1511: Use ArgumentException throw helper
+dotnet_diagnostic.CA1511.severity = warning
+
+# CA1512: Use ArgumentOutOfRangeException throw helper
+dotnet_diagnostic.CA1512.severity = warning
+
+# CA1513: Use ObjectDisposedException throw helper
+dotnet_diagnostic.CA1513.severity = warning
+
+# CA1514: Avoid redundant length argument
+dotnet_diagnostic.CA1514.severity = warning
+
+# CA1710: Identifiers should have correct suffix
+dotnet_diagnostic.CA1710.severity = warning
+
+# CA1711: Identifiers should not have incorrect suffix
+dotnet_diagnostic.CA1711.severity = warning
+
+# CA1712: Do not prefix enum values with type name
+dotnet_diagnostic.CA1712.severity = warning
+
+# CA1714: Flags enums should have plural names
+dotnet_diagnostic.CA1714.severity = warning
+
+# CA1715: Identifiers should have correct prefix
+dotnet_diagnostic.CA1715.severity = warning
+
+# CA1716: Identifiers should not match keywords
+dotnet_diagnostic.CA1716.severity = warning
+
+# CA1717: Only FlagsAttribute enums should have plural names
+dotnet_diagnostic.CA1717.severity = warning
+
+# CA1720: Identifier contains type name
+dotnet_diagnostic.CA1720.severity = warning
+
+# CA1725: Parameter names should match base declaration
+dotnet_diagnostic.CA1725.severity = warning
+
+# CA1727: Use PascalCase for named placeholders
+dotnet_diagnostic.CA1727.severity = warning
+
+# The "Performance" category is used because it encompasses many rules
+# (specifically, the CA18xx rules from Microsoft.CodeAnalysis.NetAnalyzers).
 dotnet_analyzer_diagnostic.category-Performance.severity = warning
-
-# CA1016: Mark assemblies with assembly version; Not for Unity
-dotnet_diagnostic.CA1016.severity = none
-
-# CA1051: Do not declare visible instance fields; Not for Unity
-dotnet_diagnostic.CA1051.severity = none
 
 # RCS1174: Remove redundant async/await
 dotnet_diagnostic.RCS1174.severity = warning

--- a/Runtime/Constraints/Is.cs
+++ b/Runtime/Constraints/Is.cs
@@ -2,12 +2,15 @@
 // This software is released under the MIT License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using UnityEngine;
 
 namespace TestHelper.Constraints
 {
     /// <inheritdoc />
-    // ReSharper disable once ClassNeverInstantiated.Global
+    // Not renamed: this class extends NUnit's own Is and must keep its name to read as Is.Destroyed,
+    // Is.WithinScreen, etc., matching the NUnit constraint idiom (Is.EqualTo, Is.Not, ...).
+    [SuppressMessage("Naming", "CA1716:Identifiers should not match keywords")]
     public class Is : UnityEngine.TestTools.Constraints.Is
     {
         /// <summary>

--- a/Runtime/TestHelper.globalconfig
+++ b/Runtime/TestHelper.globalconfig
@@ -6,17 +6,81 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = error
 
-# Microsoft.CodeAnalysis.NetAnalyzers categories
-dotnet_analyzer_diagnostic.category-Design.severity = warning
-dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
-dotnet_analyzer_diagnostic.category-Naming.severity = warning
+# CA1018: Mark attributes with AttributeUsageAttribute
+dotnet_diagnostic.CA1018.severity = warning
+
+# CA1041: Provide ObsoleteAttribute message
+dotnet_diagnostic.CA1041.severity = warning
+
+# CA1050: Declare types in namespaces
+dotnet_diagnostic.CA1050.severity = warning
+
+# CA1061: Do not hide base class methods
+dotnet_diagnostic.CA1061.severity = warning
+
+# CA1067: Override Object.Equals(object) when implementing IEquatable<T>
+dotnet_diagnostic.CA1067.severity = warning
+
+# CA1068: CancellationToken parameters must come last
+dotnet_diagnostic.CA1068.severity = warning
+
+# CA1069: Enums values should not be duplicated
+dotnet_diagnostic.CA1069.severity = warning
+
+# CA1070: Do not declare event fields as virtual
+dotnet_diagnostic.CA1070.severity = warning
+
+# CA1507: Use nameof to express symbol names
+dotnet_diagnostic.CA1507.severity = warning
+
+# CA1510: Use ArgumentNullException throw helper
+dotnet_diagnostic.CA1510.severity = warning
+
+# CA1511: Use ArgumentException throw helper
+dotnet_diagnostic.CA1511.severity = warning
+
+# CA1512: Use ArgumentOutOfRangeException throw helper
+dotnet_diagnostic.CA1512.severity = warning
+
+# CA1513: Use ObjectDisposedException throw helper
+dotnet_diagnostic.CA1513.severity = warning
+
+# CA1514: Avoid redundant length argument
+dotnet_diagnostic.CA1514.severity = warning
+
+# CA1710: Identifiers should have correct suffix
+dotnet_diagnostic.CA1710.severity = warning
+
+# CA1711: Identifiers should not have incorrect suffix
+dotnet_diagnostic.CA1711.severity = warning
+
+# CA1712: Do not prefix enum values with type name
+dotnet_diagnostic.CA1712.severity = warning
+
+# CA1714: Flags enums should have plural names
+dotnet_diagnostic.CA1714.severity = warning
+
+# CA1715: Identifiers should have correct prefix
+dotnet_diagnostic.CA1715.severity = warning
+
+# CA1716: Identifiers should not match keywords
+dotnet_diagnostic.CA1716.severity = warning
+
+# CA1717: Only FlagsAttribute enums should have plural names
+dotnet_diagnostic.CA1717.severity = warning
+
+# CA1720: Identifier contains type name
+dotnet_diagnostic.CA1720.severity = warning
+
+# CA1725: Parameter names should match base declaration
+dotnet_diagnostic.CA1725.severity = warning
+
+# CA1727: Use PascalCase for named placeholders
+dotnet_diagnostic.CA1727.severity = warning
+
+# The "Performance" category is used because it encompasses many rules
+# (specifically, the CA18xx rules from Microsoft.CodeAnalysis.NetAnalyzers).
 dotnet_analyzer_diagnostic.category-Performance.severity = warning
-
-# CA1016: Mark assemblies with assembly version; Not for Unity
-dotnet_diagnostic.CA1016.severity = none
-
-# CA1051: Do not declare visible instance fields; Not for Unity
-dotnet_diagnostic.CA1051.severity = none
 
 # RCS1174: Remove redundant async/await
 dotnet_diagnostic.RCS1174.severity = warning

--- a/RuntimeInternals/TestHelper.RuntimeInternals.globalconfig
+++ b/RuntimeInternals/TestHelper.RuntimeInternals.globalconfig
@@ -6,17 +6,81 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = error
 
-# Microsoft.CodeAnalysis.NetAnalyzers categories
-dotnet_analyzer_diagnostic.category-Design.severity = warning
-dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
-dotnet_analyzer_diagnostic.category-Naming.severity = warning
+# CA1018: Mark attributes with AttributeUsageAttribute
+dotnet_diagnostic.CA1018.severity = warning
+
+# CA1041: Provide ObsoleteAttribute message
+dotnet_diagnostic.CA1041.severity = warning
+
+# CA1050: Declare types in namespaces
+dotnet_diagnostic.CA1050.severity = warning
+
+# CA1061: Do not hide base class methods
+dotnet_diagnostic.CA1061.severity = warning
+
+# CA1067: Override Object.Equals(object) when implementing IEquatable<T>
+dotnet_diagnostic.CA1067.severity = warning
+
+# CA1068: CancellationToken parameters must come last
+dotnet_diagnostic.CA1068.severity = warning
+
+# CA1069: Enums values should not be duplicated
+dotnet_diagnostic.CA1069.severity = warning
+
+# CA1070: Do not declare event fields as virtual
+dotnet_diagnostic.CA1070.severity = warning
+
+# CA1507: Use nameof to express symbol names
+dotnet_diagnostic.CA1507.severity = warning
+
+# CA1510: Use ArgumentNullException throw helper
+dotnet_diagnostic.CA1510.severity = warning
+
+# CA1511: Use ArgumentException throw helper
+dotnet_diagnostic.CA1511.severity = warning
+
+# CA1512: Use ArgumentOutOfRangeException throw helper
+dotnet_diagnostic.CA1512.severity = warning
+
+# CA1513: Use ObjectDisposedException throw helper
+dotnet_diagnostic.CA1513.severity = warning
+
+# CA1514: Avoid redundant length argument
+dotnet_diagnostic.CA1514.severity = warning
+
+# CA1710: Identifiers should have correct suffix
+dotnet_diagnostic.CA1710.severity = warning
+
+# CA1711: Identifiers should not have incorrect suffix
+dotnet_diagnostic.CA1711.severity = warning
+
+# CA1712: Do not prefix enum values with type name
+dotnet_diagnostic.CA1712.severity = warning
+
+# CA1714: Flags enums should have plural names
+dotnet_diagnostic.CA1714.severity = warning
+
+# CA1715: Identifiers should have correct prefix
+dotnet_diagnostic.CA1715.severity = warning
+
+# CA1716: Identifiers should not match keywords
+dotnet_diagnostic.CA1716.severity = warning
+
+# CA1717: Only FlagsAttribute enums should have plural names
+dotnet_diagnostic.CA1717.severity = warning
+
+# CA1720: Identifier contains type name
+dotnet_diagnostic.CA1720.severity = warning
+
+# CA1725: Parameter names should match base declaration
+dotnet_diagnostic.CA1725.severity = warning
+
+# CA1727: Use PascalCase for named placeholders
+dotnet_diagnostic.CA1727.severity = warning
+
+# The "Performance" category is used because it encompasses many rules
+# (specifically, the CA18xx rules from Microsoft.CodeAnalysis.NetAnalyzers).
 dotnet_analyzer_diagnostic.category-Performance.severity = warning
-
-# CA1016: Mark assemblies with assembly version; Not for Unity
-dotnet_diagnostic.CA1016.severity = none
-
-# CA1051: Do not declare visible instance fields; Not for Unity
-dotnet_diagnostic.CA1051.severity = none
 
 # RCS1174: Remove redundant async/await
 dotnet_diagnostic.RCS1174.severity = warning


### PR DESCRIPTION
## Summary
- Enumerate Design/Maintainability/Naming rules individually in the `.globalconfig` files instead of category-wide severity overrides, since a category-wide override also raises severity for non-NetAnalyzers diagnostics reported under the same category name; Performance stays category-wide since it only covers CA18xx rules.
- Suppress CA1716 on `Is` (`Runtime/Constraints/Is.cs`) since renaming would break the `Is.Destroyed` / `Is.Not` / `Is.All` property-style syntax this class exists to provide, mirroring NUnit's own `Is` class.

## Test plan
- [x] `run_unity_tests` (PlayMode, `TestHelper.Tests`, `TestHelper.Constraints` group): 190/190 passed
