### PR TITLE
Support Unity 6.6

### DIFF
--- a/.github/workflows/metacheck.yml
+++ b/.github/workflows/metacheck.yml
@@ -31,14 +31,3 @@ jobs:
           lfs: false
 
       - uses: DeNA/unity-meta-check@a2e35e2c0b652031facd143db6f0a438b49de38a # v4
-
-      - uses: 8398a7/action-slack@1750b5085f3ec60384090fb7c52965ef822e869e # v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,job,pullRequest
-          mention: here
-          if_mention: failure
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: failure() && github.event.pull_request.head.repo.fork == false # Skip on public fork, because can not read secrets.

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -21,7 +21,7 @@ defaults:
 
 jobs:
   release-drafter:
-    if: github.repository_owner == 'nowsprinting' # Skip on forked repo
+    if: github.event.repository.fork == false # Skip on forked repo
     runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,13 +56,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # After tagged, openupm.com gets the tag and automatically publishes the UPM package.
-
-      - uses: 8398a7/action-slack@1750b5085f3ec60384090fb7c52965ef822e869e # v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,job,pullRequest
-          mention: here
-          if_mention: failure
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   check-bump-version:
-    if: github.repository_owner == 'nowsprinting' # Skip on forked repo
+    if: github.event.repository.fork == false # Skip on forked repo
     runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,9 @@ jobs:
         unityVersion: # Available versions see: https://game.ci/docs/docker/versions
           - 2019.4.41f2
           - 2022.3.62f3 # Non-Enterprise LTS
-          - 6000.0.77f1
-          - 6000.3.18f1
-          - &latest_unity_version 6000.5.0f1
+          - 6000.0.82f1
+          - 6000.3.23f1
+          - &latest_unity_version 6000.6.0f1
         testMode:
           - All # run tests in editor
         include:
@@ -140,7 +140,7 @@ jobs:
         run: echo "secret_key=UNITY_LICENSE_$(echo ${{ matrix.unityVersion }} | cut -c 1-4)" >> "$GITHUB_ENV"
 
       - name: Run tests
-        uses: game-ci/unity-test-runner@0ff419b913a3630032cbe0de48a0099b5a9f0ed9 # v4
+        uses: game-ci/unity-test-runner@f7d28f891263d875d47ef34370e9e8dd6087e1ef  # v5.0.0-beta.1
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           unityVersion: ${{ matrix.unityVersion }}  # Default is `auto`

--- a/Editor/AttributeFinder.cs
+++ b/Editor/AttributeFinder.cs
@@ -5,6 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using UnityEditor;
+#if UNITY_6000_4_OR_NEWER
+using UnityEngine.Assemblies;
+#endif
 
 namespace TestHelper.Editor
 {
@@ -47,7 +50,11 @@ namespace TestHelper.Editor
 
         internal static IEnumerable<T> FindOnAssemblies<T>() where T : Attribute
         {
+#if UNITY_6000_4_OR_NEWER
+            return FindOnProviders<T>(CurrentAssemblies.GetLoadedAssemblies());
+#else
             return FindOnProviders<T>(AppDomain.CurrentDomain.GetAssemblies());
+#endif
         }
 
         internal static IEnumerable<T> FindOnTypes<T>() where T : Attribute

--- a/Runtime/Constraints/TextOverflowingConstraint.cs
+++ b/Runtime/Constraints/TextOverflowingConstraint.cs
@@ -80,7 +80,7 @@ namespace TestHelper.Constraints
         private static TextOverflowDetection Detect(RectTransform rectTransform)
         {
             UguiTextOverflowProbe.TryDetect(rectTransform, out var detection);
-#if ENABLE_TMP
+#if ENABLE_TMP || ENABLE_UGUI2
             if (detection == null)
             {
                 TmpTextOverflowProbe.TryDetect(rectTransform, out detection);

--- a/Runtime/Constraints/TmpTextOverflowProbe.cs
+++ b/Runtime/Constraints/TmpTextOverflowProbe.cs
@@ -1,7 +1,7 @@
 // Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
-#if ENABLE_TMP
+#if ENABLE_TMP || ENABLE_UGUI2
 using TMPro;
 using UnityEngine;
 

--- a/Runtime/TestHelper.asmdef
+++ b/Runtime/TestHelper.asmdef
@@ -47,7 +47,7 @@
         {
             "name": "com.unity.ugui",
             "expression": "2.0.0",
-            "define": "ENABLE_TMP"
+            "define": "ENABLE_UGUI2"
         }
     ],
     "noEngineReferences": false

--- a/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
+++ b/Tests/Runtime/Constraints/TextOverflowingConstraintTest.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Cysharp.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.Attributes;
-#if ENABLE_TMP
+#if ENABLE_TMP || ENABLE_UGUI2
 using TMPro;
 #endif
 using UnityEngine;
@@ -63,7 +63,7 @@ namespace TestHelper.Constraints
             return uguiText;
         }
 
-#if ENABLE_TMP
+#if ENABLE_TMP || ENABLE_UGUI2
         private static TMP_FontAsset s_fallbackTmpFontAsset;
 
         private static TMP_FontAsset GetTmpFontAsset()
@@ -103,13 +103,11 @@ namespace TestHelper.Constraints
             tmpText.font = GetTmpFontAsset();
             tmpText.text = text;
             tmpText.fontSize = 20;
-            // textWrappingMode/TextWrappingModes isn't available in the TMP version bundled with
-            // older Unity LTS releases tested in CI (e.g. 2022.3); enableWordWrapping predates it
-            // and still works (just deprecated) on newer TMP too, so it compiles across the whole
-            // CI Unity version matrix.
-#pragma warning disable CS0618
+#if ENABLE_UGUI2
+            tmpText.textWrappingMode = enableWordWrapping ? TextWrappingModes.Normal : TextWrappingModes.NoWrap;
+#else
             tmpText.enableWordWrapping = enableWordWrapping;
-#pragma warning restore CS0618
+#endif
             tmpText.enableAutoSizing = enableAutoSizing;
             tmpText.overflowMode = overflowMode;
             return tmpText;
@@ -537,7 +535,7 @@ namespace TestHelper.Constraints
             Assert.That(uguiText.GetComponent<RectTransform>(), Is.Not.TextOverflowing);
         }
 
-#if ENABLE_TMP
+#if ENABLE_TMP || ENABLE_UGUI2
         [Test]
         [CreateScene]
         [Category("Acceptance")]

--- a/Tests/Runtime/TestHelper.Tests.asmdef
+++ b/Tests/Runtime/TestHelper.Tests.asmdef
@@ -42,7 +42,7 @@
         {
             "name": "com.unity.ugui",
             "expression": "2.0.0",
-            "define": "ENABLE_TMP"
+            "define": "ENABLE_UGUI2"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
## Summary
- Add Unity 6000.6.0f1 to the CI test matrix and bump the other Unity 6 entries (6000.0.82f1, 6000.3.23f1); switch to game-ci/unity-test-runner v5.0.0-beta.1
- Use `CurrentAssemblies.GetLoadedAssemblies()` on Unity 6000.4 or newer, since `AppDomain.CurrentDomain.GetAssemblies()` reported UAC0005 on Unity 6.6
- Replace the obsolete `enableWordWrapping` with `textWrappingMode` in `TextOverflowingConstraintTest`
- Workflow housekeeping: drop the Slack notification steps from release/metacheck, and gate fork-only jobs on `github.event.repository.fork` instead of a hardcoded owner name

## Test plan
- [x] `get_unity_compilation_result` succeeds on Unity 6000.4.12f1
- [x] EditMode `TestHelper.Editor.Tests` (`TemporaryBuildScenesUsingInTestTest`, `AssetRootMappingBuilderTest`): 9/9 passed on 6000.4.12f1
- [x] CI matrix including Unity 6000.6.0f1 passes (UAC0005 is only reported by the analyzer shipped with 6.6, so it cannot be verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrnfDZNyEZc6Jgy7yMMUBb